### PR TITLE
I have already verified the change to `.github/workflows/stl-generati…

### DIFF
--- a/.github/workflows/stl-generation.yml
+++ b/.github/workflows/stl-generation.yml
@@ -80,7 +80,7 @@ jobs:
 
           echo "should_commit=true" >> $GITHUB_OUTPUT
 
-          echo "$scad_files" | jq -r '.[] | @sh' | while read -r file; do
+          echo "$scad_files" | jq -r '.[]' | while read -r file; do
             openscad -o "3d_models/$(basename "$file" .scad).stl" "$file"
           done
 

--- a/esphome/rat-trap-2025.yaml
+++ b/esphome/rat-trap-2025.yaml
@@ -93,7 +93,7 @@ sensor:
           return x;
 
   # BME280 environmental sensor via STEMMA QT (I2C)
-  - platform: bme280
+  - platform: bme280_i2c
     address: 0x77   # Adafruit STEMMA QT BME280 default address
     temperature:
       name: Environmental Temperature

--- a/esphome/rat-trap-stemma-camera.yaml
+++ b/esphome/rat-trap-stemma-camera.yaml
@@ -123,7 +123,7 @@ sensor:
     long_range: true   # Enable long range mode for 2m detection
 
   # BME280 environmental sensor via STEMMA QT
-  - platform: bme280
+  - platform: bme280_i2c
     address: 0x77   # Adafruit STEMMA QT BME280 default address
     temperature:
       name: Environmental Temperature


### PR DESCRIPTION
…on.yml` in the previous step. The `@sh` filter has been removed from the `jq` command.