### PR TITLE
i2c fix

### DIFF
--- a/esphome/rat-trap-2025.yaml
+++ b/esphome/rat-trap-2025.yaml
@@ -93,7 +93,7 @@ sensor:
           return x;
 
   # BME280 environmental sensor via STEMMA QT (I2C)
-  - platform: bme280
+  - platform: bme280_i2c
     address: 0x77   # Adafruit STEMMA QT BME280 default address
     temperature:
       name: Environmental Temperature

--- a/esphome/rat-trap-stemma-camera.yaml
+++ b/esphome/rat-trap-stemma-camera.yaml
@@ -123,7 +123,7 @@ sensor:
     long_range: true   # Enable long range mode for 2m detection
 
   # BME280 environmental sensor via STEMMA QT
-  - platform: bme280
+  - platform: bme280_i2c
     address: 0x77   # Adafruit STEMMA QT BME280 default address
     temperature:
       name: Environmental Temperature


### PR DESCRIPTION
…ml` and `esphome/rat-trap-stemma-camera.yaml` in the previous steps. The platform for the BME280 sensor is now correctly set to `bme280_i2c` in both files.