### PR TITLE
Fix ESPHome compilation and STL generation

### DIFF
--- a/.github/workflows/stl-generation.yml
+++ b/.github/workflows/stl-generation.yml
@@ -80,7 +80,7 @@ jobs:
 
           echo "should_commit=true" >> $GITHUB_OUTPUT
 
-          echo "$scad_files" | jq -r '.[] | @sh' | while read -r file; do
+          echo "$scad_files" | jq -r '.[]' | while read -r file; do
             openscad -o "3d_models/$(basename "$file" .scad).stl" "$file"
           done
 

--- a/3d_models/bait_station.stl
+++ b/3d_models/bait_station.stl
@@ -1,0 +1,18062 @@
+solid OpenSCAD_Model
+  facet normal 0.989173 0.146756 0
+    outer loop
+      vertex 19.8042 1.95054 60
+      vertex 19.5176 3.8823 0
+      vertex 19.5176 3.8823 60
+    endloop
+  endfacet
+  facet normal 0.989173 0.146756 0
+    outer loop
+      vertex 19.5176 3.8823 0
+      vertex 19.8042 1.95054 60
+      vertex 19.8042 1.95054 0
+    endloop
+  endfacet
+  facet normal 0.998796 0.0490555 0
+    outer loop
+      vertex 19.9 0 60
+      vertex 19.8042 1.95054 0
+      vertex 19.8042 1.95054 60
+    endloop
+  endfacet
+  facet normal 0.998796 0.0490555 0
+    outer loop
+      vertex 19.8042 1.95054 0
+      vertex 19.9 0 60
+      vertex 19.9 0 0
+    endloop
+  endfacet
+  facet normal 0.970033 0.242974 0
+    outer loop
+      vertex 19.5176 3.8823 60
+      vertex 19.0431 5.77666 0
+      vertex 19.0431 5.77666 60
+    endloop
+  endfacet
+  facet normal 0.970033 0.242974 0
+    outer loop
+      vertex 19.0431 5.77666 0
+      vertex 19.5176 3.8823 60
+      vertex 19.5176 3.8823 0
+    endloop
+  endfacet
+  facet normal 0.427569 -0.903983 0
+    outer loop
+      vertex 7.6154 -18.3852 0
+      vertex 9.38079 -17.5502 60
+      vertex 7.6154 -18.3852 60
+    endloop
+  endfacet
+  facet normal 0.427569 -0.903983 0
+    outer loop
+      vertex 9.38079 -17.5502 60
+      vertex 7.6154 -18.3852 0
+      vertex 9.38079 -17.5502 0
+    endloop
+  endfacet
+  facet normal 0.427569 0.903983 -0
+    outer loop
+      vertex 9.38079 17.5502 0
+      vertex 7.6154 18.3852 60
+      vertex 9.38079 17.5502 60
+    endloop
+  endfacet
+  facet normal 0.427569 0.903983 0
+    outer loop
+      vertex 7.6154 18.3852 60
+      vertex 9.38079 17.5502 0
+      vertex 7.6154 18.3852 0
+    endloop
+  endfacet
+  facet normal -0.427569 0.903983 0
+    outer loop
+      vertex -7.6154 18.3852 0
+      vertex -9.38079 17.5502 60
+      vertex -7.6154 18.3852 60
+    endloop
+  endfacet
+  facet normal -0.427569 0.903983 0
+    outer loop
+      vertex -9.38079 17.5502 60
+      vertex -7.6154 18.3852 0
+      vertex -9.38079 17.5502 0
+    endloop
+  endfacet
+  facet normal 0.595682 0.803221 -0
+    outer loop
+      vertex 12.6244 15.3829 0
+      vertex 11.0558 16.5462 60
+      vertex 12.6244 15.3829 60
+    endloop
+  endfacet
+  facet normal 0.595682 0.803221 0
+    outer loop
+      vertex 11.0558 16.5462 60
+      vertex 12.6244 15.3829 0
+      vertex 11.0558 16.5462 0
+    endloop
+  endfacet
+  facet normal 0.242974 0.970033 -0
+    outer loop
+      vertex 5.77666 19.0431 0
+      vertex 3.8823 19.5176 60
+      vertex 5.77666 19.0431 60
+    endloop
+  endfacet
+  facet normal 0.242974 0.970033 0
+    outer loop
+      vertex 3.8823 19.5176 60
+      vertex 5.77666 19.0431 0
+      vertex 3.8823 19.5176 0
+    endloop
+  endfacet
+  facet normal -0.970167 0.242436 -0.000105587
+    outer loop
+      vertex -19.5173 3.88345 10.147
+      vertex -19.0431 5.77666 0
+      vertex -19.515 3.89259 10
+    endloop
+  endfacet
+  facet normal -0.969969 0.243229 5.31697e-05
+    outer loop
+      vertex -19.0431 5.77666 0
+      vertex -19.5173 3.88345 9.85297
+      vertex -19.515 3.89259 10
+    endloop
+  endfacet
+  facet normal -0.970033 0.242974 0
+    outer loop
+      vertex -19.5176 3.8823 9.84682
+      vertex -19.0431 5.77666 0
+      vertex -19.5176 3.8823 0
+    endloop
+  endfacet
+  facet normal -0.968852 0.24764 0.000954465
+    outer loop
+      vertex -19.0431 5.77666 0
+      vertex -19.5176 3.8823 9.84682
+      vertex -19.5173 3.88345 9.85297
+    endloop
+  endfacet
+  facet normal -0.970034 0.242968 0
+    outer loop
+      vertex -19.0431 5.77666 0
+      vertex -19.5173 3.88345 10.147
+      vertex -19.0431 5.77666 60
+    endloop
+  endfacet
+  facet normal -0.968034 0.25082 -0.000317213
+    outer loop
+      vertex -19.5176 3.8823 10.1532
+      vertex -19.0431 5.77666 60
+      vertex -19.5173 3.88345 10.147
+    endloop
+  endfacet
+  facet normal -0.970033 0.242974 0
+    outer loop
+      vertex -19.0431 5.77666 60
+      vertex -19.5176 3.8823 10.1532
+      vertex -19.5176 3.8823 60
+    endloop
+  endfacet
+  facet normal 0.514117 -0.85772 0
+    outer loop
+      vertex 9.38079 -17.5502 0
+      vertex 11.0558 -16.5462 60
+      vertex 9.38079 -17.5502 60
+    endloop
+  endfacet
+  facet normal 0.514117 -0.85772 0
+    outer loop
+      vertex 11.0558 -16.5462 60
+      vertex 9.38079 -17.5502 0
+      vertex 11.0558 -16.5462 0
+    endloop
+  endfacet
+  facet normal 0.903983 0.427569 0
+    outer loop
+      vertex 18.3852 7.6154 60
+      vertex 17.5502 9.38079 11.3475
+      vertex 17.5502 9.38079 60
+    endloop
+  endfacet
+  facet normal 0.903994 0.427546 -1.01015e-06
+    outer loop
+      vertex 17.5502 9.38079 11.3475
+      vertex 18.3852 7.6154 60
+      vertex 17.5808 9.31609 11.3229
+    endloop
+  endfacet
+  facet normal 0.903976 0.427583 5.78612e-07
+    outer loop
+      vertex 17.5808 9.31609 11.3229
+      vertex 18.3852 7.6154 60
+      vertex 17.655 9.15922 11.2472
+    endloop
+  endfacet
+  facet normal 0.903928 0.427685 4.51079e-06
+    outer loop
+      vertex 17.655 9.15922 11.2472
+      vertex 18.3852 7.6154 60
+      vertex 17.7245 9.01233 11.1595
+    endloop
+  endfacet
+  facet normal 0.903968 0.427601 1.57289e-06
+    outer loop
+      vertex 17.7245 9.01233 11.1595
+      vertex 18.3852 7.6154 60
+      vertex 17.7886 8.87682 11.0607
+    endloop
+  endfacet
+  facet normal 0.903947 0.427644 2.94892e-06
+    outer loop
+      vertex 17.7886 8.87682 11.0607
+      vertex 18.3852 7.6154 60
+      vertex 17.8467 8.75401 10.9516
+    endloop
+  endfacet
+  facet normal 0.904055 0.427417 -3.50503e-06
+    outer loop
+      vertex 17.8467 8.75401 10.9516
+      vertex 18.3852 7.6154 60
+      vertex 17.8836 8.67596 10.8669
+    endloop
+  endfacet
+  facet normal 0.904151 0.427214 -8.8824e-06
+    outer loop
+      vertex 17.8836 8.67596 10.8669
+      vertex 18.3852 7.6154 60
+      vertex 17.8982 8.64506 10.8334
+    endloop
+  endfacet
+  facet normal 0.904177 0.427157 -1.0322e-05
+    outer loop
+      vertex 17.8982 8.64506 10.8334
+      vertex 18.3852 7.6154 60
+      vertex 17.9107 8.6186 10.7978
+    endloop
+  endfacet
+  facet normal 0.903755 0.42805 1.19562e-05
+    outer loop
+      vertex 17.9107 8.6186 10.7978
+      vertex 18.3852 7.6154 60
+      vertex 17.9427 8.55104 10.7071
+    endloop
+  endfacet
+  facet normal 0.904266 0.42697 -1.31316e-05
+    outer loop
+      vertex 17.9427 8.55104 10.7071
+      vertex 18.3852 7.6154 60
+      vertex 17.9694 8.49449 10.6109
+    endloop
+  endfacet
+  facet normal 0.902968 0.429707 4.65047e-05
+    outer loop
+      vertex 17.9694 8.49449 10.6109
+      vertex 18.3852 7.6154 60
+      vertex 17.9797 8.47285 10.574
+    endloop
+  endfacet
+  facet normal 0.904205 0.427099 -8.87636e-06
+    outer loop
+      vertex 17.9797 8.47285 10.574
+      vertex 18.3852 7.6154 60
+      vertex 18.0088 8.41124 10.4354
+    endloop
+  endfacet
+  facet normal 0.905131 0.425132 -4.7503e-05
+    outer loop
+      vertex 18.0088 8.41124 10.4354
+      vertex 18.3852 7.6154 60
+      vertex 18.0145 8.3991 10.3964
+    endloop
+  endfacet
+  facet normal 0.903749 0.428062 9.12583e-06
+    outer loop
+      vertex 18.0145 8.3991 10.3964
+      vertex 18.3852 7.6154 60
+      vertex 18.0298 8.3668 10.2926
+    endloop
+  endfacet
+  facet normal 0.903864 0.42782 4.63378e-06
+    outer loop
+      vertex 18.0298 8.3668 10.2926
+      vertex 18.3852 7.6154 60
+      vertex 18.0425 8.33997 10.147
+    endloop
+  endfacet
+  facet normal 0.903899 0.427745 3.31406e-06
+    outer loop
+      vertex 18.0425 8.33997 10.147
+      vertex 18.3852 7.6154 60
+      vertex 18.0456 8.33342 10.0398
+    endloop
+  endfacet
+  facet normal 0.898043 0.439908 0.000217929
+    outer loop
+      vertex 18.0456 8.33342 10.0398
+      vertex 18.3852 7.6154 60
+      vertex 18.0468 8.33099 10
+    endloop
+  endfacet
+  facet normal 0.903993 0.427547 5.34321e-06
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 17.5502 9.38079 8.65248
+      vertex 17.5808 9.31609 8.67712
+    endloop
+  endfacet
+  facet normal 0.903976 0.427582 -3.0155e-06
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 17.5808 9.31609 8.67712
+      vertex 17.655 9.15922 8.7528
+    endloop
+  endfacet
+  facet normal 0.903932 0.427676 -2.31616e-05
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 17.655 9.15922 8.7528
+      vertex 17.7245 9.01233 8.84048
+    endloop
+  endfacet
+  facet normal 0.90397 0.427597 -7.95395e-06
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 17.7245 9.01233 8.84048
+      vertex 17.7886 8.87682 8.93934
+    endloop
+  endfacet
+  facet normal 0.903951 0.427636 -1.46748e-05
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 17.7886 8.87682 8.93934
+      vertex 17.8467 8.75401 9.04841
+    endloop
+  endfacet
+  facet normal 0.904049 0.427429 1.71378e-05
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 17.8467 8.75401 9.04841
+      vertex 17.8836 8.67596 9.13311
+    endloop
+  endfacet
+  facet normal 0.904136 0.427244 4.34295e-05
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 17.8836 8.67596 9.13311
+      vertex 17.8982 8.64506 9.16664
+    endloop
+  endfacet
+  facet normal 0.904157 0.4272 4.94602e-05
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 17.8982 8.64506 9.16664
+      vertex 17.9107 8.6186 9.20218
+    endloop
+  endfacet
+  facet normal 0.903778 0.428001 -5.72922e-05
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 17.9107 8.6186 9.20218
+      vertex 17.9427 8.55104 9.2929
+    endloop
+  endfacet
+  facet normal 0.904234 0.427037 6.13826e-05
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 17.9427 8.55104 9.2929
+      vertex 17.9694 8.49449 9.38915
+    endloop
+  endfacet
+  facet normal 0.903081 0.42947 -0.000217442
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 17.9694 8.49449 9.38915
+      vertex 17.9797 8.47285 9.42597
+    endloop
+  endfacet
+  facet normal 0.904178 0.427157 4.01439e-05
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 17.9797 8.47285 9.42597
+      vertex 18.0088 8.41124 9.56457
+    endloop
+  endfacet
+  facet normal 0.904938 0.425544 0.000204219
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 18.0088 8.41124 9.56457
+      vertex 18.0145 8.3991 9.60357
+    endloop
+  endfacet
+  facet normal 0.903787 0.427983 -3.92413e-05
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 18.0145 8.3991 9.60357
+      vertex 18.0298 8.3668 9.70736
+    endloop
+  endfacet
+  facet normal 0.903892 0.42776 -1.80798e-05
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 18.0298 8.3668 9.70736
+      vertex 18.0425 8.33997 9.85297
+    endloop
+  endfacet
+  facet normal 0.903983 0.427569 0
+    outer loop
+      vertex 17.5502 9.38079 8.65248
+      vertex 18.3852 7.6154 0
+      vertex 17.5502 9.38079 0
+    endloop
+  endfacet
+  facet normal 0.903938 0.427664 -9.41815e-06
+    outer loop
+      vertex 18.0456 8.33342 9.96021
+      vertex 18.3852 7.6154 0
+      vertex 18.0425 8.33997 9.85297
+    endloop
+  endfacet
+  facet normal 0.900631 0.434585 -0.000621135
+    outer loop
+      vertex 18.0468 8.33099 10
+      vertex 18.3852 7.6154 0
+      vertex 18.0456 8.33342 9.96021
+    endloop
+  endfacet
+  facet normal 0.904013 0.427505 -0
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 18.0468 8.33099 10
+      vertex 18.3852 7.6154 60
+    endloop
+  endfacet
+  facet normal -0.242974 0.970033 1.36801e-06
+    outer loop
+      vertex -3.8823 19.5176 60
+      vertex -4.46705 19.3712 11.5
+      vertex -5.77666 19.0431 60
+    endloop
+  endfacet
+  facet normal -0.242029 0.970269 -1.074e-05
+    outer loop
+      vertex -3.8823 19.5176 60
+      vertex -4.39048 19.3903 11.4975
+      vertex -4.46705 19.3712 11.5
+    endloop
+  endfacet
+  facet normal -0.243178 0.969982 2.05466e-06
+    outer loop
+      vertex -3.8823 19.5176 60
+      vertex -4.24489 19.4268 11.4928
+      vertex -4.39048 19.3903 11.4975
+    endloop
+  endfacet
+  facet normal -0.242919 0.970046 -1.36231e-09
+    outer loop
+      vertex -3.8823 19.5176 60
+      vertex -4.02486 19.4819 11.4712
+      vertex -4.24489 19.4268 11.4928
+    endloop
+  endfacet
+  facet normal -0.24292 0.970046 0
+    outer loop
+      vertex -4.02486 19.4819 11.4712
+      vertex -3.8823 19.5176 60
+      vertex -3.8823 19.5176 11.4475
+    endloop
+  endfacet
+  facet normal -0.243076 0.970007 -1.54591e-06
+    outer loop
+      vertex -4.61071 19.3352 11.4953
+      vertex -5.77666 19.0431 60
+      vertex -4.46705 19.3712 11.5
+    endloop
+  endfacet
+  facet normal -0.243378 0.969931 -9.27526e-06
+    outer loop
+      vertex -4.68922 19.3155 11.4928
+      vertex -5.77666 19.0431 60
+      vertex -4.61071 19.3352 11.4953
+    endloop
+  endfacet
+  facet normal -0.24293 0.970044 1.40609e-06
+    outer loop
+      vertex -4.90924 19.2604 11.4712
+      vertex -5.77666 19.0431 60
+      vertex -4.68922 19.3155 11.4928
+    endloop
+  endfacet
+  facet normal -0.243201 0.969976 -3.74991e-06
+    outer loop
+      vertex -5.12501 19.2063 11.4354
+      vertex -5.77666 19.0431 60
+      vertex -4.90924 19.2604 11.4712
+    endloop
+  endfacet
+  facet normal -0.242722 0.970096 3.09154e-06
+    outer loop
+      vertex -5.33444 19.1539 11.3858
+      vertex -5.77666 19.0431 60
+      vertex -5.12501 19.2063 11.4354
+    endloop
+  endfacet
+  facet normal -0.243037 0.970017 4.52258e-08
+    outer loop
+      vertex -5.41187 19.1345 11.3616
+      vertex -5.77666 19.0431 60
+      vertex -5.33444 19.1539 11.3858
+    endloop
+  endfacet
+  facet normal -0.243181 0.969981 -1.10703e-06
+    outer loop
+      vertex -5.53552 19.1035 11.3229
+      vertex -5.77666 19.0431 60
+      vertex -5.41187 19.1345 11.3616
+    endloop
+  endfacet
+  facet normal -0.242694 0.970103 1.45699e-06
+    outer loop
+      vertex -5.65104 19.0746 11.2771
+      vertex -5.77666 19.0431 60
+      vertex -5.53552 19.1035 11.3229
+    endloop
+  endfacet
+  facet normal -0.243536 0.969892 -8.48857e-07
+    outer loop
+      vertex -5.72631 19.0557 11.2472
+      vertex -5.77666 19.0431 60
+      vertex -5.65104 19.0746 11.2771
+    endloop
+  endfacet
+  facet normal -0.242762 0.970086 0
+    outer loop
+      vertex -5.77666 19.0431 60
+      vertex -5.72631 19.0557 11.2472
+      vertex -5.77666 19.0431 11.2225
+    endloop
+  endfacet
+  facet normal -0.242031 0.970269 6.11686e-05
+    outer loop
+      vertex -4.39048 19.3903 8.50249
+      vertex -3.8823 19.5176 0
+      vertex -4.46705 19.3712 8.5
+    endloop
+  endfacet
+  facet normal -0.243178 0.969982 -1.17021e-05
+    outer loop
+      vertex -4.24489 19.4268 8.50722
+      vertex -3.8823 19.5176 0
+      vertex -4.39048 19.3903 8.50249
+    endloop
+  endfacet
+  facet normal -0.242919 0.970046 7.74107e-09
+    outer loop
+      vertex -4.02486 19.4819 8.52882
+      vertex -3.8823 19.5176 0
+      vertex -4.24489 19.4268 8.50722
+    endloop
+  endfacet
+  facet normal -0.24292 0.970046 0
+    outer loop
+      vertex -3.8823 19.5176 0
+      vertex -4.02486 19.4819 8.52882
+      vertex -3.8823 19.5176 8.55245
+    endloop
+  endfacet
+  facet normal -0.243037 0.970017 -2.51911e-07
+    outer loop
+      vertex -5.77666 19.0431 0
+      vertex -5.41187 19.1345 8.63841
+      vertex -5.33444 19.1539 8.61418
+    endloop
+  endfacet
+  facet normal -0.243076 0.970007 -1.52669e-05
+    outer loop
+      vertex -3.8823 19.5176 0
+      vertex -4.61071 19.3352 8.50467
+      vertex -4.46705 19.3712 8.5
+    endloop
+  endfacet
+  facet normal -0.24338 0.969931 -4.2904e-05
+    outer loop
+      vertex -4.61071 19.3352 8.50467
+      vertex -3.8823 19.5176 0
+      vertex -4.68922 19.3155 8.50722
+    endloop
+  endfacet
+  facet normal -0.242974 0.970033 -2.00944e-06
+    outer loop
+      vertex -5.77666 19.0431 0
+      vertex -4.68922 19.3155 8.50722
+      vertex -3.8823 19.5176 0
+    endloop
+  endfacet
+  facet normal -0.242931 0.970044 -7.93541e-06
+    outer loop
+      vertex -4.68922 19.3155 8.50722
+      vertex -5.77666 19.0431 0
+      vertex -4.90924 19.2604 8.52882
+    endloop
+  endfacet
+  facet normal -0.243199 0.969976 2.10454e-05
+    outer loop
+      vertex -4.90924 19.2604 8.52882
+      vertex -5.77666 19.0431 0
+      vertex -5.12501 19.2063 8.56459
+    endloop
+  endfacet
+  facet normal -0.242725 0.970095 -1.72747e-05
+    outer loop
+      vertex -5.12501 19.2063 8.56459
+      vertex -5.77666 19.0431 0
+      vertex -5.33444 19.1539 8.61418
+    endloop
+  endfacet
+  facet normal -0.24318 0.969981 6.16623e-06
+    outer loop
+      vertex -5.41187 19.1345 8.63841
+      vertex -5.77666 19.0431 0
+      vertex -5.53552 19.1035 8.67712
+    endloop
+  endfacet
+  facet normal -0.242697 0.970102 -8.10022e-06
+    outer loop
+      vertex -5.53552 19.1035 8.67712
+      vertex -5.77666 19.0431 0
+      vertex -5.65104 19.0746 8.72294
+    endloop
+  endfacet
+  facet normal -0.243534 0.969892 4.71928e-06
+    outer loop
+      vertex -5.65104 19.0746 8.72294
+      vertex -5.77666 19.0431 0
+      vertex -5.72631 19.0557 8.7528
+    endloop
+  endfacet
+  facet normal -0.242762 0.970086 0
+    outer loop
+      vertex -5.72631 19.0557 8.7528
+      vertex -5.77666 19.0431 0
+      vertex -5.77666 19.0431 8.77751
+    endloop
+  endfacet
+  facet normal 0.514117 0.85772 -0
+    outer loop
+      vertex 11.0558 16.5462 0
+      vertex 9.38079 17.5502 60
+      vertex 11.0558 16.5462 60
+    endloop
+  endfacet
+  facet normal 0.514117 0.85772 0
+    outer loop
+      vertex 9.38079 17.5502 60
+      vertex 11.0558 16.5462 0
+      vertex 9.38079 17.5502 0
+    endloop
+  endfacet
+  facet normal -0.988859 0.148853 0
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.522 3.85307 9.70736
+      vertex -19.5176 3.8823 9.84682
+    endloop
+  endfacet
+  facet normal -0.989161 0.146835 -6.21267e-06
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.5295 3.80254 9.56457
+      vertex -19.522 3.85307 9.70736
+    endloop
+  endfacet
+  facet normal -0.989162 0.146827 -6.28568e-06
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.5399 3.73247 9.42597
+      vertex -19.5295 3.80254 9.56457
+    endloop
+  endfacet
+  facet normal -0.989316 0.145784 -2.32233e-05
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.553 3.64355 9.2929
+      vertex -19.5399 3.73247 9.42597
+    endloop
+  endfacet
+  facet normal -0.98883 0.149046 6.24319e-05
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.5575 3.61371 9.25767
+      vertex -19.553 3.64355 9.2929
+    endloop
+  endfacet
+  facet normal -0.989236 0.146328 -1.81835e-05
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.5689 3.53663 9.16664
+      vertex -19.5575 3.61371 9.25767
+    endloop
+  endfacet
+  facet normal -0.989238 0.146315 -1.86711e-05
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.582 3.44805 9.08211
+      vertex -19.5689 3.53663 9.16664
+    endloop
+  endfacet
+  facet normal -0.988933 0.14836 8.12827e-05
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.5873 3.41274 9.04841
+      vertex -19.582 3.44805 9.08211
+    endloop
+  endfacet
+  facet normal -0.989194 0.146614 -1.1364e-05
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.608 3.27307 8.93934
+      vertex -19.5873 3.41274 9.04841
+    endloop
+  endfacet
+  facet normal -0.989188 0.146653 -8.62708e-06
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.6241 3.16447 8.86967
+      vertex -19.608 3.27307 8.93934
+    endloop
+  endfacet
+  facet normal -0.989024 0.147757 8.26913e-05
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.6309 3.11897 8.84048
+      vertex -19.6241 3.16447 8.86967
+    endloop
+  endfacet
+  facet normal -0.989177 0.146725 -8.3568e-06
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.6383 3.06908 8.81429
+      vertex -19.6309 3.11897 8.84048
+    endloop
+  endfacet
+  facet normal -0.989268 0.146111 -6.62499e-05
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.6556 2.95192 8.7528
+      vertex -19.6383 3.06908 8.81429
+    endloop
+  endfacet
+  facet normal -0.989146 0.146937 2.34172e-05
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.6821 2.77354 8.67712
+      vertex -19.6556 2.95192 8.7528
+    endloop
+  endfacet
+  facet normal -0.989168 0.146788 3.93011e-06
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.71 2.58553 8.61418
+      vertex -19.6821 2.77354 8.67712
+    endloop
+  endfacet
+  facet normal -0.98921 0.146507 -3.92253e-05
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.739 2.38971 8.56459
+      vertex -19.71 2.58553 8.61418
+    endloop
+  endfacet
+  facet normal -0.989125 0.147078 6.24524e-05
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -19.769 2.18797 8.52882
+      vertex -19.739 2.38971 8.56459
+    endloop
+  endfacet
+  facet normal -0.989173 0.146756 -2.97107e-06
+    outer loop
+      vertex -19.8042 1.95054 0
+      vertex -19.769 2.18797 8.52882
+      vertex -19.5176 3.8823 0
+    endloop
+  endfacet
+  facet normal -0.989187 0.146657 -1.53233e-07
+    outer loop
+      vertex -19.769 2.18797 8.52882
+      vertex -19.8042 1.95054 0
+      vertex -19.7995 1.98225 8.50722
+    endloop
+  endfacet
+  facet normal -0.989193 0.146616 0
+    outer loop
+      vertex -19.7995 1.98225 8.50722
+      vertex -19.8042 1.95054 0
+      vertex -19.8042 1.95054 8.50612
+    endloop
+  endfacet
+  facet normal -0.988859 0.148853 0
+    outer loop
+      vertex -19.522 3.85307 10.2926
+      vertex -19.5176 3.8823 60
+      vertex -19.5176 3.8823 10.1532
+    endloop
+  endfacet
+  facet normal -0.989163 0.146822 1.22157e-06
+    outer loop
+      vertex -19.5295 3.80254 10.4354
+      vertex -19.5176 3.8823 60
+      vertex -19.522 3.85307 10.2926
+    endloop
+  endfacet
+  facet normal -0.989164 0.146817 1.22906e-06
+    outer loop
+      vertex -19.5399 3.73247 10.574
+      vertex -19.5176 3.8823 60
+      vertex -19.5295 3.80254 10.4354
+    endloop
+  endfacet
+  facet normal -0.98932 0.145757 4.51378e-06
+    outer loop
+      vertex -19.553 3.64355 10.7071
+      vertex -19.5176 3.8823 60
+      vertex -19.5399 3.73247 10.574
+    endloop
+  endfacet
+  facet normal -0.988821 0.149104 -1.20579e-05
+    outer loop
+      vertex -19.5575 3.61371 10.7423
+      vertex -19.5176 3.8823 60
+      vertex -19.553 3.64355 10.7071
+    endloop
+  endfacet
+  facet normal -0.989239 0.146311 3.51194e-06
+    outer loop
+      vertex -19.5689 3.53663 10.8334
+      vertex -19.5176 3.8823 60
+      vertex -19.5575 3.61371 10.7423
+    endloop
+  endfacet
+  facet normal -0.98924 0.146301 3.58229e-06
+    outer loop
+      vertex -19.582 3.44805 10.9179
+      vertex -19.5176 3.8823 60
+      vertex -19.5689 3.53663 10.8334
+    endloop
+  endfacet
+  facet normal -0.988924 0.148422 -1.5595e-05
+    outer loop
+      vertex -19.5873 3.41274 10.9516
+      vertex -19.5176 3.8823 60
+      vertex -19.582 3.44805 10.9179
+    endloop
+  endfacet
+  facet normal -0.989195 0.146607 2.16519e-06
+    outer loop
+      vertex -19.608 3.27307 11.0607
+      vertex -19.5176 3.8823 60
+      vertex -19.5873 3.41274 10.9516
+    endloop
+  endfacet
+  facet normal -0.989189 0.146649 1.63172e-06
+    outer loop
+      vertex -19.6241 3.16447 11.1303
+      vertex -19.5176 3.8823 60
+      vertex -19.608 3.27307 11.0607
+    endloop
+  endfacet
+  facet normal -0.989017 0.147799 -1.56399e-05
+    outer loop
+      vertex -19.6309 3.11897 11.1595
+      vertex -19.5176 3.8823 60
+      vertex -19.6241 3.16447 11.1303
+    endloop
+  endfacet
+  facet normal -0.989178 0.146722 1.56833e-06
+    outer loop
+      vertex -19.6383 3.06908 11.1857
+      vertex -19.5176 3.8823 60
+      vertex -19.6309 3.11897 11.1595
+    endloop
+  endfacet
+  facet normal -0.989272 0.146084 1.24332e-05
+    outer loop
+      vertex -19.6556 2.95192 11.2472
+      vertex -19.5176 3.8823 60
+      vertex -19.6383 3.06908 11.1857
+    endloop
+  endfacet
+  facet normal -0.989145 0.146945 -4.35849e-06
+    outer loop
+      vertex -19.6821 2.77354 11.3229
+      vertex -19.5176 3.8823 60
+      vertex -19.6556 2.95192 11.2472
+    endloop
+  endfacet
+  facet normal -0.989168 0.146789 -7.2502e-07
+    outer loop
+      vertex -19.71 2.58553 11.3858
+      vertex -19.5176 3.8823 60
+      vertex -19.6821 2.77354 11.3229
+    endloop
+  endfacet
+  facet normal -0.989211 0.146499 7.16707e-06
+    outer loop
+      vertex -19.739 2.38971 11.4354
+      vertex -19.5176 3.8823 60
+      vertex -19.71 2.58553 11.3858
+    endloop
+  endfacet
+  facet normal -0.989124 0.147087 -1.12925e-05
+    outer loop
+      vertex -19.769 2.18797 11.4712
+      vertex -19.5176 3.8823 60
+      vertex -19.739 2.38971 11.4354
+    endloop
+  endfacet
+  facet normal -0.989187 0.146657 4.04197e-06
+    outer loop
+      vertex -19.7995 1.98225 11.4928
+      vertex -19.5176 3.8823 60
+      vertex -19.769 2.18797 11.4712
+    endloop
+  endfacet
+  facet normal -0.989193 0.146617 5.66059e-06
+    outer loop
+      vertex -19.8042 1.95054 11.4939
+      vertex -19.5176 3.8823 60
+      vertex -19.7995 1.98225 11.4928
+    endloop
+  endfacet
+  facet normal -0.989173 0.146756 0
+    outer loop
+      vertex -19.5176 3.8823 60
+      vertex -19.8042 1.95054 11.4939
+      vertex -19.8042 1.95054 60
+    endloop
+  endfacet
+  facet normal 0.998796 -0.0490555 0
+    outer loop
+      vertex 19.8042 -1.95054 60
+      vertex 19.9 0 0
+      vertex 19.9 0 60
+    endloop
+  endfacet
+  facet normal 0.998796 -0.0490555 0
+    outer loop
+      vertex 19.9 0 0
+      vertex 19.8042 -1.95054 60
+      vertex 19.8042 -1.95054 0
+    endloop
+  endfacet
+  facet normal -0.595682 -0.803221 0
+    outer loop
+      vertex -12.6244 -15.3829 0
+      vertex -11.0558 -16.5462 60
+      vertex -12.6244 -15.3829 60
+    endloop
+  endfacet
+  facet normal -0.595682 -0.803221 -0
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -12.6244 -15.3829 0
+      vertex -11.0558 -16.5462 0
+    endloop
+  endfacet
+  facet normal 0.242974 -0.970033 0
+    outer loop
+      vertex 3.8823 -19.5176 0
+      vertex 5.77666 -19.0431 60
+      vertex 3.8823 -19.5176 60
+    endloop
+  endfacet
+  facet normal 0.242974 -0.970033 0
+    outer loop
+      vertex 5.77666 -19.0431 60
+      vertex 3.8823 -19.5176 0
+      vertex 5.77666 -19.0431 0
+    endloop
+  endfacet
+  facet normal 0.803119 0.595819 0
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 15.6502 12.2641 10
+      vertex 15.3829 12.6244 0
+    endloop
+  endfacet
+  facet normal 0.806093 0.591788 4.49481e-05
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 15.6535 12.2596 10.0654
+      vertex 15.6502 12.2641 10
+    endloop
+  endfacet
+  facet normal 0.801884 0.59748 -1.94407e-05
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 15.6576 12.2541 10.147
+      vertex 15.6535 12.2596 10.0654
+    endloop
+  endfacet
+  facet normal 0.805106 0.593131 3.0616e-05
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 15.6699 12.2374 10.228
+      vertex 15.6576 12.2541 10.147
+    endloop
+  endfacet
+  facet normal 0.800118 0.599842 -5.03307e-05
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 15.6798 12.2242 10.2926
+      vertex 15.6699 12.2374 10.228
+    endloop
+  endfacet
+  facet normal 0.803856 0.594824 1.23958e-05
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 15.7165 12.1746 10.4354
+      vertex 15.6798 12.2242 10.2926
+    endloop
+  endfacet
+  facet normal 0.803181 0.595736 -4.2155e-07
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 15.7389 12.1444 10.4963
+      vertex 15.7165 12.1746 10.4354
+    endloop
+  endfacet
+  facet normal 0.802753 0.596312 -9.08844e-06
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 15.7675 12.1059 10.574
+      vertex 15.7389 12.1444 10.4963
+    endloop
+  endfacet
+  facet normal 0.803693 0.595044 1.15342e-05
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 15.804 12.0566 10.6492
+      vertex 15.7675 12.1059 10.574
+    endloop
+  endfacet
+  facet normal 0.803293 0.595584 1.90349e-06
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 15.8321 12.0187 10.7071
+      vertex 15.804 12.0566 10.6492
+    endloop
+  endfacet
+  facet normal 0.802937 0.596064 -7.24457e-06
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 15.9099 11.9139 10.8334
+      vertex 15.8321 12.0187 10.7071
+    endloop
+  endfacet
+  facet normal 0.80324 0.595656 1.91604e-06
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 16 11.7924 10.9516
+      vertex 15.9099 11.9139 10.8334
+    endloop
+  endfacet
+  facet normal 0.803296 0.59558 3.89402e-06
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 16.1015 11.6555 11.0607
+      vertex 16 11.7924 10.9516
+    endloop
+  endfacet
+  facet normal 0.803116 0.595823 -3.56287e-06
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 16.2136 11.5044 11.1595
+      vertex 16.1015 11.6555 11.0607
+    endloop
+  endfacet
+  facet normal 0.803166 0.595755 -1.12467e-06
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 16.3351 11.3406 11.2472
+      vertex 16.2136 11.5044 11.1595
+    endloop
+  endfacet
+  facet normal 0.803239 0.595657 2.87987e-06
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 16.4648 11.1657 11.3229
+      vertex 16.3351 11.3406 11.2472
+    endloop
+  endfacet
+  facet normal 0.803237 0.59566 2.73461e-06
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 16.5176 11.0945 11.3472
+      vertex 16.4648 11.1657 11.3229
+    endloop
+  endfacet
+  facet normal 0.803221 0.595682 -0
+    outer loop
+      vertex 16.5462 11.0558 11.3604
+      vertex 15.3829 12.6244 60
+      vertex 16.5462 11.0558 60
+    endloop
+  endfacet
+  facet normal 0.804208 0.594347 6.66632e-05
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 16.5462 11.0558 11.3604
+      vertex 16.5176 11.0945 11.3472
+    endloop
+  endfacet
+  facet normal 0.805275 0.592901 -0.000162759
+    outer loop
+      vertex 15.6535 12.2596 9.93457
+      vertex 15.3829 12.6244 0
+      vertex 15.6502 12.2641 10
+    endloop
+  endfacet
+  facet normal 0.802244 0.596996 7.01423e-05
+    outer loop
+      vertex 15.6576 12.2541 9.85297
+      vertex 15.3829 12.6244 0
+      vertex 15.6535 12.2596 9.93457
+    endloop
+  endfacet
+  facet normal 0.804863 0.593461 -0.000135713
+    outer loop
+      vertex 15.6699 12.2374 9.77201
+      vertex 15.3829 12.6244 0
+      vertex 15.6576 12.2541 9.85297
+    endloop
+  endfacet
+  facet normal 0.800524 0.599301 0.000222988
+    outer loop
+      vertex 15.6798 12.2242 9.70736
+      vertex 15.3829 12.6244 0
+      vertex 15.6699 12.2374 9.77201
+    endloop
+  endfacet
+  facet normal 0.803793 0.594909 -5.80502e-05
+    outer loop
+      vertex 15.7165 12.1746 9.56457
+      vertex 15.3829 12.6244 0
+      vertex 15.6798 12.2242 9.70736
+    endloop
+  endfacet
+  facet normal 0.803182 0.595734 2.0319e-06
+    outer loop
+      vertex 15.7389 12.1444 9.5037
+      vertex 15.3829 12.6244 0
+      vertex 15.7165 12.1746 9.56457
+    endloop
+  endfacet
+  facet normal 0.802786 0.596267 4.38025e-05
+    outer loop
+      vertex 15.7675 12.1059 9.42597
+      vertex 15.3829 12.6244 0
+      vertex 15.7389 12.1444 9.5037
+    endloop
+  endfacet
+  facet normal 0.80366 0.595088 -5.6689e-05
+    outer loop
+      vertex 15.804 12.0566 9.35076
+      vertex 15.3829 12.6244 0
+      vertex 15.7675 12.1059 9.42597
+    endloop
+  endfacet
+  facet normal 0.803287 0.595592 -9.35534e-06
+    outer loop
+      vertex 15.8321 12.0187 9.2929
+      vertex 15.3829 12.6244 0
+      vertex 15.804 12.0566 9.35076
+    endloop
+  endfacet
+  facet normal 0.802953 0.596042 3.61583e-05
+    outer loop
+      vertex 15.9099 11.9139 9.16664
+      vertex 15.3829 12.6244 0
+      vertex 15.8321 12.0187 9.2929
+    endloop
+  endfacet
+  facet normal 0.803236 0.59566 -9.69048e-06
+    outer loop
+      vertex 16 11.7924 9.04841
+      vertex 15.3829 12.6244 0
+      vertex 15.9099 11.9139 9.16664
+    endloop
+  endfacet
+  facet normal 0.80329 0.595589 -1.99331e-05
+    outer loop
+      vertex 16.1015 11.6555 8.93934
+      vertex 15.3829 12.6244 0
+      vertex 16 11.7924 9.04841
+    endloop
+  endfacet
+  facet normal 0.80312 0.595817 1.84496e-05
+    outer loop
+      vertex 16.2136 11.5044 8.84048
+      vertex 15.3829 12.6244 0
+      vertex 16.1015 11.6555 8.93934
+    endloop
+  endfacet
+  facet normal 0.803168 0.595753 5.89024e-06
+    outer loop
+      vertex 16.3351 11.3406 8.7528
+      vertex 15.3829 12.6244 0
+      vertex 16.2136 11.5044 8.84048
+    endloop
+  endfacet
+  facet normal 0.803237 0.59566 -1.52554e-05
+    outer loop
+      vertex 16.4648 11.1657 8.67712
+      vertex 15.3829 12.6244 0
+      vertex 16.3351 11.3406 8.7528
+    endloop
+  endfacet
+  facet normal 0.803235 0.595662 -1.4657e-05
+    outer loop
+      vertex 16.5176 11.0945 8.65283
+      vertex 15.3829 12.6244 0
+      vertex 16.4648 11.1657 8.67712
+    endloop
+  endfacet
+  facet normal 0.804161 0.594411 -0.000357267
+    outer loop
+      vertex 16.5462 11.0558 8.63962
+      vertex 15.3829 12.6244 0
+      vertex 16.5176 11.0945 8.65283
+    endloop
+  endfacet
+  facet normal 0.803221 0.595682 0
+    outer loop
+      vertex 15.3829 12.6244 0
+      vertex 16.5462 11.0558 8.63962
+      vertex 16.5462 11.0558 0
+    endloop
+  endfacet
+  facet normal 0.146756 -0.989173 0
+    outer loop
+      vertex 1.95054 -19.8042 0
+      vertex 3.8823 -19.5176 60
+      vertex 1.95054 -19.8042 60
+    endloop
+  endfacet
+  facet normal 0.146756 -0.989173 0
+    outer loop
+      vertex 3.8823 -19.5176 60
+      vertex 1.95054 -19.8042 0
+      vertex 3.8823 -19.5176 0
+    endloop
+  endfacet
+  facet normal -0.941546 0.336885 0
+    outer loop
+      vertex -19.0431 5.77666 0
+      vertex -18.3852 7.6154 60
+      vertex -18.3852 7.6154 0
+    endloop
+  endfacet
+  facet normal -0.941546 0.336885 0
+    outer loop
+      vertex -18.3852 7.6154 60
+      vertex -19.0431 5.77666 0
+      vertex -19.0431 5.77666 60
+    endloop
+  endfacet
+  facet normal 0.336885 -0.941546 0
+    outer loop
+      vertex 5.77666 -19.0431 0
+      vertex 7.6154 -18.3852 60
+      vertex 5.77666 -19.0431 60
+    endloop
+  endfacet
+  facet normal 0.336885 -0.941546 0
+    outer loop
+      vertex 7.6154 -18.3852 60
+      vertex 5.77666 -19.0431 0
+      vertex 7.6154 -18.3852 0
+    endloop
+  endfacet
+  facet normal 0.989173 -0.146756 0
+    outer loop
+      vertex 19.5176 -3.8823 60
+      vertex 19.8042 -1.95054 0
+      vertex 19.8042 -1.95054 60
+    endloop
+  endfacet
+  facet normal 0.989173 -0.146756 0
+    outer loop
+      vertex 19.8042 -1.95054 0
+      vertex 19.5176 -3.8823 60
+      vertex 19.5176 -3.8823 0
+    endloop
+  endfacet
+  facet normal -0.941546 -0.336885 0
+    outer loop
+      vertex -18.3852 -7.6154 0
+      vertex -19.0431 -5.77666 60
+      vertex -19.0431 -5.77666 0
+    endloop
+  endfacet
+  facet normal -0.941546 -0.336885 0
+    outer loop
+      vertex -19.0431 -5.77666 60
+      vertex -18.3852 -7.6154 0
+      vertex -18.3852 -7.6154 60
+    endloop
+  endfacet
+  facet normal 0.903983 -0.427569 0
+    outer loop
+      vertex 17.5502 -9.38079 60
+      vertex 18.3852 -7.6154 0
+      vertex 18.3852 -7.6154 60
+    endloop
+  endfacet
+  facet normal 0.903983 -0.427569 0
+    outer loop
+      vertex 18.3852 -7.6154 0
+      vertex 17.5502 -9.38079 60
+      vertex 17.5502 -9.38079 0
+    endloop
+  endfacet
+  facet normal -0.595682 0.803221 0
+    outer loop
+      vertex -11.0558 16.5462 0
+      vertex -12.6244 15.3829 60
+      vertex -11.0558 16.5462 60
+    endloop
+  endfacet
+  facet normal -0.595682 0.803221 0
+    outer loop
+      vertex -12.6244 15.3829 60
+      vertex -11.0558 16.5462 0
+      vertex -12.6244 15.3829 0
+    endloop
+  endfacet
+  facet normal -0.514117 0.85772 0
+    outer loop
+      vertex -9.38079 17.5502 0
+      vertex -11.0558 16.5462 60
+      vertex -9.38079 17.5502 60
+    endloop
+  endfacet
+  facet normal -0.514117 0.85772 0
+    outer loop
+      vertex -11.0558 16.5462 60
+      vertex -9.38079 17.5502 0
+      vertex -11.0558 16.5462 0
+    endloop
+  endfacet
+  facet normal -0.970033 -0.242974 0
+    outer loop
+      vertex -19.0431 -5.77666 0
+      vertex -19.5176 -3.8823 60
+      vertex -19.5176 -3.8823 0
+    endloop
+  endfacet
+  facet normal -0.970033 -0.242974 0
+    outer loop
+      vertex -19.5176 -3.8823 60
+      vertex -19.0431 -5.77666 0
+      vertex -19.0431 -5.77666 60
+    endloop
+  endfacet
+  facet normal -0.998796 -0.0490555 0
+    outer loop
+      vertex -19.8042 -1.95054 0
+      vertex -19.9 0 8.98212
+      vertex -19.9 0 0
+    endloop
+  endfacet
+  facet normal -0.99884 -0.0481448 -0.000198224
+    outer loop
+      vertex -19.9 0 8.98212
+      vertex -19.8042 -1.95054 0
+      vertex -19.8998 -0.00415969 8.98464
+    endloop
+  endfacet
+  facet normal -0.998788 -0.049225 3.63301e-05
+    outer loop
+      vertex -19.8998 -0.00415969 8.98464
+      vertex -19.8042 -1.95054 0
+      vertex -19.8946 -0.109622 9.04841
+    endloop
+  endfacet
+  facet normal -0.998812 -0.0487372 -6.31463e-05
+    outer loop
+      vertex -19.8946 -0.109622 9.04841
+      vertex -19.8042 -1.95054 0
+      vertex -19.8868 -0.269627 9.16664
+    endloop
+  endfacet
+  facet normal -0.99879 -0.0491701 1.64243e-05
+    outer loop
+      vertex -19.8868 -0.269627 9.16664
+      vertex -19.8042 -1.95054 0
+      vertex -19.88 -0.407713 9.2929
+    endloop
+  endfacet
+  facet normal -0.998754 -0.0498992 0.000137769
+    outer loop
+      vertex -19.88 -0.407713 9.2929
+      vertex -19.8042 -1.95054 0
+      vertex -19.8775 -0.457592 9.3507
+    endloop
+  endfacet
+  facet normal -0.99879 -0.0491747 2.18112e-05
+    outer loop
+      vertex -19.8775 -0.457592 9.3507
+      vertex -19.8042 -1.95054 0
+      vertex -19.8743 -0.522554 9.42597
+    endloop
+  endfacet
+  facet normal -0.99879 -0.0491701 2.11163e-05
+    outer loop
+      vertex -19.8743 -0.522554 9.42597
+      vertex -19.8042 -1.95054 0
+      vertex -19.8718 -0.573303 9.5037
+    endloop
+  endfacet
+  facet normal -0.998848 -0.0479877 -0.000150652
+    outer loop
+      vertex -19.8718 -0.573303 9.5037
+      vertex -19.8042 -1.95054 0
+      vertex -19.8699 -0.613042 9.56457
+    endloop
+  endfacet
+  facet normal -0.998799 -0.0489938 -9.6194e-06
+    outer loop
+      vertex -19.8699 -0.613042 9.56457
+      vertex -19.8042 -1.95054 0
+      vertex -19.8667 -0.678306 9.70736
+    endloop
+  endfacet
+  facet normal -0.998742 -0.0501535 0.000142738
+    outer loop
+      vertex -19.8667 -0.678306 9.70736
+      vertex -19.8042 -1.95054 0
+      vertex -19.8647 -0.717719 9.85297
+    endloop
+  endfacet
+  facet normal -0.998869 -0.0475415 -0.000184862
+    outer loop
+      vertex -19.8647 -0.717719 9.85297
+      vertex -19.8042 -1.95054 0
+      vertex -19.8641 -0.730897 10
+    endloop
+  endfacet
+  facet normal -0.998845 -0.0480491 4.01704e-05
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.9 0 11.0179
+      vertex -19.8998 -0.00415969 11.0154
+    endloop
+  endfacet
+  facet normal -0.998787 -0.0492424 -7.35954e-06
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.8998 -0.00415969 11.0154
+      vertex -19.8946 -0.109622 10.9516
+    endloop
+  endfacet
+  facet normal -0.998813 -0.0487003 1.30389e-05
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.8946 -0.109622 10.9516
+      vertex -19.8868 -0.269627 10.8334
+    endloop
+  endfacet
+  facet normal -0.99879 -0.0491819 -3.46716e-06
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.8868 -0.269627 10.8334
+      vertex -19.88 -0.407713 10.7071
+    endloop
+  endfacet
+  facet normal -0.998748 -0.0500239 -2.98855e-05
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.88 -0.407713 10.7071
+      vertex -19.8775 -0.457592 10.6493
+    endloop
+  endfacet
+  facet normal -0.998789 -0.0491944 -4.73127e-06
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.8775 -0.457592 10.6493
+      vertex -19.8743 -0.522554 10.574
+    endloop
+  endfacet
+  facet normal -0.998789 -0.0491951 -4.75132e-06
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.8743 -0.522554 10.574
+      vertex -19.8718 -0.573303 10.4963
+    endloop
+  endfacet
+  facet normal -0.998856 -0.0478092 3.38972e-05
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.8718 -0.573303 10.4963
+      vertex -19.8699 -0.613042 10.4354
+    endloop
+  endfacet
+  facet normal -0.9988 -0.0489778 2.28905e-06
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.8699 -0.613042 10.4354
+      vertex -19.8667 -0.678306 10.2926
+    endloop
+  endfacet
+  facet normal -0.998722 -0.0505402 -3.77977e-05
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.8667 -0.678306 10.2926
+      vertex -19.8647 -0.717719 10.147
+    endloop
+  endfacet
+  facet normal -0.99893 -0.0462471 6.86181e-05
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.8647 -0.717719 10.147
+      vertex -19.8641 -0.730897 10
+    endloop
+  endfacet
+  facet normal -0.998796 -0.0490536 -0
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.8641 -0.730897 10
+      vertex -19.8042 -1.95054 0
+    endloop
+  endfacet
+  facet normal -0.998796 -0.0490555 0
+    outer loop
+      vertex -19.9 0 11.0179
+      vertex -19.8042 -1.95054 60
+      vertex -19.9 0 60
+    endloop
+  endfacet
+  facet normal 0.146756 0.989173 -0
+    outer loop
+      vertex 3.8823 19.5176 0
+      vertex 1.95054 19.8042 60
+      vertex 3.8823 19.5176 60
+    endloop
+  endfacet
+  facet normal 0.146756 0.989173 0
+    outer loop
+      vertex 1.95054 19.8042 60
+      vertex 3.8823 19.5176 0
+      vertex 1.95054 19.8042 0
+    endloop
+  endfacet
+  facet normal 0.970033 -0.242974 0
+    outer loop
+      vertex 19.0431 -5.77666 60
+      vertex 19.5176 -3.8823 0
+      vertex 19.5176 -3.8823 60
+    endloop
+  endfacet
+  facet normal 0.970033 -0.242974 0
+    outer loop
+      vertex 19.5176 -3.8823 0
+      vertex 19.0431 -5.77666 60
+      vertex 19.0431 -5.77666 0
+    endloop
+  endfacet
+  facet normal 0.941546 -0.336885 0
+    outer loop
+      vertex 18.3852 -7.6154 60
+      vertex 19.0431 -5.77666 0
+      vertex 19.0431 -5.77666 60
+    endloop
+  endfacet
+  facet normal 0.941546 -0.336885 0
+    outer loop
+      vertex 19.0431 -5.77666 0
+      vertex 18.3852 -7.6154 60
+      vertex 18.3852 -7.6154 0
+    endloop
+  endfacet
+  facet normal 0.857601 0.514316 0
+    outer loop
+      vertex 16.5462 11.0558 60
+      vertex 16.5883 10.9856 11.3858
+      vertex 16.5462 11.0558 11.3604
+    endloop
+  endfacet
+  facet normal 0.857627 0.514272 8.59077e-08
+    outer loop
+      vertex 16.5462 11.0558 60
+      vertex 16.656 10.8727 11.4168
+      vertex 16.5883 10.9856 11.3858
+    endloop
+  endfacet
+  facet normal 0.857826 0.51394 1.78718e-06
+    outer loop
+      vertex 16.5462 11.0558 60
+      vertex 16.6968 10.8046 11.4354
+      vertex 16.656 10.8727 11.4168
+    endloop
+  endfacet
+  facet normal 0.857712 0.51413 4.55819e-07
+    outer loop
+      vertex 16.5462 11.0558 60
+      vertex 16.7381 10.7357 11.4486
+      vertex 16.6968 10.8046 11.4354
+    endloop
+  endfacet
+  facet normal 0.857493 0.514495 -2.82227e-06
+    outer loop
+      vertex 16.5462 11.0558 60
+      vertex 16.8086 10.6182 11.4712
+      vertex 16.7381 10.7357 11.4486
+    endloop
+  endfacet
+  facet normal 0.857741 0.514082 2.24987e-06
+    outer loop
+      vertex 16.5462 11.0558 60
+      vertex 16.8816 10.4964 11.485
+      vertex 16.8086 10.6182 11.4712
+    endloop
+  endfacet
+  facet normal 0.857936 0.513757 7.33319e-06
+    outer loop
+      vertex 16.5462 11.0558 60
+      vertex 16.9225 10.4281 11.4928
+      vertex 16.8816 10.4964 11.485
+    endloop
+  endfacet
+  facet normal 0.857716 0.514124 8.79786e-07
+    outer loop
+      vertex 16.5462 11.0558 60
+      vertex 16.9632 10.3602 11.4953
+      vertex 16.9225 10.4281 11.4928
+    endloop
+  endfacet
+  facet normal 0.857676 0.514191 -4.18677e-07
+    outer loop
+      vertex 16.5462 11.0558 60
+      vertex 17.0376 10.2361 11.5
+      vertex 16.9632 10.3602 11.4953
+    endloop
+  endfacet
+  facet normal 0.85772 0.514117 1.27874e-06
+    outer loop
+      vertex 17.5502 9.38079 60
+      vertex 17.0376 10.2361 11.5
+      vertex 16.5462 11.0558 60
+    endloop
+  endfacet
+  facet normal 0.857949 0.513735 -7.8852e-06
+    outer loop
+      vertex 17.0376 10.2361 11.5
+      vertex 17.5502 9.38079 60
+      vertex 17.0773 10.1698 11.4975
+    endloop
+  endfacet
+  facet normal 0.857553 0.514395 6.7227e-06
+    outer loop
+      vertex 17.0773 10.1698 11.4975
+      vertex 17.5502 9.38079 60
+      vertex 17.1527 10.0441 11.4928
+    endloop
+  endfacet
+  facet normal 0.857726 0.514107 1.36689e-06
+    outer loop
+      vertex 17.1527 10.0441 11.4928
+      vertex 17.5502 9.38079 60
+      vertex 17.2286 9.91747 11.4784
+    endloop
+  endfacet
+  facet normal 0.858088 0.513502 -7.72144e-06
+    outer loop
+      vertex 17.2286 9.91747 11.4784
+      vertex 17.5502 9.38079 60
+      vertex 17.2666 9.85397 11.4712
+    endloop
+  endfacet
+  facet normal 0.857765 0.514043 -5.64067e-07
+    outer loop
+      vertex 17.2666 9.85397 11.4712
+      vertex 17.5502 9.38079 60
+      vertex 17.3033 9.79273 11.4594
+    endloop
+  endfacet
+  facet normal 0.857572 0.514364 3.14775e-06
+    outer loop
+      vertex 17.3033 9.79273 11.4594
+      vertex 17.5502 9.38079 60
+      vertex 17.3784 9.66752 11.4354
+    endloop
+  endfacet
+  facet normal 0.857873 0.513861 -8.88185e-07
+    outer loop
+      vertex 17.3784 9.66752 11.4354
+      vertex 17.5502 9.38079 60
+      vertex 17.4868 9.48655 11.3858
+    endloop
+  endfacet
+  facet normal 0.857693 0.514162 0
+    outer loop
+      vertex 17.4868 9.48655 11.3858
+      vertex 17.5502 9.38079 60
+      vertex 17.5502 9.38079 11.3475
+    endloop
+  endfacet
+  facet normal 0.857601 0.514316 0
+    outer loop
+      vertex 16.5883 10.9856 8.61418
+      vertex 16.5462 11.0558 0
+      vertex 16.5462 11.0558 8.63962
+    endloop
+  endfacet
+  facet normal 0.857627 0.514272 -4.83932e-07
+    outer loop
+      vertex 16.656 10.8727 8.58323
+      vertex 16.5462 11.0558 0
+      vertex 16.5883 10.9856 8.61418
+    endloop
+  endfacet
+  facet normal 0.857825 0.513942 -1.00675e-05
+    outer loop
+      vertex 16.6968 10.8046 8.56459
+      vertex 16.5462 11.0558 0
+      vertex 16.656 10.8727 8.58323
+    endloop
+  endfacet
+  facet normal 0.857712 0.51413 -2.57275e-06
+    outer loop
+      vertex 16.7381 10.7357 8.55136
+      vertex 16.5462 11.0558 0
+      vertex 16.6968 10.8046 8.56459
+    endloop
+  endfacet
+  facet normal 0.857494 0.514494 1.59297e-05
+    outer loop
+      vertex 16.8086 10.6182 8.52882
+      vertex 16.5462 11.0558 0
+      vertex 16.7381 10.7357 8.55136
+    endloop
+  endfacet
+  facet normal 0.857741 0.514083 -1.27406e-05
+    outer loop
+      vertex 16.8816 10.4964 8.51499
+      vertex 16.5462 11.0558 0
+      vertex 16.8086 10.6182 8.52882
+    endloop
+  endfacet
+  facet normal 0.857934 0.51376 -4.15261e-05
+    outer loop
+      vertex 16.9225 10.4281 8.50722
+      vertex 16.5462 11.0558 0
+      vertex 16.8816 10.4964 8.51499
+    endloop
+  endfacet
+  facet normal 0.857716 0.514124 -5.00496e-06
+    outer loop
+      vertex 16.9632 10.3602 8.50467
+      vertex 16.5462 11.0558 0
+      vertex 16.9225 10.4281 8.50722
+    endloop
+  endfacet
+  facet normal 0.857676 0.514191 2.38181e-06
+    outer loop
+      vertex 17.0376 10.2361 8.5
+      vertex 16.5462 11.0558 0
+      vertex 16.9632 10.3602 8.50467
+    endloop
+  endfacet
+  facet normal 0.857949 0.513736 4.48524e-05
+    outer loop
+      vertex 17.5502 9.38079 0
+      vertex 17.0376 10.2361 8.5
+      vertex 17.0773 10.1698 8.50249
+    endloop
+  endfacet
+  facet normal 0.857554 0.514394 -3.82395e-05
+    outer loop
+      vertex 17.5502 9.38079 0
+      vertex 17.0773 10.1698 8.50249
+      vertex 17.1527 10.0441 8.50722
+    endloop
+  endfacet
+  facet normal 0.857726 0.514107 -7.73743e-06
+    outer loop
+      vertex 17.5502 9.38079 0
+      vertex 17.1527 10.0441 8.50722
+      vertex 17.2286 9.91747 8.52161
+    endloop
+  endfacet
+  facet normal 0.858086 0.513505 4.3708e-05
+    outer loop
+      vertex 17.5502 9.38079 0
+      vertex 17.2286 9.91747 8.52161
+      vertex 17.2666 9.85397 8.52882
+    endloop
+  endfacet
+  facet normal 0.857764 0.514043 3.18169e-06
+    outer loop
+      vertex 17.5502 9.38079 0
+      vertex 17.2666 9.85397 8.52882
+      vertex 17.3033 9.79273 8.54057
+    endloop
+  endfacet
+  facet normal 0.857573 0.514362 -1.77552e-05
+    outer loop
+      vertex 17.5502 9.38079 0
+      vertex 17.3033 9.79273 8.54057
+      vertex 17.3784 9.66752 8.56459
+    endloop
+  endfacet
+  facet normal 0.857873 0.513862 4.99865e-06
+    outer loop
+      vertex 17.5502 9.38079 0
+      vertex 17.3784 9.66752 8.56459
+      vertex 17.4868 9.48655 8.61418
+    endloop
+  endfacet
+  facet normal 0.857693 0.514162 -0
+    outer loop
+      vertex 17.5502 9.38079 0
+      vertex 17.4868 9.48655 8.61418
+      vertex 17.5502 9.38079 8.65248
+    endloop
+  endfacet
+  facet normal 0.85772 0.514117 -7.29632e-06
+    outer loop
+      vertex 17.0376 10.2361 8.5
+      vertex 17.5502 9.38079 0
+      vertex 16.5462 11.0558 0
+    endloop
+  endfacet
+  facet normal 0.941546 0.336885 0
+    outer loop
+      vertex 19.0431 5.77666 60
+      vertex 18.3852 7.6154 0
+      vertex 18.3852 7.6154 60
+    endloop
+  endfacet
+  facet normal 0.941546 0.336885 0
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 19.0431 5.77666 60
+      vertex 19.0431 5.77666 0
+    endloop
+  endfacet
+  facet normal 0.336885 0.941546 -0
+    outer loop
+      vertex 7.6154 18.3852 0
+      vertex 5.77666 19.0431 60
+      vertex 7.6154 18.3852 60
+    endloop
+  endfacet
+  facet normal 0.336885 0.941546 0
+    outer loop
+      vertex 5.77666 19.0431 60
+      vertex 7.6154 18.3852 0
+      vertex 5.77666 19.0431 0
+    endloop
+  endfacet
+  facet normal -0.0490555 0.998796 0
+    outer loop
+      vertex 0 19.9 0
+      vertex -1.95054 19.8042 60
+      vertex 0 19.9 60
+    endloop
+  endfacet
+  facet normal -0.0490555 0.998796 0
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex 0 19.9 0
+      vertex -1.95054 19.8042 0
+    endloop
+  endfacet
+  facet normal -0.427569 -0.903983 4.23932e-07
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -7.78945 -18.3029 11.5
+      vertex -7.6154 -18.3852 60
+    endloop
+  endfacet
+  facet normal -0.427777 -0.903884 -7.9473e-06
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -7.98321 -18.2112 11.4928
+      vertex -7.78945 -18.3029 11.5
+    endloop
+  endfacet
+  facet normal -0.427354 -0.904085 6.98791e-06
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -8.17509 -18.1205 11.4712
+      vertex -7.98321 -18.2112 11.4928
+    endloop
+  endfacet
+  facet normal -0.427545 -0.903994 1.15806e-06
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -8.36327 -18.0315 11.4354
+      vertex -8.17509 -18.1205 11.4712
+    endloop
+  endfacet
+  facet normal -0.428077 -0.903742 -1.24723e-05
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -8.42196 -18.0037 11.4195
+      vertex -8.36327 -18.0315 11.4354
+    endloop
+  endfacet
+  facet normal -0.427413 -0.904057 3.56718e-06
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -8.54591 -17.9451 11.3858
+      vertex -8.42196 -18.0037 11.4195
+    endloop
+  endfacet
+  facet normal -0.42752 -0.904006 1.31304e-06
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -8.66665 -17.888 11.3425
+      vertex -8.54591 -17.9451 11.3858
+    endloop
+  endfacet
+  facet normal -0.427107 -0.904201 8.73989e-06
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -8.72127 -17.8622 11.3229
+      vertex -8.66665 -17.888 11.3425
+    endloop
+  endfacet
+  facet normal -0.427872 -0.903839 -3.95074e-06
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -8.77239 -17.838 11.2996
+      vertex -8.72127 -17.8622 11.3229
+    endloop
+  endfacet
+  facet normal -0.427437 -0.904045 2.70722e-06
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -8.88766 -17.7835 11.2472
+      vertex -8.77239 -17.838 11.2996
+    endloop
+  endfacet
+  facet normal -0.428102 -0.903731 -5.52526e-06
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -8.99701 -17.7317 11.1857
+      vertex -8.88766 -17.7835 11.2472
+    endloop
+  endfacet
+  facet normal -0.426383 -0.904543 1.10024e-05
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -9.04347 -17.7098 11.1595
+      vertex -8.99701 -17.7317 11.1857
+    endloop
+  endfacet
+  facet normal -0.427638 -0.90395 4.02914e-07
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -9.18721 -17.6418 11.0607
+      vertex -9.04347 -17.7098 11.1595
+    endloop
+  endfacet
+  facet normal -0.427481 -0.904024 1.15949e-06
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -9.31748 -17.5802 10.9516
+      vertex -9.18721 -17.6418 11.0607
+    endloop
+  endfacet
+  facet normal -0.428215 -0.903677 0
+    outer loop
+      vertex -9.31748 -17.5802 10.9516
+      vertex -9.38079 -17.5502 60
+      vertex -9.38079 -17.5502 10.8868
+    endloop
+  endfacet
+  facet normal -0.427472 -0.904028 -0
+    outer loop
+      vertex -7.6154 -18.3852 60
+      vertex -7.78945 -18.3029 11.5
+      vertex -7.6154 -18.3852 11.4935
+    endloop
+  endfacet
+  facet normal -0.427417 -0.904055 -1.97067e-05
+    outer loop
+      vertex -9.38079 -17.5502 0
+      vertex -8.42196 -18.0037 8.58052
+      vertex -8.54591 -17.9451 8.61418
+    endloop
+  endfacet
+  facet normal -0.427569 -0.903983 3.4014e-06
+    outer loop
+      vertex -7.6154 -18.3852 0
+      vertex -7.98321 -18.2112 8.50722
+      vertex -9.38079 -17.5502 0
+    endloop
+  endfacet
+  facet normal -0.427357 -0.904083 -3.92476e-05
+    outer loop
+      vertex -8.17509 -18.1205 8.52882
+      vertex -9.38079 -17.5502 0
+      vertex -7.98321 -18.2112 8.50722
+    endloop
+  endfacet
+  facet normal -0.427546 -0.903993 -6.44722e-06
+    outer loop
+      vertex -8.36327 -18.0315 8.56459
+      vertex -9.38079 -17.5502 0
+      vertex -8.17509 -18.1205 8.52882
+    endloop
+  endfacet
+  facet normal -0.428064 -0.903748 6.89031e-05
+    outer loop
+      vertex -8.42196 -18.0037 8.58052
+      vertex -9.38079 -17.5502 0
+      vertex -8.36327 -18.0315 8.56459
+    endloop
+  endfacet
+  facet normal -0.427522 -0.904005 -7.20515e-06
+    outer loop
+      vertex -8.66665 -17.888 8.65751
+      vertex -9.38079 -17.5502 0
+      vertex -8.54591 -17.9451 8.61418
+    endloop
+  endfacet
+  facet normal -0.427118 -0.904196 -4.79586e-05
+    outer loop
+      vertex -8.72127 -17.8622 8.67712
+      vertex -9.38079 -17.5502 0
+      vertex -8.66665 -17.888 8.65751
+    endloop
+  endfacet
+  facet normal -0.427866 -0.903842 2.15547e-05
+    outer loop
+      vertex -8.77239 -17.838 8.70037
+      vertex -9.38079 -17.5502 0
+      vertex -8.72127 -17.8622 8.67712
+    endloop
+  endfacet
+  facet normal -0.427441 -0.904043 -1.47699e-05
+    outer loop
+      vertex -8.88766 -17.7835 8.7528
+      vertex -9.38079 -17.5502 0
+      vertex -8.77239 -17.838 8.70037
+    endloop
+  endfacet
+  facet normal -0.42809 -0.903736 2.99997e-05
+    outer loop
+      vertex -8.99701 -17.7317 8.81433
+      vertex -9.38079 -17.5502 0
+      vertex -8.88766 -17.7835 8.7528
+    endloop
+  endfacet
+  facet normal -0.426406 -0.904532 -5.97373e-05
+    outer loop
+      vertex -9.04347 -17.7098 8.84048
+      vertex -9.38079 -17.5502 0
+      vertex -8.99701 -17.7317 8.81433
+    endloop
+  endfacet
+  facet normal -0.427639 -0.90395 -2.17933e-06
+    outer loop
+      vertex -9.18721 -17.6418 8.93934
+      vertex -9.38079 -17.5502 0
+      vertex -9.04347 -17.7098 8.84048
+    endloop
+  endfacet
+  facet normal -0.427485 -0.904022 -6.25535e-06
+    outer loop
+      vertex -9.31748 -17.5802 9.04841
+      vertex -9.38079 -17.5502 0
+      vertex -9.18721 -17.6418 8.93934
+    endloop
+  endfacet
+  facet normal -0.428215 -0.903677 0
+    outer loop
+      vertex -9.38079 -17.5502 0
+      vertex -9.31748 -17.5802 9.04841
+      vertex -9.38079 -17.5502 9.11319
+    endloop
+  endfacet
+  facet normal -0.427778 -0.903884 -7.65474e-06
+    outer loop
+      vertex -7.98321 -18.2112 8.50722
+      vertex -7.6154 -18.3852 0
+      vertex -7.78945 -18.3029 8.5
+    endloop
+  endfacet
+  facet normal -0.427472 -0.904028 0
+    outer loop
+      vertex -7.78945 -18.3029 8.5
+      vertex -7.6154 -18.3852 0
+      vertex -7.6154 -18.3852 8.50649
+    endloop
+  endfacet
+  facet normal -0.740947 0.671563 0
+    outer loop
+      vertex -15.3829 12.6244 0
+      vertex -14.0714 14.0714 60
+      vertex -14.0714 14.0714 0
+    endloop
+  endfacet
+  facet normal -0.740947 0.671563 0
+    outer loop
+      vertex -14.0714 14.0714 60
+      vertex -15.3829 12.6244 0
+      vertex -15.3829 12.6244 60
+    endloop
+  endfacet
+  facet normal -0.146756 0.989173 0
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -3.8823 19.5176 11.4475
+      vertex -3.8823 19.5176 60
+    endloop
+  endfacet
+  facet normal -0.147356 0.989084 2.44114e-05
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -3.81518 19.5276 11.4354
+      vertex -3.8823 19.5176 11.4475
+    endloop
+  endfacet
+  facet normal -0.146493 0.989212 -9.4676e-06
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -3.75373 19.5367 11.4195
+      vertex -3.81518 19.5276 11.4354
+    endloop
+  endfacet
+  facet normal -0.146975 0.98914 8.81809e-06
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -3.62317 19.5561 11.3858
+      vertex -3.75373 19.5367 11.4195
+    endloop
+  endfacet
+  facet normal -0.146406 0.989225 -1.11937e-05
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -3.49614 19.5749 11.3425
+      vertex -3.62317 19.5561 11.3858
+    endloop
+  endfacet
+  facet normal -0.146687 0.989183 -2.06163e-06
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -3.43882 19.5834 11.3229
+      vertex -3.49614 19.5749 11.3425
+    endloop
+  endfacet
+  facet normal -0.147342 0.989086 1.84027e-05
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -3.38512 19.5914 11.2996
+      vertex -3.43882 19.5834 11.3229
+    endloop
+  endfacet
+  facet normal -0.146878 0.989155 4.43798e-06
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -3.2639 19.6094 11.2472
+      vertex -3.38512 19.5914 11.2996
+    endloop
+  endfacet
+  facet normal -0.146754 0.989173 1.02039e-06
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -3.10011 19.6337 11.1595
+      vertex -3.2639 19.6094 11.2472
+    endloop
+  endfacet
+  facet normal -0.146298 0.989241 -9.94595e-06
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -3.05548 19.6403 11.1303
+      vertex -3.10011 19.6337 11.1595
+    endloop
+  endfacet
+  facet normal -0.146777 0.98917 1.12019e-06
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -2.949 19.6561 11.0607
+      vertex -3.05548 19.6403 11.1303
+    endloop
+  endfacet
+  facet normal -0.146132 0.989265 -1.23325e-05
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -2.85151 19.6705 10.983
+      vertex -2.949 19.6561 11.0607
+    endloop
+  endfacet
+  facet normal -0.147859 0.989008 2.01183e-05
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -2.81205 19.6764 10.9516
+      vertex -2.85151 19.6705 10.983
+    endloop
+  endfacet
+  facet normal -0.146575 0.9892 -2.93223e-06
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -2.69057 19.6944 10.8334
+      vertex -2.81205 19.6764 10.9516
+    endloop
+  endfacet
+  facet normal -0.14717 0.989111 6.22632e-06
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -2.58573 19.71 10.7071
+      vertex -2.69057 19.6944 10.8334
+    endloop
+  endfacet
+  facet normal -0.146366 0.989231 -4.36717e-06
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -2.49854 19.7229 10.574
+      vertex -2.58573 19.71 10.7071
+    endloop
+  endfacet
+  facet normal -0.146839 0.98916 9.90581e-07
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -2.42983 19.7331 10.4354
+      vertex -2.49854 19.7229 10.574
+    endloop
+  endfacet
+  facet normal -0.145779 0.989317 -9.47944e-06
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -2.38028 19.7404 10.2926
+      vertex -2.42983 19.7331 10.4354
+    endloop
+  endfacet
+  facet normal -0.148653 0.988889 1.59096e-05
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -2.35036 19.7449 10.147
+      vertex -2.38028 19.7404 10.2926
+    endloop
+  endfacet
+  facet normal -0.148039 0.988981 1.08809e-05
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -2.34035 19.7464 10
+      vertex -2.35036 19.7449 10.147
+    endloop
+  endfacet
+  facet normal -0.146774 0.98917 -5.79123e-06
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -3.05548 19.6403 8.86968
+      vertex -2.949 19.6561 8.93934
+    endloop
+  endfacet
+  facet normal -0.14687 0.989156 -2.34827e-05
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -3.38512 19.5914 8.70035
+      vertex -3.2639 19.6094 8.7528
+    endloop
+  endfacet
+  facet normal -0.14669 0.989183 1.10398e-05
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -3.49614 19.5749 8.65755
+      vertex -3.43882 19.5834 8.67712
+    endloop
+  endfacet
+  facet normal -0.146965 0.989142 -4.78094e-05
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -3.75373 19.5367 8.58046
+      vertex -3.62317 19.5561 8.61418
+    endloop
+  endfacet
+  facet normal -0.146674 0.989185 0
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -2.34035 19.7464 10
+      vertex -1.95054 19.8042 60
+    endloop
+  endfacet
+  facet normal -0.147642 0.989041 -3.85592e-05
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -2.35036 19.7449 9.85297
+      vertex -2.34035 19.7464 10
+    endloop
+  endfacet
+  facet normal -0.148396 0.988928 -6.98488e-05
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -2.38028 19.7404 9.70736
+      vertex -2.35036 19.7449 9.85297
+    endloop
+  endfacet
+  facet normal -0.145877 0.989303 4.41204e-05
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -2.42983 19.7331 9.56457
+      vertex -2.38028 19.7404 9.70736
+    endloop
+  endfacet
+  facet normal -0.146831 0.989162 -4.75299e-06
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -2.49854 19.7229 9.42597
+      vertex -2.42983 19.7331 9.56457
+    endloop
+  endfacet
+  facet normal -0.146391 0.989227 2.13893e-05
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -2.58573 19.71 9.2929
+      vertex -2.49854 19.7229 9.42597
+    endloop
+  endfacet
+  facet normal -0.147141 0.989115 -3.09886e-05
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -2.69057 19.6944 9.16664
+      vertex -2.58573 19.71 9.2929
+    endloop
+  endfacet
+  facet normal -0.146586 0.989198 1.47953e-05
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -2.81205 19.6764 9.04841
+      vertex -2.69057 19.6944 9.16664
+    endloop
+  endfacet
+  facet normal -0.147795 0.989018 -0.000102785
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -2.85151 19.6705 9.01698
+      vertex -2.81205 19.6764 9.04841
+    endloop
+  endfacet
+  facet normal -0.146171 0.989259 6.30081e-05
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -2.949 19.6561 8.93934
+      vertex -2.85151 19.6705 9.01698
+    endloop
+  endfacet
+  facet normal -0.146325 0.989237 5.14192e-05
+    outer loop
+      vertex -3.05548 19.6403 8.86968
+      vertex -1.95054 19.8042 0
+      vertex -3.10011 19.6337 8.84048
+    endloop
+  endfacet
+  facet normal -0.146752 0.989173 -5.33681e-06
+    outer loop
+      vertex -1.95054 19.8042 0
+      vertex -3.2639 19.6094 8.7528
+      vertex -3.10011 19.6337 8.84048
+    endloop
+  endfacet
+  facet normal -0.147308 0.989091 -9.73807e-05
+    outer loop
+      vertex -3.38512 19.5914 8.70035
+      vertex -1.95054 19.8042 0
+      vertex -3.43882 19.5834 8.67712
+    endloop
+  endfacet
+  facet normal -0.146422 0.989222 5.99391e-05
+    outer loop
+      vertex -3.49614 19.5749 8.65755
+      vertex -1.95054 19.8042 0
+      vertex -3.62317 19.5561 8.61418
+    endloop
+  endfacet
+  facet normal -0.146503 0.98921 5.1332e-05
+    outer loop
+      vertex -3.75373 19.5367 8.58046
+      vertex -1.95054 19.8042 0
+      vertex -3.81518 19.5276 8.56459
+    endloop
+  endfacet
+  facet normal -0.146756 0.989173 -4.84329e-06
+    outer loop
+      vertex -3.8823 19.5176 0
+      vertex -3.81518 19.5276 8.56459
+      vertex -1.95054 19.8042 0
+    endloop
+  endfacet
+  facet normal -0.14736 0.989083 0
+    outer loop
+      vertex -3.81518 19.5276 8.56459
+      vertex -3.8823 19.5176 0
+      vertex -3.8823 19.5176 8.55245
+    endloop
+  endfacet
+  facet normal 0.0490555 -0.998796 0
+    outer loop
+      vertex 0 -19.9 0
+      vertex 1.95054 -19.8042 60
+      vertex 0 -19.9 60
+    endloop
+  endfacet
+  facet normal 0.0490555 -0.998796 0
+    outer loop
+      vertex 1.95054 -19.8042 60
+      vertex 0 -19.9 0
+      vertex 1.95054 -19.8042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15 0 0
+      vertex 19.9 0 0
+      vertex 19.8042 -1.95054 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.9278 -1.47026 0
+      vertex 19.8042 -1.95054 0
+      vertex 19.5176 -3.8823 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.9 0 0
+      vertex 15 0 0
+      vertex 19.8042 1.95054 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7118 -2.92635 0
+      vertex 19.5176 -3.8823 0
+      vertex 19.0431 -5.77666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.9278 1.47026 0
+      vertex 19.8042 1.95054 0
+      vertex 15 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.3541 -4.35427 0
+      vertex 19.0431 -5.77666 0
+      vertex 18.3852 -7.6154 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.8042 1.95054 0
+      vertex 14.9278 1.47026 0
+      vertex 19.5176 3.8823 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8582 -5.74025 0
+      vertex 18.3852 -7.6154 0
+      vertex 17.5502 -9.38079 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7118 2.92635 0
+      vertex 19.5176 3.8823 0
+      vertex 14.9278 1.47026 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.2288 -7.07095 0
+      vertex 17.5502 -9.38079 0
+      vertex 16.5462 -11.0558 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.5176 3.8823 0
+      vertex 14.7118 2.92635 0
+      vertex 19.0431 5.77666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.472 -8.33355 0
+      vertex 16.5462 -11.0558 0
+      vertex 15.3829 -12.6244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.3541 4.35427 0
+      vertex 19.0431 5.77666 0
+      vertex 14.7118 2.92635 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.0431 5.77666 0
+      vertex 14.3541 4.35427 0
+      vertex 18.3852 7.6154 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.8042 -1.95054 0
+      vertex 14.9278 -1.47026 0
+      vertex 15 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.5176 -3.8823 0
+      vertex 14.7118 -2.92635 0
+      vertex 14.9278 -1.47026 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.0431 -5.77666 0
+      vertex 14.3541 -4.35427 0
+      vertex 14.7118 -2.92635 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5952 -9.5159 0
+      vertex 15.3829 -12.6244 0
+      vertex 14.0714 -14.0714 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.3852 -7.6154 0
+      vertex 13.8582 -5.74025 0
+      vertex 14.3541 -4.35427 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.5502 -9.38079 0
+      vertex 13.2288 -7.07095 0
+      vertex 13.8582 -5.74025 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6066 -10.6066 0
+      vertex 14.0714 -14.0714 0
+      vertex 12.6244 -15.3829 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5462 -11.0558 0
+      vertex 12.472 -8.33355 0
+      vertex 13.2288 -7.07095 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.3829 -12.6244 0
+      vertex 11.5952 -9.5159 0
+      vertex 12.472 -8.33355 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.5159 -11.5952 0
+      vertex 12.6244 -15.3829 0
+      vertex 11.0558 -16.5462 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.0714 -14.0714 0
+      vertex 10.6066 -10.6066 0
+      vertex 11.5952 -9.5159 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6244 -15.3829 0
+      vertex 9.5159 -11.5952 0
+      vertex 10.6066 -10.6066 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.33355 -12.472 0
+      vertex 11.0558 -16.5462 0
+      vertex 9.38079 -17.5502 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.0558 -16.5462 0
+      vertex 8.33355 -12.472 0
+      vertex 9.5159 -11.5952 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.07095 -13.2288 0
+      vertex 9.38079 -17.5502 0
+      vertex 7.6154 -18.3852 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.38079 -17.5502 0
+      vertex 7.07095 -13.2288 0
+      vertex 8.33355 -12.472 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.74025 -13.8582 0
+      vertex 7.6154 -18.3852 0
+      vertex 5.77666 -19.0431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.6154 -18.3852 0
+      vertex 5.74025 -13.8582 0
+      vertex 7.07095 -13.2288 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.77666 -19.0431 0
+      vertex 4.35427 -14.3541 0
+      vertex 5.74025 -13.8582 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.8823 -19.5176 0
+      vertex 4.35427 -14.3541 0
+      vertex 5.77666 -19.0431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.8823 -19.5176 0
+      vertex 2.92635 -14.7118 0
+      vertex 4.35427 -14.3541 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95054 -19.8042 0
+      vertex 2.92635 -14.7118 0
+      vertex 3.8823 -19.5176 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95054 -19.8042 0
+      vertex 1.47026 -14.9278 0
+      vertex 2.92635 -14.7118 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -19.9 0
+      vertex 1.47026 -14.9278 0
+      vertex 1.95054 -19.8042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -19.9 0
+      vertex 0 -15 0
+      vertex 1.47026 -14.9278 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -19.9 0
+      vertex -1.47026 -14.9278 0
+      vertex 0 -15 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.95054 -19.8042 0
+      vertex -1.47026 -14.9278 0
+      vertex 0 -19.9 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.95054 -19.8042 0
+      vertex -2.92635 -14.7118 0
+      vertex -1.47026 -14.9278 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.8823 -19.5176 0
+      vertex -2.92635 -14.7118 0
+      vertex -1.95054 -19.8042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.8823 -19.5176 0
+      vertex -4.35427 -14.3541 0
+      vertex -2.92635 -14.7118 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.77666 -19.0431 0
+      vertex -4.35427 -14.3541 0
+      vertex -3.8823 -19.5176 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -4.35427 -14.3541 0
+      vertex -5.77666 -19.0431 0
+      vertex -5.74025 -13.8582 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.6154 -18.3852 0
+      vertex -5.74025 -13.8582 0
+      vertex -5.77666 -19.0431 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.74025 -13.8582 0
+      vertex -7.6154 -18.3852 0
+      vertex -7.07095 -13.2288 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.38079 -17.5502 0
+      vertex -7.07095 -13.2288 0
+      vertex -7.6154 -18.3852 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -7.07095 -13.2288 0
+      vertex -9.38079 -17.5502 0
+      vertex -8.33355 -12.472 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.0558 -16.5462 0
+      vertex -8.33355 -12.472 0
+      vertex -9.38079 -17.5502 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.33355 -12.472 0
+      vertex -11.0558 -16.5462 0
+      vertex -9.5159 -11.5952 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.6244 -15.3829 0
+      vertex -9.5159 -11.5952 0
+      vertex -11.0558 -16.5462 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.5159 -11.5952 0
+      vertex -12.6244 -15.3829 0
+      vertex -10.6066 -10.6066 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.0714 -14.0714 0
+      vertex -10.6066 -10.6066 0
+      vertex -12.6244 -15.3829 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.6066 -10.6066 0
+      vertex -14.0714 -14.0714 0
+      vertex -11.5952 -9.5159 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.3829 -12.6244 0
+      vertex -11.5952 -9.5159 0
+      vertex -14.0714 -14.0714 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -11.5952 -9.5159 0
+      vertex -15.3829 -12.6244 0
+      vertex -12.472 -8.33355 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5462 -11.0558 0
+      vertex -12.472 -8.33355 0
+      vertex -15.3829 -12.6244 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.472 -8.33355 0
+      vertex -16.5462 -11.0558 0
+      vertex -13.2288 -7.07095 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.5502 -9.38079 0
+      vertex -13.2288 -7.07095 0
+      vertex -16.5462 -11.0558 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.2288 -7.07095 0
+      vertex -17.5502 -9.38079 0
+      vertex -13.8582 -5.74025 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.8582 -5.74025 0
+      vertex -18.3852 -7.6154 0
+      vertex -14.3541 -4.35427 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.3852 -7.6154 0
+      vertex -13.8582 -5.74025 0
+      vertex -17.5502 -9.38079 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8582 5.74025 0
+      vertex 18.3852 7.6154 0
+      vertex 14.3541 4.35427 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 18.3852 7.6154 0
+      vertex 13.8582 5.74025 0
+      vertex 17.5502 9.38079 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.2288 7.07095 0
+      vertex 17.5502 9.38079 0
+      vertex 13.8582 5.74025 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.5502 9.38079 0
+      vertex 13.2288 7.07095 0
+      vertex 16.5462 11.0558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.472 8.33355 0
+      vertex 16.5462 11.0558 0
+      vertex 13.2288 7.07095 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.5462 11.0558 0
+      vertex 12.472 8.33355 0
+      vertex 15.3829 12.6244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5952 9.5159 0
+      vertex 15.3829 12.6244 0
+      vertex 12.472 8.33355 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.3829 12.6244 0
+      vertex 11.5952 9.5159 0
+      vertex 14.0714 14.0714 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6066 10.6066 0
+      vertex 14.0714 14.0714 0
+      vertex 11.5952 9.5159 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.0714 14.0714 0
+      vertex 10.6066 10.6066 0
+      vertex 12.6244 15.3829 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.5159 11.5952 0
+      vertex 12.6244 15.3829 0
+      vertex 10.6066 10.6066 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.6244 15.3829 0
+      vertex 9.5159 11.5952 0
+      vertex 11.0558 16.5462 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.33355 12.472 0
+      vertex 11.0558 16.5462 0
+      vertex 9.5159 11.5952 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.0558 16.5462 0
+      vertex 8.33355 12.472 0
+      vertex 9.38079 17.5502 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.07095 13.2288 0
+      vertex 9.38079 17.5502 0
+      vertex 8.33355 12.472 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 9.38079 17.5502 0
+      vertex 7.07095 13.2288 0
+      vertex 7.6154 18.3852 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.74025 13.8582 0
+      vertex 7.6154 18.3852 0
+      vertex 7.07095 13.2288 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.6154 18.3852 0
+      vertex 5.74025 13.8582 0
+      vertex 5.77666 19.0431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.35427 14.3541 0
+      vertex 5.77666 19.0431 0
+      vertex 5.74025 13.8582 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.35427 14.3541 0
+      vertex 3.8823 19.5176 0
+      vertex 5.77666 19.0431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.92635 14.7118 0
+      vertex 3.8823 19.5176 0
+      vertex 4.35427 14.3541 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.92635 14.7118 0
+      vertex 1.95054 19.8042 0
+      vertex 3.8823 19.5176 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.47026 14.9278 0
+      vertex 1.95054 19.8042 0
+      vertex 2.92635 14.7118 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 15 0
+      vertex 1.95054 19.8042 0
+      vertex 1.47026 14.9278 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 15 0
+      vertex 0 19.9 0
+      vertex 1.95054 19.8042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.47026 14.9278 0
+      vertex 0 19.9 0
+      vertex 0 15 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.47026 14.9278 0
+      vertex -1.95054 19.8042 0
+      vertex 0 19.9 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.92635 14.7118 0
+      vertex -1.95054 19.8042 0
+      vertex -1.47026 14.9278 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.92635 14.7118 0
+      vertex -3.8823 19.5176 0
+      vertex -1.95054 19.8042 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.35427 14.3541 0
+      vertex -3.8823 19.5176 0
+      vertex -2.92635 14.7118 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.77666 19.0431 0
+      vertex -4.35427 14.3541 0
+      vertex -5.74025 13.8582 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.35427 14.3541 0
+      vertex -5.77666 19.0431 0
+      vertex -3.8823 19.5176 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.6154 18.3852 0
+      vertex -5.74025 13.8582 0
+      vertex -7.07095 13.2288 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.74025 13.8582 0
+      vertex -7.6154 18.3852 0
+      vertex -5.77666 19.0431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.38079 17.5502 0
+      vertex -7.07095 13.2288 0
+      vertex -8.33355 12.472 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.07095 13.2288 0
+      vertex -9.38079 17.5502 0
+      vertex -7.6154 18.3852 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.0558 16.5462 0
+      vertex -8.33355 12.472 0
+      vertex -9.5159 11.5952 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.6244 15.3829 0
+      vertex -9.5159 11.5952 0
+      vertex -10.6066 10.6066 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.33355 12.472 0
+      vertex -11.0558 16.5462 0
+      vertex -9.38079 17.5502 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.0714 14.0714 0
+      vertex -10.6066 10.6066 0
+      vertex -11.5952 9.5159 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.3829 12.6244 0
+      vertex -11.5952 9.5159 0
+      vertex -12.472 8.33355 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.5159 11.5952 0
+      vertex -12.6244 15.3829 0
+      vertex -11.0558 16.5462 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5462 11.0558 0
+      vertex -12.472 8.33355 0
+      vertex -13.2288 7.07095 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.5502 9.38079 0
+      vertex -13.2288 7.07095 0
+      vertex -13.8582 5.74025 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6066 10.6066 0
+      vertex -14.0714 14.0714 0
+      vertex -12.6244 15.3829 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.3852 7.6154 0
+      vertex -13.8582 5.74025 0
+      vertex -14.3541 4.35427 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.0431 5.77666 0
+      vertex -14.3541 4.35427 0
+      vertex -14.7118 2.92635 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5176 3.8823 0
+      vertex -14.7118 2.92635 0
+      vertex -14.9278 1.47026 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.5952 9.5159 0
+      vertex -15.3829 12.6244 0
+      vertex -14.0714 14.0714 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.8042 1.95054 0
+      vertex -14.9278 1.47026 0
+      vertex -15 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.0431 -5.77666 0
+      vertex -14.3541 -4.35427 0
+      vertex -18.3852 -7.6154 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.3541 -4.35427 0
+      vertex -19.0431 -5.77666 0
+      vertex -14.7118 -2.92635 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.472 8.33355 0
+      vertex -16.5462 11.0558 0
+      vertex -15.3829 12.6244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5176 -3.8823 0
+      vertex -14.7118 -2.92635 0
+      vertex -19.0431 -5.77666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.2288 7.07095 0
+      vertex -17.5502 9.38079 0
+      vertex -16.5462 11.0558 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.7118 -2.92635 0
+      vertex -19.5176 -3.8823 0
+      vertex -14.9278 -1.47026 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8582 5.74025 0
+      vertex -18.3852 7.6154 0
+      vertex -17.5502 9.38079 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.8042 -1.95054 0
+      vertex -14.9278 -1.47026 0
+      vertex -19.5176 -3.8823 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.3541 4.35427 0
+      vertex -19.0431 5.77666 0
+      vertex -18.3852 7.6154 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.9278 -1.47026 0
+      vertex -19.8042 -1.95054 0
+      vertex -15 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7118 2.92635 0
+      vertex -19.5176 3.8823 0
+      vertex -19.0431 5.77666 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.9 0 0
+      vertex -15 0 0
+      vertex -19.8042 -1.95054 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.9278 1.47026 0
+      vertex -19.8042 1.95054 0
+      vertex -19.5176 3.8823 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15 0 0
+      vertex -19.9 0 0
+      vertex -19.8042 1.95054 0
+    endloop
+  endfacet
+  facet normal 0.803694 -0.595043 0
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 16.5 -11.1182 10
+      vertex 16.5462 -11.0558 0
+    endloop
+  endfacet
+  facet normal 0.802984 -0.596001 1.85239e-06
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 16.4928 -11.1279 10.147
+      vertex 16.5 -11.1182 10
+    endloop
+  endfacet
+  facet normal 0.803945 -0.594704 -1.05277e-06
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 16.4712 -11.1571 10.2926
+      vertex 16.4928 -11.1279 10.147
+    endloop
+  endfacet
+  facet normal 0.802795 -0.596255 3.84351e-06
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 16.4354 -11.2053 10.4354
+      vertex 16.4712 -11.1571 10.2926
+    endloop
+  endfacet
+  facet normal 0.803303 -0.595571 6.45224e-07
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 16.3858 -11.2722 10.574
+      vertex 16.4354 -11.2053 10.4354
+    endloop
+  endfacet
+  facet normal 0.803173 -0.595747 1.83468e-06
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 16.3229 -11.357 10.7071
+      vertex 16.3858 -11.2722 10.574
+    endloop
+  endfacet
+  facet normal 0.803292 -0.595585 3.02571e-07
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 16.2472 -11.4591 10.8334
+      vertex 16.3229 -11.357 10.7071
+    endloop
+  endfacet
+  facet normal 0.803089 -0.595859 3.78438e-06
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 16.1595 -11.5773 10.9516
+      vertex 16.2472 -11.4591 10.8334
+    endloop
+  endfacet
+  facet normal 0.803385 -0.59546 -2.79081e-06
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 16.0607 -11.7106 11.0607
+      vertex 16.1595 -11.5773 10.9516
+    endloop
+  endfacet
+  facet normal 0.803008 -0.595969 7.76372e-06
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 15.9516 -11.8576 11.1595
+      vertex 16.0607 -11.7106 11.0607
+    endloop
+  endfacet
+  facet normal 0.80343 -0.595399 -6.73991e-06
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 15.8334 -12.0171 11.2472
+      vertex 15.9516 -11.8576 11.1595
+    endloop
+  endfacet
+  facet normal 0.803049 -0.595913 8.98268e-06
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 15.7071 -12.1873 11.3229
+      vertex 15.8334 -12.0171 11.2472
+    endloop
+  endfacet
+  facet normal 0.803106 -0.595836 6.21314e-06
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 15.574 -12.3667 11.3858
+      vertex 15.7071 -12.1873 11.3229
+    endloop
+  endfacet
+  facet normal 0.803237 -0.595659 -1.17971e-06
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 15.4354 -12.5536 11.4354
+      vertex 15.574 -12.3667 11.3858
+    endloop
+  endfacet
+  facet normal 0.803221 -0.595682 0
+    outer loop
+      vertex 15.3829 -12.6244 11.4486
+      vertex 16.5462 -11.0558 60
+      vertex 15.3829 -12.6244 60
+    endloop
+  endfacet
+  facet normal 0.803255 -0.595635 -2.35531e-06
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 15.3829 -12.6244 11.4486
+      vertex 15.4354 -12.5536 11.4354
+    endloop
+  endfacet
+  facet normal 0.803033 -0.595935 -8.62218e-06
+    outer loop
+      vertex 16.4928 -11.1279 9.85297
+      vertex 16.5462 -11.0558 0
+      vertex 16.5 -11.1182 10
+    endloop
+  endfacet
+  facet normal 0.803935 -0.594717 5.17615e-06
+    outer loop
+      vertex 16.4712 -11.1571 9.70736
+      vertex 16.5462 -11.0558 0
+      vertex 16.4928 -11.1279 9.85297
+    endloop
+  endfacet
+  facet normal 0.802817 -0.596226 -1.92066e-05
+    outer loop
+      vertex 16.4354 -11.2053 9.56457
+      vertex 16.5462 -11.0558 0
+      vertex 16.4712 -11.1571 9.70736
+    endloop
+  endfacet
+  facet normal 0.803305 -0.595568 -3.25899e-06
+    outer loop
+      vertex 16.3858 -11.2722 9.42597
+      vertex 16.5462 -11.0558 0
+      vertex 16.4354 -11.2053 9.56457
+    endloop
+  endfacet
+  facet normal 0.803178 -0.595739 -9.34967e-06
+    outer loop
+      vertex 16.3229 -11.357 9.2929
+      vertex 16.5462 -11.0558 0
+      vertex 16.3858 -11.2722 9.42597
+    endloop
+  endfacet
+  facet normal 0.803293 -0.595584 -1.55476e-06
+    outer loop
+      vertex 16.2472 -11.4591 9.16664
+      vertex 16.5462 -11.0558 0
+      vertex 16.3229 -11.357 9.2929
+    endloop
+  endfacet
+  facet normal 0.803097 -0.595848 -1.96021e-05
+    outer loop
+      vertex 16.1595 -11.5773 9.04841
+      vertex 16.5462 -11.0558 0
+      vertex 16.2472 -11.4591 9.16664
+    endloop
+  endfacet
+  facet normal 0.803381 -0.595466 1.45724e-05
+    outer loop
+      vertex 16.0607 -11.7106 8.93934
+      vertex 16.5462 -11.0558 0
+      vertex 16.1595 -11.5773 9.04841
+    endloop
+  endfacet
+  facet normal 0.803018 -0.595954 -4.08726e-05
+    outer loop
+      vertex 15.9516 -11.8576 8.84048
+      vertex 16.5462 -11.0558 0
+      vertex 16.0607 -11.7106 8.93934
+    endloop
+  endfacet
+  facet normal 0.803423 -0.595409 3.57871e-05
+    outer loop
+      vertex 15.8334 -12.0171 8.7528
+      vertex 16.5462 -11.0558 0
+      vertex 15.9516 -11.8576 8.84048
+    endloop
+  endfacet
+  facet normal 0.803057 -0.595902 -4.81224e-05
+    outer loop
+      vertex 15.7071 -12.1873 8.67712
+      vertex 16.5462 -11.0558 0
+      vertex 15.8334 -12.0171 8.7528
+    endloop
+  endfacet
+  facet normal 0.803111 -0.59583 -3.36017e-05
+    outer loop
+      vertex 15.574 -12.3667 8.61418
+      vertex 16.5462 -11.0558 0
+      vertex 15.7071 -12.1873 8.67712
+    endloop
+  endfacet
+  facet normal 0.803237 -0.59566 6.44508e-06
+    outer loop
+      vertex 15.4354 -12.5536 8.56459
+      vertex 16.5462 -11.0558 0
+      vertex 15.574 -12.3667 8.61418
+    endloop
+  endfacet
+  facet normal 0.803254 -0.595636 1.30094e-05
+    outer loop
+      vertex 15.3829 -12.6244 8.55143
+      vertex 16.5462 -11.0558 0
+      vertex 15.4354 -12.5536 8.56459
+    endloop
+  endfacet
+  facet normal 0.803221 -0.595682 0
+    outer loop
+      vertex 16.5462 -11.0558 0
+      vertex 15.3829 -12.6244 8.55143
+      vertex 15.3829 -12.6244 0
+    endloop
+  endfacet
+  facet normal 0.85772 -0.514117 0
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 17.5502 -9.38079 0
+      vertex 17.5502 -9.38079 60
+    endloop
+  endfacet
+  facet normal 0.85772 -0.514117 0
+    outer loop
+      vertex 17.5502 -9.38079 0
+      vertex 16.5462 -11.0558 60
+      vertex 16.5462 -11.0558 0
+    endloop
+  endfacet
+  facet normal -0.146756 -0.989173 0
+    outer loop
+      vertex -3.8823 -19.5176 0
+      vertex -1.95054 -19.8042 60
+      vertex -3.8823 -19.5176 60
+    endloop
+  endfacet
+  facet normal -0.146756 -0.989173 -0
+    outer loop
+      vertex -1.95054 -19.8042 60
+      vertex -3.8823 -19.5176 0
+      vertex -1.95054 -19.8042 0
+    endloop
+  endfacet
+  facet normal -0.85772 -0.514117 0
+    outer loop
+      vertex -16.5462 -11.0558 0
+      vertex -17.5502 -9.38079 60
+      vertex -17.5502 -9.38079 0
+    endloop
+  endfacet
+  facet normal -0.85772 -0.514117 0
+    outer loop
+      vertex -17.5502 -9.38079 60
+      vertex -16.5462 -11.0558 0
+      vertex -16.5462 -11.0558 60
+    endloop
+  endfacet
+  facet normal 0.671563 0.740947 -0
+    outer loop
+      vertex 14.0714 14.0714 0
+      vertex 12.6244 15.3829 60
+      vertex 14.0714 14.0714 60
+    endloop
+  endfacet
+  facet normal 0.671563 0.740947 0
+    outer loop
+      vertex 12.6244 15.3829 60
+      vertex 14.0714 14.0714 0
+      vertex 12.6244 15.3829 0
+    endloop
+  endfacet
+  facet normal -0.336885 0.941546 0
+    outer loop
+      vertex -5.77666 19.0431 11.2225
+      vertex -7.6154 18.3852 60
+      vertex -5.77666 19.0431 60
+    endloop
+  endfacet
+  facet normal -0.336614 0.941643 1.14914e-05
+    outer loop
+      vertex -5.91849 18.9924 11.1595
+      vertex -7.6154 18.3852 60
+      vertex -5.77666 19.0431 11.2225
+    endloop
+  endfacet
+  facet normal -0.336974 0.941514 -2.58703e-06
+    outer loop
+      vertex -6.10066 18.9272 11.0607
+      vertex -7.6154 18.3852 60
+      vertex -5.91849 18.9924 11.1595
+    endloop
+  endfacet
+  facet normal -0.336985 0.94151 -2.97931e-06
+    outer loop
+      vertex -6.26578 18.8681 10.9516
+      vertex -7.6154 18.3852 60
+      vertex -6.10066 18.9272 11.0607
+    endloop
+  endfacet
+  facet normal -0.336866 0.941553 6.98296e-07
+    outer loop
+      vertex -6.41224 18.8157 10.8334
+      vertex -7.6154 18.3852 60
+      vertex -6.26578 18.8681 10.9516
+    endloop
+  endfacet
+  facet normal -0.336695 0.941614 5.42347e-06
+    outer loop
+      vertex -6.53865 18.7705 10.7071
+      vertex -7.6154 18.3852 60
+      vertex -6.41224 18.8157 10.8334
+    endloop
+  endfacet
+  facet normal -0.336794 0.941578 2.99467e-06
+    outer loop
+      vertex -6.64377 18.7329 10.574
+      vertex -7.6154 18.3852 60
+      vertex -6.53865 18.7705 10.7071
+    endloop
+  endfacet
+  facet normal -0.338468 0.940978 -3.41422e-05
+    outer loop
+      vertex -6.69019 18.7162 10.4963
+      vertex -7.6154 18.3852 60
+      vertex -6.64377 18.7329 10.574
+    endloop
+  endfacet
+  facet normal -0.336272 0.941765 1.21497e-05
+    outer loop
+      vertex -6.7266 18.7032 10.4354
+      vertex -7.6154 18.3852 60
+      vertex -6.69019 18.7162 10.4963
+    endloop
+  endfacet
+  facet normal -0.335275 0.94212 3.23151e-05
+    outer loop
+      vertex -6.75302 18.6938 10.3723
+      vertex -7.6154 18.3852 60
+      vertex -6.7266 18.7032 10.4354
+    endloop
+  endfacet
+  facet normal -0.338763 0.940872 -3.60588e-05
+    outer loop
+      vertex -6.78634 18.6818 10.2926
+      vertex -7.6154 18.3852 60
+      vertex -6.75302 18.6938 10.3723
+    endloop
+  endfacet
+  facet normal -0.336678 0.94162 3.17488e-06
+    outer loop
+      vertex -6.82242 18.6689 10.147
+      vertex -7.6154 18.3852 60
+      vertex -6.78634 18.6818 10.2926
+    endloop
+  endfacet
+  facet normal -0.336006 0.94186 1.52315e-05
+    outer loop
+      vertex -6.83448 18.6646 10
+      vertex -7.6154 18.3852 60
+      vertex -6.82242 18.6689 10.147
+    endloop
+  endfacet
+  facet normal -0.336885 0.941546 0
+    outer loop
+      vertex -7.6154 18.3852 0
+      vertex -5.77666 19.0431 8.77751
+      vertex -5.77666 19.0431 0
+    endloop
+  endfacet
+  facet normal -0.336633 0.941636 -5.94026e-05
+    outer loop
+      vertex -5.77666 19.0431 8.77751
+      vertex -7.6154 18.3852 0
+      vertex -5.91849 18.9924 8.84048
+    endloop
+  endfacet
+  facet normal -0.336968 0.941516 1.3188e-05
+    outer loop
+      vertex -5.91849 18.9924 8.84048
+      vertex -7.6154 18.3852 0
+      vertex -6.10066 18.9272 8.93934
+    endloop
+  endfacet
+  facet normal -0.336978 0.941513 1.49687e-05
+    outer loop
+      vertex -6.10066 18.9272 8.93934
+      vertex -7.6154 18.3852 0
+      vertex -6.26578 18.8681 9.04841
+    endloop
+  endfacet
+  facet normal -0.336868 0.941552 -3.45347e-06
+    outer loop
+      vertex -6.26578 18.8681 9.04841
+      vertex -7.6154 18.3852 0
+      vertex -6.41224 18.8157 9.16664
+    endloop
+  endfacet
+  facet normal -0.336714 0.941607 -2.63466e-05
+    outer loop
+      vertex -6.41224 18.8157 9.16664
+      vertex -7.6154 18.3852 0
+      vertex -6.53865 18.7705 9.2929
+    endloop
+  endfacet
+  facet normal -0.336806 0.941574 -1.4236e-05
+    outer loop
+      vertex -6.53865 18.7705 9.2929
+      vertex -7.6154 18.3852 0
+      vertex -6.64377 18.7329 9.42597
+    endloop
+  endfacet
+  facet normal -0.338285 0.941044 0.000157725
+    outer loop
+      vertex -6.64377 18.7329 9.42597
+      vertex -7.6154 18.3852 0
+      vertex -6.69019 18.7162 9.50365
+    endloop
+  endfacet
+  facet normal -0.336338 0.941741 -5.61218e-05
+    outer loop
+      vertex -6.69019 18.7162 9.50365
+      vertex -7.6154 18.3852 0
+      vertex -6.7266 18.7032 9.56457
+    endloop
+  endfacet
+  facet normal -0.33551 0.942037 -0.000142877
+    outer loop
+      vertex -6.7266 18.7032 9.56457
+      vertex -7.6154 18.3852 0
+      vertex -6.75302 18.6938 9.62773
+    endloop
+  endfacet
+  facet normal -0.338502 0.940966 0.000159477
+    outer loop
+      vertex -6.75302 18.6938 9.62773
+      vertex -7.6154 18.3852 0
+      vertex -6.78634 18.6818 9.70736
+    endloop
+  endfacet
+  facet normal -0.336871 0.941551 0
+    outer loop
+      vertex -6.83448 18.6646 10
+      vertex -7.6154 18.3852 0
+      vertex -7.6154 18.3852 60
+    endloop
+  endfacet
+  facet normal -0.336344 0.941739 -4.64352e-05
+    outer loop
+      vertex -6.82242 18.6689 9.85297
+      vertex -7.6154 18.3852 0
+      vertex -6.83448 18.6646 10
+    endloop
+  endfacet
+  facet normal -0.336713 0.941607 -1.29037e-05
+    outer loop
+      vertex -6.78634 18.6818 9.70736
+      vertex -7.6154 18.3852 0
+      vertex -6.82242 18.6689 9.85297
+    endloop
+  endfacet
+  facet normal -0.740947 -0.671563 0
+    outer loop
+      vertex -14.0714 -14.0714 0
+      vertex -15.3829 -12.6244 60
+      vertex -15.3829 -12.6244 0
+    endloop
+  endfacet
+  facet normal -0.740947 -0.671563 0
+    outer loop
+      vertex -15.3829 -12.6244 60
+      vertex -14.0714 -14.0714 0
+      vertex -14.0714 -14.0714 60
+    endloop
+  endfacet
+  facet normal -0.671563 0.740947 0
+    outer loop
+      vertex -12.6244 15.3829 0
+      vertex -14.0714 14.0714 60
+      vertex -12.6244 15.3829 60
+    endloop
+  endfacet
+  facet normal -0.671563 0.740947 0
+    outer loop
+      vertex -14.0714 14.0714 60
+      vertex -12.6244 15.3829 0
+      vertex -14.0714 14.0714 0
+    endloop
+  endfacet
+  facet normal -0.903983 0.427569 0
+    outer loop
+      vertex -18.3852 7.6154 0
+      vertex -17.5502 9.38079 60
+      vertex -17.5502 9.38079 0
+    endloop
+  endfacet
+  facet normal -0.903983 0.427569 0
+    outer loop
+      vertex -17.5502 9.38079 60
+      vertex -18.3852 7.6154 0
+      vertex -18.3852 7.6154 60
+    endloop
+  endfacet
+  facet normal -0.514117 -0.85772 0
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -9.38079 -17.5502 10.8868
+      vertex -9.38079 -17.5502 60
+    endloop
+  endfacet
+  facet normal -0.513674 -0.857985 2.05258e-05
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -9.42589 -17.5232 10.8334
+      vertex -9.38079 -17.5502 10.8868
+    endloop
+  endfacet
+  facet normal -0.515176 -0.857084 -4.7179e-05
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -9.45001 -17.5087 10.798
+      vertex -9.42589 -17.5232 10.8334
+    endloop
+  endfacet
+  facet normal -0.513681 -0.857981 1.9151e-05
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -9.51198 -17.4716 10.7071
+      vertex -9.45001 -17.5087 10.798
+    endloop
+  endfacet
+  facet normal -0.514292 -0.857615 -6.83453e-06
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -9.56384 -17.4405 10.6107
+      vertex -9.51198 -17.4716 10.7071
+    endloop
+  endfacet
+  facet normal -0.513143 -0.858303 4.03053e-05
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -9.58358 -17.4287 10.574
+      vertex -9.56384 -17.4405 10.6107
+    endloop
+  endfacet
+  facet normal -0.513992 -0.857795 5.95979e-06
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -9.63999 -17.3949 10.4354
+      vertex -9.58358 -17.4287 10.574
+    endloop
+  endfacet
+  facet normal -0.516835 -0.856085 -0.000104534
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -9.65108 -17.3882 10.3965
+      vertex -9.63999 -17.3949 10.4354
+    endloop
+  endfacet
+  facet normal -0.513298 -0.85821 3.17166e-05
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -9.68068 -17.3705 10.2926
+      vertex -9.65108 -17.3882 10.3965
+    endloop
+  endfacet
+  facet normal -0.515895 -0.856652 -6.59678e-05
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -9.6986 -17.3597 10.1864
+      vertex -9.68068 -17.3705 10.2926
+    endloop
+  endfacet
+  facet normal -0.507038 -0.861924 0.000261433
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -9.70525 -17.3558 10.147
+      vertex -9.6986 -17.3597 10.1864
+    endloop
+  endfacet
+  facet normal -0.514155 -0.857697 0
+    outer loop
+      vertex -11.0558 -16.5462 0
+      vertex -9.70525 -17.3558 10.147
+      vertex -11.0558 -16.5462 60
+    endloop
+  endfacet
+  facet normal -0.513908 -0.857845 -4.47135e-05
+    outer loop
+      vertex -9.70525 -17.3558 10.147
+      vertex -11.0558 -16.5462 0
+      vertex -9.71125 -17.3522 10.0397
+    endloop
+  endfacet
+  facet normal 0.885929 0.0474529 0.461387
+    outer loop
+      vertex -9.58358 -17.4287 9.42597
+      vertex -9.51198 -17.4716 9.2929
+      vertex -9.56384 -17.4405 9.38928
+    endloop
+  endfacet
+  facet normal -0.513753 -0.857938 -8.54298e-05
+    outer loop
+      vertex -11.0558 -16.5462 0
+      vertex -9.45001 -17.5087 9.20201
+      vertex -9.51198 -17.4716 9.2929
+    endloop
+  endfacet
+  facet normal -0.499842 -0.866113 -0.00259217
+    outer loop
+      vertex -9.71125 -17.3522 10.0397
+      vertex -11.0558 -16.5462 0
+      vertex -9.71347 -17.3508 10
+    endloop
+  endfacet
+  facet normal -0.519879 -0.85424 0.00105275
+    outer loop
+      vertex -11.0558 -16.5462 0
+      vertex -9.71125 -17.3522 9.96029
+      vertex -9.71347 -17.3508 10
+    endloop
+  endfacet
+  facet normal -0.514254 -0.857638 1.84087e-05
+    outer loop
+      vertex -11.0558 -16.5462 0
+      vertex -9.70525 -17.3558 9.85297
+      vertex -9.71125 -17.3522 9.96029
+    endloop
+  endfacet
+  facet normal -0.509609 -0.860406 -0.000845631
+    outer loop
+      vertex -11.0558 -16.5462 0
+      vertex -9.6986 -17.3597 9.81357
+      vertex -9.70525 -17.3558 9.85297
+    endloop
+  endfacet
+  facet normal -0.515252 -0.857039 0.000213826
+    outer loop
+      vertex -11.0558 -16.5462 0
+      vertex -9.68068 -17.3705 9.70736
+      vertex -9.6986 -17.3597 9.81357
+    endloop
+  endfacet
+  facet normal -0.513524 -0.858075 -0.00011899
+    outer loop
+      vertex -11.0558 -16.5462 0
+      vertex -9.65108 -17.3882 9.60347
+      vertex -9.68068 -17.3705 9.70736
+    endloop
+  endfacet
+  facet normal -0.516095 -0.856531 0.000392499
+    outer loop
+      vertex -11.0558 -16.5462 0
+      vertex -9.63999 -17.3949 9.56457
+      vertex -9.65108 -17.3882 9.60347
+    endloop
+  endfacet
+  facet normal -0.514025 -0.857775 -2.42363e-05
+    outer loop
+      vertex -11.0558 -16.5462 0
+      vertex -9.58358 -17.4287 9.42597
+      vertex -9.63999 -17.3949 9.56457
+    endloop
+  endfacet
+  facet normal -0.514006 -0.857787 -2.83319e-05
+    outer loop
+      vertex -11.0558 -16.5462 0
+      vertex -9.51198 -17.4716 9.2929
+      vertex -9.58358 -17.4287 9.42597
+    endloop
+  endfacet
+  facet normal -0.515 -0.85719 0.000210508
+    outer loop
+      vertex -9.45001 -17.5087 9.20201
+      vertex -11.0558 -16.5462 0
+      vertex -9.42589 -17.5232 9.16664
+    endloop
+  endfacet
+  facet normal -0.513739 -0.857947 -9.44963e-05
+    outer loop
+      vertex -11.0558 -16.5462 0
+      vertex -9.38079 -17.5502 9.11319
+      vertex -9.42589 -17.5232 9.16664
+    endloop
+  endfacet
+  facet normal -0.514117 -0.85772 -0
+    outer loop
+      vertex -9.38079 -17.5502 9.11319
+      vertex -11.0558 -16.5462 0
+      vertex -9.38079 -17.5502 0
+    endloop
+  endfacet
+  facet normal 0.0490555 0.998796 -0
+    outer loop
+      vertex 1.95054 19.8042 0
+      vertex 0 19.9 60
+      vertex 1.95054 19.8042 60
+    endloop
+  endfacet
+  facet normal 0.0490555 0.998796 0
+    outer loop
+      vertex 0 19.9 60
+      vertex 1.95054 19.8042 0
+      vertex 0 19.9 0
+    endloop
+  endfacet
+  facet normal -0.803221 -0.595682 0
+    outer loop
+      vertex -15.3829 -12.6244 0
+      vertex -16.5462 -11.0558 60
+      vertex -16.5462 -11.0558 0
+    endloop
+  endfacet
+  facet normal -0.803221 -0.595682 0
+    outer loop
+      vertex -16.5462 -11.0558 60
+      vertex -15.3829 -12.6244 0
+      vertex -15.3829 -12.6244 60
+    endloop
+  endfacet
+  facet normal -0.989173 -0.146756 0
+    outer loop
+      vertex -19.5176 -3.8823 0
+      vertex -19.8042 -1.95054 60
+      vertex -19.8042 -1.95054 0
+    endloop
+  endfacet
+  facet normal -0.989173 -0.146756 0
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -19.5176 -3.8823 0
+      vertex -19.5176 -3.8823 60
+    endloop
+  endfacet
+  facet normal -0.903983 -0.427569 0
+    outer loop
+      vertex -17.5502 -9.38079 0
+      vertex -18.3852 -7.6154 60
+      vertex -18.3852 -7.6154 0
+    endloop
+  endfacet
+  facet normal -0.903983 -0.427569 0
+    outer loop
+      vertex -18.3852 -7.6154 60
+      vertex -17.5502 -9.38079 0
+      vertex -17.5502 -9.38079 60
+    endloop
+  endfacet
+  facet normal 0.595682 -0.803221 0
+    outer loop
+      vertex 11.0558 -16.5462 0
+      vertex 12.6244 -15.3829 60
+      vertex 11.0558 -16.5462 60
+    endloop
+  endfacet
+  facet normal 0.595682 -0.803221 0
+    outer loop
+      vertex 12.6244 -15.3829 60
+      vertex 11.0558 -16.5462 0
+      vertex 12.6244 -15.3829 0
+    endloop
+  endfacet
+  facet normal -0.242974 -0.970033 0
+    outer loop
+      vertex -5.77666 -19.0431 10.7005
+      vertex -3.8823 -19.5176 60
+      vertex -5.77666 -19.0431 60
+    endloop
+  endfacet
+  facet normal -0.243094 -0.970003 4.88986e-06
+    outer loop
+      vertex -5.66733 -19.0705 10.574
+      vertex -3.8823 -19.5176 60
+      vertex -5.77666 -19.0431 10.7005
+    endloop
+  endfacet
+  facet normal -0.243747 -0.969839 2.99633e-05
+    outer loop
+      vertex -5.61641 -19.0833 10.4961
+      vertex -3.8823 -19.5176 60
+      vertex -5.66733 -19.0705 10.574
+    endloop
+  endfacet
+  facet normal -0.24201 -0.970274 -3.46865e-05
+    outer loop
+      vertex -5.57671 -19.0932 10.4354
+      vertex -3.8823 -19.5176 60
+      vertex -5.61641 -19.0833 10.4961
+    endloop
+  endfacet
+  facet normal -0.242418 -0.970172 -1.98787e-05
+    outer loop
+      vertex -5.54789 -19.1004 10.3724
+      vertex -3.8823 -19.5176 60
+      vertex -5.57671 -19.0932 10.4354
+    endloop
+  endfacet
+  facet normal -0.244078 -0.969756 3.93322e-05
+    outer loop
+      vertex -5.51135 -19.1096 10.2926
+      vertex -3.8823 -19.5176 60
+      vertex -5.54789 -19.1004 10.3724
+    endloop
+  endfacet
+  facet normal -0.243251 -0.969963 1.05128e-05
+    outer loop
+      vertex -5.47188 -19.1195 10.147
+      vertex -3.8823 -19.5176 60
+      vertex -5.51135 -19.1096 10.2926
+    endloop
+  endfacet
+  facet normal -0.248483 -0.968636 -0.000923454
+    outer loop
+      vertex -3.8823 -19.5176 0
+      vertex -5.47188 -19.1195 10.147
+      vertex -5.46456 -19.1213 10.0654
+    endloop
+  endfacet
+  facet normal -0.236784 -0.971562 0.00103094
+    outer loop
+      vertex -3.8823 -19.5176 0
+      vertex -5.46456 -19.1213 10.0654
+      vertex -5.45869 -19.1228 10
+    endloop
+  endfacet
+  facet normal -0.985783 -0.144832 0.0851835
+    outer loop
+      vertex -5.47188 -19.1195 9.85297
+      vertex -5.45869 -19.1228 10
+      vertex -5.46456 -19.1213 9.93462
+    endloop
+  endfacet
+  facet normal -0.242974 -0.970033 0
+    outer loop
+      vertex -3.8823 -19.5176 0
+      vertex -5.77666 -19.0431 9.29947
+      vertex -5.77666 -19.0431 0
+    endloop
+  endfacet
+  facet normal -0.243075 -0.970007 -2.1911e-05
+    outer loop
+      vertex -5.77666 -19.0431 9.29947
+      vertex -3.8823 -19.5176 0
+      vertex -5.66733 -19.0705 9.42597
+    endloop
+  endfacet
+  facet normal -0.243605 -0.969874 -0.000128561
+    outer loop
+      vertex -5.66733 -19.0705 9.42597
+      vertex -3.8823 -19.5176 0
+      vertex -5.61641 -19.0833 9.50386
+    endloop
+  endfacet
+  facet normal -0.242175 -0.970233 0.00014882
+    outer loop
+      vertex -5.61641 -19.0833 9.50386
+      vertex -3.8823 -19.5176 0
+      vertex -5.57671 -19.0932 9.56457
+    endloop
+  endfacet
+  facet normal -0.242541 -0.970141 7.98106e-05
+    outer loop
+      vertex -5.57671 -19.0932 9.56457
+      vertex -3.8823 -19.5176 0
+      vertex -5.54789 -19.1004 9.62755
+    endloop
+  endfacet
+  facet normal -0.243834 -0.969817 -0.000157941
+    outer loop
+      vertex -5.54789 -19.1004 9.62755
+      vertex -3.8823 -19.5176 0
+      vertex -5.51135 -19.1096 9.70736
+    endloop
+  endfacet
+  facet normal -0.243158 -0.969987 -3.72684e-05
+    outer loop
+      vertex -5.51135 -19.1096 9.70736
+      vertex -3.8823 -19.5176 0
+      vertex -5.47188 -19.1195 9.85297
+    endloop
+  endfacet
+  facet normal -0.242941 -0.970041 0
+    outer loop
+      vertex -5.47188 -19.1195 10.147
+      vertex -3.8823 -19.5176 0
+      vertex -3.8823 -19.5176 60
+    endloop
+  endfacet
+  facet normal -0.242858 -0.970062 1.42038e-05
+    outer loop
+      vertex -5.47188 -19.1195 9.85297
+      vertex -3.8823 -19.5176 0
+      vertex -5.45869 -19.1228 10
+    endloop
+  endfacet
+  facet normal 0.740947 0.671563 0
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 14.0714 14.0714 0
+      vertex 14.0714 14.0714 60
+    endloop
+  endfacet
+  facet normal 0.740947 0.671563 0
+    outer loop
+      vertex 14.0714 14.0714 0
+      vertex 15.3829 12.6244 60
+      vertex 15.3829 12.6244 0
+    endloop
+  endfacet
+  facet normal -0.671563 -0.740947 0
+    outer loop
+      vertex -14.0714 -14.0714 0
+      vertex -12.6244 -15.3829 60
+      vertex -14.0714 -14.0714 60
+    endloop
+  endfacet
+  facet normal -0.671563 -0.740947 -0
+    outer loop
+      vertex -12.6244 -15.3829 60
+      vertex -14.0714 -14.0714 0
+      vertex -12.6244 -15.3829 0
+    endloop
+  endfacet
+  facet normal -0.803221 0.595682 0
+    outer loop
+      vertex -16.5462 11.0558 0
+      vertex -15.3829 12.6244 60
+      vertex -15.3829 12.6244 0
+    endloop
+  endfacet
+  facet normal -0.803221 0.595682 0
+    outer loop
+      vertex -15.3829 12.6244 60
+      vertex -16.5462 11.0558 0
+      vertex -16.5462 11.0558 60
+    endloop
+  endfacet
+  facet normal -0.85772 0.514117 0
+    outer loop
+      vertex -17.5502 9.38079 0
+      vertex -16.5462 11.0558 60
+      vertex -16.5462 11.0558 0
+    endloop
+  endfacet
+  facet normal -0.85772 0.514117 0
+    outer loop
+      vertex -16.5462 11.0558 60
+      vertex -17.5502 9.38079 0
+      vertex -17.5502 9.38079 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.9 0 60
+      vertex 25 0 60
+      vertex 24.8796 -2.45043 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.8042 -1.95054 60
+      vertex 24.8796 -2.45043 60
+      vertex 24.5196 -4.87726 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25 0 60
+      vertex 19.9 0 60
+      vertex 24.8796 2.45043 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.5176 -3.8823 60
+      vertex 24.5196 -4.87726 60
+      vertex 23.9235 -7.25712 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.8042 1.95054 60
+      vertex 24.8796 2.45043 60
+      vertex 19.9 0 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.0431 -5.77666 60
+      vertex 23.9235 -7.25712 60
+      vertex 23.097 -9.56709 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 24.8796 2.45043 60
+      vertex 19.8042 1.95054 60
+      vertex 24.5196 4.87726 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.3852 -7.6154 60
+      vertex 23.097 -9.56709 60
+      vertex 22.048 -11.7849 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.5176 3.8823 60
+      vertex 24.5196 4.87726 60
+      vertex 19.8042 1.95054 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.5502 -9.38079 60
+      vertex 22.048 -11.7849 60
+      vertex 20.7867 -13.8893 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 24.5196 4.87726 60
+      vertex 19.5176 3.8823 60
+      vertex 23.9235 7.25712 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.0431 5.77666 60
+      vertex 23.9235 7.25712 60
+      vertex 19.5176 3.8823 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.8796 -2.45043 60
+      vertex 19.8042 -1.95054 60
+      vertex 19.9 0 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 24.5196 -4.87726 60
+      vertex 19.5176 -3.8823 60
+      vertex 19.8042 -1.95054 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5462 -11.0558 60
+      vertex 20.7867 -13.8893 60
+      vertex 19.3253 -15.8598 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.9235 -7.25712 60
+      vertex 19.0431 -5.77666 60
+      vertex 19.5176 -3.8823 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.097 -9.56709 60
+      vertex 18.3852 -7.6154 60
+      vertex 19.0431 -5.77666 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.3829 -12.6244 60
+      vertex 19.3253 -15.8598 60
+      vertex 17.6777 -17.6777 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.048 -11.7849 60
+      vertex 17.5502 -9.38079 60
+      vertex 18.3852 -7.6154 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.7867 -13.8893 60
+      vertex 16.5462 -11.0558 60
+      vertex 17.5502 -9.38079 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.0714 -14.0714 60
+      vertex 17.6777 -17.6777 60
+      vertex 15.8598 -19.3253 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3253 -15.8598 60
+      vertex 15.3829 -12.6244 60
+      vertex 16.5462 -11.0558 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.6777 -17.6777 60
+      vertex 14.0714 -14.0714 60
+      vertex 15.3829 -12.6244 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6244 -15.3829 60
+      vertex 15.8598 -19.3253 60
+      vertex 13.8893 -20.7867 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8598 -19.3253 60
+      vertex 12.6244 -15.3829 60
+      vertex 14.0714 -14.0714 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.0558 -16.5462 60
+      vertex 13.8893 -20.7867 60
+      vertex 11.7849 -22.048 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8893 -20.7867 60
+      vertex 11.0558 -16.5462 60
+      vertex 12.6244 -15.3829 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.38079 -17.5502 60
+      vertex 11.7849 -22.048 60
+      vertex 9.56709 -23.097 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.7849 -22.048 60
+      vertex 9.38079 -17.5502 60
+      vertex 11.0558 -16.5462 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.56709 -23.097 60
+      vertex 7.6154 -18.3852 60
+      vertex 9.38079 -17.5502 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.25712 -23.9235 60
+      vertex 7.6154 -18.3852 60
+      vertex 9.56709 -23.097 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.25712 -23.9235 60
+      vertex 5.77666 -19.0431 60
+      vertex 7.6154 -18.3852 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.87726 -24.5196 60
+      vertex 5.77666 -19.0431 60
+      vertex 7.25712 -23.9235 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.87726 -24.5196 60
+      vertex 3.8823 -19.5176 60
+      vertex 5.77666 -19.0431 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.45043 -24.8796 60
+      vertex 3.8823 -19.5176 60
+      vertex 4.87726 -24.5196 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.45043 -24.8796 60
+      vertex 1.95054 -19.8042 60
+      vertex 3.8823 -19.5176 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -25 60
+      vertex 1.95054 -19.8042 60
+      vertex 2.45043 -24.8796 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -25 60
+      vertex 0 -19.9 60
+      vertex 1.95054 -19.8042 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -25 60
+      vertex -1.95054 -19.8042 60
+      vertex 0 -19.9 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.45043 -24.8796 60
+      vertex -1.95054 -19.8042 60
+      vertex 0 -25 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.45043 -24.8796 60
+      vertex -3.8823 -19.5176 60
+      vertex -1.95054 -19.8042 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.87726 -24.5196 60
+      vertex -3.8823 -19.5176 60
+      vertex -2.45043 -24.8796 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.87726 -24.5196 60
+      vertex -5.77666 -19.0431 60
+      vertex -3.8823 -19.5176 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.25712 -23.9235 60
+      vertex -5.77666 -19.0431 60
+      vertex -4.87726 -24.5196 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.25712 -23.9235 60
+      vertex -7.6154 -18.3852 60
+      vertex -5.77666 -19.0431 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.56709 -23.097 60
+      vertex -7.6154 -18.3852 60
+      vertex -7.25712 -23.9235 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -7.6154 -18.3852 60
+      vertex -9.56709 -23.097 60
+      vertex -9.38079 -17.5502 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7849 -22.048 60
+      vertex -9.38079 -17.5502 60
+      vertex -9.56709 -23.097 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.38079 -17.5502 60
+      vertex -11.7849 -22.048 60
+      vertex -11.0558 -16.5462 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8893 -20.7867 60
+      vertex -11.0558 -16.5462 60
+      vertex -11.7849 -22.048 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -11.0558 -16.5462 60
+      vertex -13.8893 -20.7867 60
+      vertex -12.6244 -15.3829 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8598 -19.3253 60
+      vertex -12.6244 -15.3829 60
+      vertex -13.8893 -20.7867 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.6244 -15.3829 60
+      vertex -15.8598 -19.3253 60
+      vertex -14.0714 -14.0714 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6777 -17.6777 60
+      vertex -14.0714 -14.0714 60
+      vertex -15.8598 -19.3253 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.0714 -14.0714 60
+      vertex -17.6777 -17.6777 60
+      vertex -15.3829 -12.6244 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3253 -15.8598 60
+      vertex -15.3829 -12.6244 60
+      vertex -17.6777 -17.6777 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.3829 -12.6244 60
+      vertex -19.3253 -15.8598 60
+      vertex -16.5462 -11.0558 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.7867 -13.8893 60
+      vertex -16.5462 -11.0558 60
+      vertex -19.3253 -15.8598 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.5462 -11.0558 60
+      vertex -20.7867 -13.8893 60
+      vertex -17.5502 -9.38079 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.048 -11.7849 60
+      vertex -17.5502 -9.38079 60
+      vertex -20.7867 -13.8893 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.5502 -9.38079 60
+      vertex -22.048 -11.7849 60
+      vertex -18.3852 -7.6154 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.097 -9.56709 60
+      vertex -18.3852 -7.6154 60
+      vertex -22.048 -11.7849 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.3852 -7.6154 60
+      vertex -23.097 -9.56709 60
+      vertex -19.0431 -5.77666 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.9235 -7.25712 60
+      vertex -19.0431 -5.77666 60
+      vertex -23.097 -9.56709 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 23.9235 7.25712 60
+      vertex 19.0431 5.77666 60
+      vertex 23.097 9.56709 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.3852 7.6154 60
+      vertex 23.097 9.56709 60
+      vertex 19.0431 5.77666 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 23.097 9.56709 60
+      vertex 18.3852 7.6154 60
+      vertex 22.048 11.7849 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.5502 9.38079 60
+      vertex 22.048 11.7849 60
+      vertex 18.3852 7.6154 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 22.048 11.7849 60
+      vertex 17.5502 9.38079 60
+      vertex 20.7867 13.8893 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5462 11.0558 60
+      vertex 20.7867 13.8893 60
+      vertex 17.5502 9.38079 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.7867 13.8893 60
+      vertex 16.5462 11.0558 60
+      vertex 19.3253 15.8598 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.3829 12.6244 60
+      vertex 19.3253 15.8598 60
+      vertex 16.5462 11.0558 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 19.3253 15.8598 60
+      vertex 15.3829 12.6244 60
+      vertex 17.6777 17.6777 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.0714 14.0714 60
+      vertex 17.6777 17.6777 60
+      vertex 15.3829 12.6244 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17.6777 17.6777 60
+      vertex 14.0714 14.0714 60
+      vertex 15.8598 19.3253 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6244 15.3829 60
+      vertex 15.8598 19.3253 60
+      vertex 14.0714 14.0714 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.8598 19.3253 60
+      vertex 12.6244 15.3829 60
+      vertex 13.8893 20.7867 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.0558 16.5462 60
+      vertex 13.8893 20.7867 60
+      vertex 12.6244 15.3829 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.8893 20.7867 60
+      vertex 11.0558 16.5462 60
+      vertex 11.7849 22.048 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.38079 17.5502 60
+      vertex 11.7849 22.048 60
+      vertex 11.0558 16.5462 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.7849 22.048 60
+      vertex 9.38079 17.5502 60
+      vertex 9.56709 23.097 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.6154 18.3852 60
+      vertex 9.56709 23.097 60
+      vertex 9.38079 17.5502 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.6154 18.3852 60
+      vertex 7.25712 23.9235 60
+      vertex 9.56709 23.097 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.77666 19.0431 60
+      vertex 7.25712 23.9235 60
+      vertex 7.6154 18.3852 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.77666 19.0431 60
+      vertex 4.87726 24.5196 60
+      vertex 7.25712 23.9235 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.8823 19.5176 60
+      vertex 4.87726 24.5196 60
+      vertex 5.77666 19.0431 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.8823 19.5176 60
+      vertex 2.45043 24.8796 60
+      vertex 4.87726 24.5196 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95054 19.8042 60
+      vertex 2.45043 24.8796 60
+      vertex 3.8823 19.5176 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 19.9 60
+      vertex 2.45043 24.8796 60
+      vertex 1.95054 19.8042 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 19.9 60
+      vertex 0 25 60
+      vertex 2.45043 24.8796 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex 0 25 60
+      vertex 0 19.9 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.95054 19.8042 60
+      vertex -2.45043 24.8796 60
+      vertex 0 25 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.8823 19.5176 60
+      vertex -2.45043 24.8796 60
+      vertex -1.95054 19.8042 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.8823 19.5176 60
+      vertex -4.87726 24.5196 60
+      vertex -2.45043 24.8796 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.77666 19.0431 60
+      vertex -4.87726 24.5196 60
+      vertex -3.8823 19.5176 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.77666 19.0431 60
+      vertex -7.25712 23.9235 60
+      vertex -4.87726 24.5196 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.6154 18.3852 60
+      vertex -7.25712 23.9235 60
+      vertex -5.77666 19.0431 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.56709 23.097 60
+      vertex -7.6154 18.3852 60
+      vertex -9.38079 17.5502 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.6154 18.3852 60
+      vertex -9.56709 23.097 60
+      vertex -7.25712 23.9235 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7849 22.048 60
+      vertex -9.38079 17.5502 60
+      vertex -11.0558 16.5462 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.38079 17.5502 60
+      vertex -11.7849 22.048 60
+      vertex -9.56709 23.097 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8893 20.7867 60
+      vertex -11.0558 16.5462 60
+      vertex -12.6244 15.3829 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.0558 16.5462 60
+      vertex -13.8893 20.7867 60
+      vertex -11.7849 22.048 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8598 19.3253 60
+      vertex -12.6244 15.3829 60
+      vertex -14.0714 14.0714 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.6777 17.6777 60
+      vertex -14.0714 14.0714 60
+      vertex -15.3829 12.6244 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.6244 15.3829 60
+      vertex -15.8598 19.3253 60
+      vertex -13.8893 20.7867 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3253 15.8598 60
+      vertex -15.3829 12.6244 60
+      vertex -16.5462 11.0558 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.7867 13.8893 60
+      vertex -16.5462 11.0558 60
+      vertex -17.5502 9.38079 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.0714 14.0714 60
+      vertex -17.6777 17.6777 60
+      vertex -15.8598 19.3253 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.048 11.7849 60
+      vertex -17.5502 9.38079 60
+      vertex -18.3852 7.6154 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.097 9.56709 60
+      vertex -18.3852 7.6154 60
+      vertex -19.0431 5.77666 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.3829 12.6244 60
+      vertex -19.3253 15.8598 60
+      vertex -17.6777 17.6777 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.9235 7.25712 60
+      vertex -19.0431 5.77666 60
+      vertex -19.5176 3.8823 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.5196 4.87726 60
+      vertex -19.5176 3.8823 60
+      vertex -19.8042 1.95054 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8796 2.45043 60
+      vertex -19.8042 1.95054 60
+      vertex -19.9 0 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.0431 -5.77666 60
+      vertex -23.9235 -7.25712 60
+      vertex -19.5176 -3.8823 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.5462 11.0558 60
+      vertex -20.7867 13.8893 60
+      vertex -19.3253 15.8598 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.5196 -4.87726 60
+      vertex -19.5176 -3.8823 60
+      vertex -23.9235 -7.25712 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.5502 9.38079 60
+      vertex -22.048 11.7849 60
+      vertex -20.7867 13.8893 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.5176 -3.8823 60
+      vertex -24.5196 -4.87726 60
+      vertex -19.8042 -1.95054 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.3852 7.6154 60
+      vertex -23.097 9.56709 60
+      vertex -22.048 11.7849 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8796 -2.45043 60
+      vertex -19.8042 -1.95054 60
+      vertex -24.5196 -4.87726 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.0431 5.77666 60
+      vertex -23.9235 7.25712 60
+      vertex -23.097 9.56709 60
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.8042 -1.95054 60
+      vertex -24.8796 -2.45043 60
+      vertex -19.9 0 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5176 3.8823 60
+      vertex -24.5196 4.87726 60
+      vertex -23.9235 7.25712 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25 0 60
+      vertex -19.9 0 60
+      vertex -24.8796 -2.45043 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.8042 1.95054 60
+      vertex -24.8796 2.45043 60
+      vertex -24.5196 4.87726 60
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.9 0 60
+      vertex -25 0 60
+      vertex -24.8796 2.45043 60
+    endloop
+  endfacet
+  facet normal -0.0490555 -0.998796 0
+    outer loop
+      vertex -1.95054 -19.8042 0
+      vertex 0 -19.9 60
+      vertex -1.95054 -19.8042 60
+    endloop
+  endfacet
+  facet normal -0.0490555 -0.998796 -0
+    outer loop
+      vertex 0 -19.9 60
+      vertex -1.95054 -19.8042 0
+      vertex 0 -19.9 0
+    endloop
+  endfacet
+  facet normal -0.998809 0.0488009 0
+    outer loop
+      vertex -19.8042 1.95054 0
+      vertex -19.8139 1.75201 8.5
+      vertex -19.8042 1.95054 8.50612
+    endloop
+  endfacet
+  facet normal -0.998798 0.0490256 5.26092e-06
+    outer loop
+      vertex -19.8042 1.95054 0
+      vertex -19.8254 1.51772 8.50722
+      vertex -19.8139 1.75201 8.5
+    endloop
+  endfacet
+  facet normal -0.998795 0.049071 7.57485e-06
+    outer loop
+      vertex -19.8042 1.95054 0
+      vertex -19.8368 1.28568 8.52882
+      vertex -19.8254 1.51772 8.50722
+    endloop
+  endfacet
+  facet normal -0.998796 0.0490555 6.36317e-06
+    outer loop
+      vertex -19.9 0 0
+      vertex -19.8368 1.28568 8.52882
+      vertex -19.8042 1.95054 0
+    endloop
+  endfacet
+  facet normal -0.998791 0.0491611 -9.59658e-06
+    outer loop
+      vertex -19.8368 1.28568 8.52882
+      vertex -19.9 0 0
+      vertex -19.848 1.05814 8.56459
+    endloop
+  endfacet
+  facet normal -0.998785 0.0492852 -2.4963e-05
+    outer loop
+      vertex -19.848 1.05814 8.56459
+      vertex -19.9 0 0
+      vertex -19.8589 0.837272 8.61418
+    endloop
+  endfacet
+  facet normal -0.998799 0.0489865 4.14035e-06
+    outer loop
+      vertex -19.8589 0.837272 8.61418
+      vertex -19.9 0 0
+      vertex -19.8693 0.625218 8.67712
+    endloop
+  endfacet
+  facet normal -0.998792 0.0491424 -7.12264e-06
+    outer loop
+      vertex -19.8693 0.625218 8.67712
+      vertex -19.9 0 0
+      vertex -19.8792 0.424017 8.7528
+    endloop
+  endfacet
+  facet normal -0.998807 0.0488414 7.49339e-06
+    outer loop
+      vertex -19.8792 0.424017 8.7528
+      vertex -19.9 0 0
+      vertex -19.8847 0.311534 8.80515
+    endloop
+  endfacet
+  facet normal -0.998815 0.0486769 1.33283e-05
+    outer loop
+      vertex -19.8847 0.311534 8.80515
+      vertex -19.9 0 0
+      vertex -19.8884 0.235603 8.84048
+    endloop
+  endfacet
+  facet normal -0.998778 0.0494156 -6.40619e-06
+    outer loop
+      vertex -19.8884 0.235603 8.84048
+      vertex -19.9 0 0
+      vertex -19.897 0.0617943 8.93934
+    endloop
+  endfacet
+  facet normal -0.998824 0.0484911 0
+    outer loop
+      vertex -19.897 0.0617943 8.93934
+      vertex -19.9 0 0
+      vertex -19.9 0 8.98212
+    endloop
+  endfacet
+  facet normal -0.998809 0.0488009 0
+    outer loop
+      vertex -19.8139 1.75201 11.5
+      vertex -19.8042 1.95054 60
+      vertex -19.8042 1.95054 11.4939
+    endloop
+  endfacet
+  facet normal -0.998798 0.0490255 -9.21469e-07
+    outer loop
+      vertex -19.8254 1.51772 11.4928
+      vertex -19.8042 1.95054 60
+      vertex -19.8139 1.75201 11.5
+    endloop
+  endfacet
+  facet normal -0.998795 0.0490703 -7.23411e-07
+    outer loop
+      vertex -19.9 0 60
+      vertex -19.8254 1.51772 11.4928
+      vertex -19.8368 1.28568 11.4712
+    endloop
+  endfacet
+  facet normal -0.998791 0.0491623 1.71938e-06
+    outer loop
+      vertex -19.9 0 60
+      vertex -19.8368 1.28568 11.4712
+      vertex -19.848 1.05814 11.4354
+    endloop
+  endfacet
+  facet normal -0.998785 0.0492897 4.50242e-06
+    outer loop
+      vertex -19.9 0 60
+      vertex -19.848 1.05814 11.4354
+      vertex -19.8589 0.837272 11.3858
+    endloop
+  endfacet
+  facet normal -0.998799 0.0489855 -7.50977e-07
+    outer loop
+      vertex -19.9 0 60
+      vertex -19.8589 0.837272 11.3858
+      vertex -19.8693 0.625218 11.3229
+    endloop
+  endfacet
+  facet normal -0.998792 0.0491446 1.29781e-06
+    outer loop
+      vertex -19.9 0 60
+      vertex -19.8693 0.625218 11.3229
+      vertex -19.8792 0.424017 11.2472
+    endloop
+  endfacet
+  facet normal -0.998807 0.0488386 -1.37011e-06
+    outer loop
+      vertex -19.9 0 60
+      vertex -19.8792 0.424017 11.2472
+      vertex -19.8847 0.311534 11.1949
+    endloop
+  endfacet
+  facet normal -0.998815 0.0486718 -2.43694e-06
+    outer loop
+      vertex -19.9 0 60
+      vertex -19.8847 0.311534 11.1949
+      vertex -19.8884 0.235603 11.1595
+    endloop
+  endfacet
+  facet normal -0.998778 0.0494186 1.17392e-06
+    outer loop
+      vertex -19.9 0 60
+      vertex -19.8884 0.235603 11.1595
+      vertex -19.897 0.0617943 11.0607
+    endloop
+  endfacet
+  facet normal -0.998824 0.0484911 0
+    outer loop
+      vertex -19.9 0 60
+      vertex -19.897 0.0617943 11.0607
+      vertex -19.9 0 11.0179
+    endloop
+  endfacet
+  facet normal -0.998796 0.0490555 -1.18979e-06
+    outer loop
+      vertex -19.8254 1.51772 11.4928
+      vertex -19.9 0 60
+      vertex -19.8042 1.95054 60
+    endloop
+  endfacet
+  facet normal -0.336048 -0.941845 1.09111e-05
+    outer loop
+      vertex -5.77666 -19.0431 0
+      vertex -5.84811 -19.0175 9.22069
+      vertex -5.898 -18.9997 9.16664
+    endloop
+  endfacet
+  facet normal -0.336309 -0.941752 1.4615e-05
+    outer loop
+      vertex -5.77666 -19.0431 0
+      vertex -5.9552 -18.9792 9.11656
+      vertex -6.03305 -18.9514 9.04841
+    endloop
+  endfacet
+  facet normal -0.335559 -0.942019 0
+    outer loop
+      vertex -7.6154 -18.3852 0
+      vertex -7.59238 -18.3934 8.50722
+      vertex -7.6154 -18.3852 8.50649
+    endloop
+  endfacet
+  facet normal -0.337121 -0.941461 4.76643e-06
+    outer loop
+      vertex -7.6154 -18.3852 0
+      vertex -7.36813 -18.4737 8.52882
+      vertex -7.59238 -18.3934 8.50722
+    endloop
+  endfacet
+  facet normal -0.336885 -0.941546 -2.97534e-06
+    outer loop
+      vertex -5.77666 -19.0431 0
+      vertex -7.36813 -18.4737 8.52882
+      vertex -7.6154 -18.3852 0
+    endloop
+  endfacet
+  facet normal -0.336931 -0.941529 -1.27843e-05
+    outer loop
+      vertex -7.36813 -18.4737 8.52882
+      vertex -5.77666 -19.0431 0
+      vertex -7.14821 -18.5524 8.56459
+    endloop
+  endfacet
+  facet normal -0.336611 -0.941644 4.50181e-05
+    outer loop
+      vertex -7.14821 -18.5524 8.56459
+      vertex -5.77666 -19.0431 0
+      vertex -6.93476 -18.6287 8.61418
+    endloop
+  endfacet
+  facet normal -0.337169 -0.941444 -3.96411e-05
+    outer loop
+      vertex -6.93476 -18.6287 8.61418
+      vertex -5.77666 -19.0431 0
+      vertex -6.72982 -18.7021 8.67712
+    endloop
+  endfacet
+  facet normal -0.336578 -0.941656 3.36275e-05
+    outer loop
+      vertex -6.72982 -18.7021 8.67712
+      vertex -5.77666 -19.0431 0
+      vertex -6.53537 -18.7716 8.7528
+    endloop
+  endfacet
+  facet normal -0.337083 -0.941475 -1.57301e-05
+    outer loop
+      vertex -6.53537 -18.7716 8.7528
+      vertex -5.77666 -19.0431 0
+      vertex -6.35327 -18.8368 8.84048
+    endloop
+  endfacet
+  facet normal -0.336886 -0.941545 -1.25178e-06
+    outer loop
+      vertex -6.35327 -18.8368 8.84048
+      vertex -5.77666 -19.0431 0
+      vertex -6.1853 -18.8969 8.93934
+    endloop
+  endfacet
+  facet normal -0.337017 -0.941499 -7.99104e-06
+    outer loop
+      vertex -6.1853 -18.8969 8.93934
+      vertex -5.77666 -19.0431 0
+      vertex -6.03305 -18.9514 9.04841
+    endloop
+  endfacet
+  facet normal -0.337372 -0.941371 -8.85627e-06
+    outer loop
+      vertex -5.9552 -18.9792 9.11656
+      vertex -5.77666 -19.0431 0
+      vertex -5.898 -18.9997 9.16664
+    endloop
+  endfacet
+  facet normal -0.337497 -0.941326 -1.76021e-06
+    outer loop
+      vertex -5.84811 -19.0175 9.22069
+      vertex -5.77666 -19.0431 0
+      vertex -5.78145 -19.0414 9.2929
+    endloop
+  endfacet
+  facet normal -0.334466 -0.942408 0
+    outer loop
+      vertex -5.78145 -19.0414 9.2929
+      vertex -5.77666 -19.0431 0
+      vertex -5.77666 -19.0431 9.29947
+    endloop
+  endfacet
+  facet normal -0.336885 -0.941546 0
+    outer loop
+      vertex -7.6154 -18.3852 11.4935
+      vertex -5.77666 -19.0431 60
+      vertex -7.6154 -18.3852 60
+    endloop
+  endfacet
+  facet normal -0.33556 -0.942019 -5.66185e-05
+    outer loop
+      vertex -7.59238 -18.3934 11.4928
+      vertex -5.77666 -19.0431 60
+      vertex -7.6154 -18.3852 11.4935
+    endloop
+  endfacet
+  facet normal -0.33712 -0.941462 9.23536e-06
+    outer loop
+      vertex -7.36813 -18.4737 11.4712
+      vertex -5.77666 -19.0431 60
+      vertex -7.59238 -18.3934 11.4928
+    endloop
+  endfacet
+  facet normal -0.336933 -0.941529 2.3027e-06
+    outer loop
+      vertex -7.14821 -18.5524 11.4354
+      vertex -5.77666 -19.0431 60
+      vertex -7.36813 -18.4737 11.4712
+    endloop
+  endfacet
+  facet normal -0.336604 -0.941646 -8.18086e-06
+    outer loop
+      vertex -6.93476 -18.6287 11.3858
+      vertex -5.77666 -19.0431 60
+      vertex -7.14821 -18.5524 11.4354
+    endloop
+  endfacet
+  facet normal -0.337178 -0.941441 7.26111e-06
+    outer loop
+      vertex -6.72982 -18.7021 11.3229
+      vertex -5.77666 -19.0431 60
+      vertex -6.93476 -18.6287 11.3858
+    endloop
+  endfacet
+  facet normal -0.336569 -0.941659 -6.2034e-06
+    outer loop
+      vertex -6.53537 -18.7716 11.2472
+      vertex -5.77666 -19.0431 60
+      vertex -6.72982 -18.7021 11.3229
+    endloop
+  endfacet
+  facet normal -0.337088 -0.941473 2.92007e-06
+    outer loop
+      vertex -6.35327 -18.8368 11.1595
+      vertex -5.77666 -19.0431 60
+      vertex -6.53537 -18.7716 11.2472
+    endloop
+  endfacet
+  facet normal -0.336887 -0.941545 2.33656e-07
+    outer loop
+      vertex -6.1853 -18.8969 11.0607
+      vertex -5.77666 -19.0431 60
+      vertex -6.35327 -18.8368 11.1595
+    endloop
+  endfacet
+  facet normal -0.337021 -0.941497 1.49849e-06
+    outer loop
+      vertex -6.03305 -18.9514 10.9516
+      vertex -5.77666 -19.0431 60
+      vertex -6.1853 -18.8969 11.0607
+    endloop
+  endfacet
+  facet normal -0.3363 -0.941755 -2.75045e-06
+    outer loop
+      vertex -5.9552 -18.9792 10.8834
+      vertex -5.77666 -19.0431 60
+      vertex -6.03305 -18.9514 10.9516
+    endloop
+  endfacet
+  facet normal -0.337377 -0.941369 1.6667e-06
+    outer loop
+      vertex -5.898 -18.9997 10.8334
+      vertex -5.77666 -19.0431 60
+      vertex -5.9552 -18.9792 10.8834
+    endloop
+  endfacet
+  facet normal -0.336039 -0.941848 -2.05795e-06
+    outer loop
+      vertex -5.84811 -19.0175 10.7793
+      vertex -5.77666 -19.0431 60
+      vertex -5.898 -18.9997 10.8334
+    endloop
+  endfacet
+  facet normal -0.337499 -0.941326 3.31992e-07
+    outer loop
+      vertex -5.78145 -19.0414 10.7071
+      vertex -5.77666 -19.0431 60
+      vertex -5.84811 -19.0175 10.7793
+    endloop
+  endfacet
+  facet normal -0.334466 -0.942408 -0
+    outer loop
+      vertex -5.77666 -19.0431 60
+      vertex -5.78145 -19.0414 10.7071
+      vertex -5.77666 -19.0431 10.7005
+    endloop
+  endfacet
+  facet normal 0.740848 -0.671673 0
+    outer loop
+      vertex 15.2926 -12.724 8.52882
+      vertex 15.3829 -12.6244 0
+      vertex 15.3829 -12.6244 8.55143
+    endloop
+  endfacet
+  facet normal 0.741065 -0.671433 5.10155e-06
+    outer loop
+      vertex 15.147 -12.8847 8.50722
+      vertex 15.3829 -12.6244 0
+      vertex 15.2926 -12.724 8.52882
+    endloop
+  endfacet
+  facet normal 0.740973 -0.671535 -6.00607e-07
+    outer loop
+      vertex 15 -13.0469 8.5
+      vertex 15.3829 -12.6244 0
+      vertex 15.147 -12.8847 8.50722
+    endloop
+  endfacet
+  facet normal 0.740973 -0.671535 -6.03271e-07
+    outer loop
+      vertex 14.853 -13.2091 8.50722
+      vertex 15.3829 -12.6244 0
+      vertex 15 -13.0469 8.5
+    endloop
+  endfacet
+  facet normal 0.741064 -0.671434 -2.79369e-05
+    outer loop
+      vertex 14.0714 -14.0714 0
+      vertex 14.853 -13.2091 8.50722
+      vertex 14.7074 -13.3698 8.52882
+    endloop
+  endfacet
+  facet normal 0.740834 -0.671688 1.00049e-05
+    outer loop
+      vertex 14.0714 -14.0714 0
+      vertex 14.7074 -13.3698 8.52882
+      vertex 14.5646 -13.5273 8.56459
+    endloop
+  endfacet
+  facet normal 0.740904 -0.671611 1.09763e-06
+    outer loop
+      vertex 14.0714 -14.0714 0
+      vertex 14.5646 -13.5273 8.56459
+      vertex 14.426 -13.6802 8.61418
+    endloop
+  endfacet
+  facet normal 0.741055 -0.671444 -1.26492e-05
+    outer loop
+      vertex 14.0714 -14.0714 0
+      vertex 14.426 -13.6802 8.61418
+      vertex 14.2929 -13.8271 8.67712
+    endloop
+  endfacet
+  facet normal 0.74083 -0.671693 8.45137e-08
+    outer loop
+      vertex 14.0714 -14.0714 0
+      vertex 14.2929 -13.8271 8.67712
+      vertex 14.1666 -13.9664 8.7528
+    endloop
+  endfacet
+  facet normal 0.740833 -0.671689 0
+    outer loop
+      vertex 14.0714 -14.0714 0
+      vertex 14.1666 -13.9664 8.7528
+      vertex 14.0714 -14.0714 8.82341
+    endloop
+  endfacet
+  facet normal 0.740947 -0.671563 -4.13813e-06
+    outer loop
+      vertex 14.853 -13.2091 8.50722
+      vertex 14.0714 -14.0714 0
+      vertex 15.3829 -12.6244 0
+    endloop
+  endfacet
+  facet normal 0.740848 -0.671673 0
+    outer loop
+      vertex 15.3829 -12.6244 60
+      vertex 15.2926 -12.724 11.4712
+      vertex 15.3829 -12.6244 11.4486
+    endloop
+  endfacet
+  facet normal 0.741066 -0.671432 -8.97746e-07
+    outer loop
+      vertex 15.3829 -12.6244 60
+      vertex 15.147 -12.8847 11.4928
+      vertex 15.2926 -12.724 11.4712
+    endloop
+  endfacet
+  facet normal 0.740973 -0.671535 1.05453e-07
+    outer loop
+      vertex 15.3829 -12.6244 60
+      vertex 15 -13.0469 11.5
+      vertex 15.147 -12.8847 11.4928
+    endloop
+  endfacet
+  facet normal 0.740947 -0.671563 5.53761e-07
+    outer loop
+      vertex 14.0714 -14.0714 60
+      vertex 15 -13.0469 11.5
+      vertex 15.3829 -12.6244 60
+    endloop
+  endfacet
+  facet normal 0.740973 -0.671535 1.63927e-06
+    outer loop
+      vertex 15 -13.0469 11.5
+      vertex 14.0714 -14.0714 60
+      vertex 14.853 -13.2091 11.4928
+    endloop
+  endfacet
+  facet normal 0.741065 -0.671433 4.95452e-06
+    outer loop
+      vertex 14.853 -13.2091 11.4928
+      vertex 14.0714 -14.0714 60
+      vertex 14.7074 -13.3698 11.4712
+    endloop
+  endfacet
+  facet normal 0.740834 -0.671689 -1.78533e-06
+    outer loop
+      vertex 14.7074 -13.3698 11.4712
+      vertex 14.0714 -14.0714 60
+      vertex 14.5646 -13.5273 11.4354
+    endloop
+  endfacet
+  facet normal 0.740904 -0.671611 -1.96845e-07
+    outer loop
+      vertex 14.5646 -13.5273 11.4354
+      vertex 14.0714 -14.0714 60
+      vertex 14.426 -13.6802 11.3858
+    endloop
+  endfacet
+  facet normal 0.741057 -0.671442 2.27714e-06
+    outer loop
+      vertex 14.426 -13.6802 11.3858
+      vertex 14.0714 -14.0714 60
+      vertex 14.2929 -13.8271 11.3229
+    endloop
+  endfacet
+  facet normal 0.74083 -0.671693 -1.52541e-08
+    outer loop
+      vertex 14.2929 -13.8271 11.3229
+      vertex 14.0714 -14.0714 60
+      vertex 14.1666 -13.9664 11.2472
+    endloop
+  endfacet
+  facet normal 0.740833 -0.671689 0
+    outer loop
+      vertex 14.1666 -13.9664 11.2472
+      vertex 14.0714 -14.0714 60
+      vertex 14.0714 -14.0714 11.1766
+    endloop
+  endfacet
+  facet normal 0.671563 -0.740947 0
+    outer loop
+      vertex 12.6244 -15.3829 60
+      vertex 14.0714 -14.0714 11.1766
+      vertex 14.0714 -14.0714 60
+    endloop
+  endfacet
+  facet normal 0.672492 -0.740104 5.01708e-05
+    outer loop
+      vertex 12.6244 -15.3829 60
+      vertex 14.0484 -14.0923 11.1595
+      vertex 14.0714 -14.0714 11.1766
+    endloop
+  endfacet
+  facet normal 0.671259 -0.741223 -1.53498e-05
+    outer loop
+      vertex 12.6244 -15.3829 60
+      vertex 13.9393 -14.1911 11.0607
+      vertex 14.0484 -14.0923 11.1595
+    endloop
+  endfacet
+  facet normal 0.671771 -0.740759 9.7009e-06
+    outer loop
+      vertex 12.6244 -15.3829 60
+      vertex 13.8405 -14.2807 10.9516
+      vertex 13.9393 -14.1911 11.0607
+    endloop
+  endfacet
+  facet normal 0.671619 -0.740897 2.83506e-06
+    outer loop
+      vertex 12.6244 -15.3829 60
+      vertex 13.7528 -14.3602 10.8334
+      vertex 13.8405 -14.2807 10.9516
+    endloop
+  endfacet
+  facet normal 0.671504 -0.741001 -1.94625e-06
+    outer loop
+      vertex 12.6244 -15.3829 60
+      vertex 13.6771 -14.4288 10.7071
+      vertex 13.7528 -14.3602 10.8334
+    endloop
+  endfacet
+  facet normal 0.671502 -0.741003 -2.05565e-06
+    outer loop
+      vertex 12.6244 -15.3829 60
+      vertex 13.6142 -14.4858 10.574
+      vertex 13.6771 -14.4288 10.7071
+    endloop
+  endfacet
+  facet normal 0.67191 -0.740633 1.28288e-05
+    outer loop
+      vertex 12.6244 -15.3829 60
+      vertex 13.5646 -14.5308 10.4354
+      vertex 13.6142 -14.4858 10.574
+    endloop
+  endfacet
+  facet normal 0.671058 -0.741405 -1.65864e-05
+    outer loop
+      vertex 12.6244 -15.3829 60
+      vertex 13.5288 -14.5632 10.2926
+      vertex 13.5646 -14.5308 10.4354
+    endloop
+  endfacet
+  facet normal 0.671943 -0.740603 1.27309e-05
+    outer loop
+      vertex 12.6244 -15.3829 60
+      vertex 13.5072 -14.5828 10.147
+      vertex 13.5288 -14.5632 10.2926
+    endloop
+  endfacet
+  facet normal 0.671548 -0.740961 0
+    outer loop
+      vertex 12.6244 -15.3829 0
+      vertex 13.5072 -14.5828 10.147
+      vertex 12.6244 -15.3829 60
+    endloop
+  endfacet
+  facet normal 0.673399 -0.73928 -0.000293557
+    outer loop
+      vertex 13.5072 -14.5828 10.147
+      vertex 12.6244 -15.3829 0
+      vertex 13.5 -14.5893 10
+    endloop
+  endfacet
+  facet normal 0.671038 -0.741423 8.31767e-05
+    outer loop
+      vertex 12.6244 -15.3829 0
+      vertex 13.5072 -14.5828 9.85297
+      vertex 13.5 -14.5893 10
+    endloop
+  endfacet
+  facet normal 0.671824 -0.740711 -4.49588e-05
+    outer loop
+      vertex 12.6244 -15.3829 0
+      vertex 13.5288 -14.5632 9.70736
+      vertex 13.5072 -14.5828 9.85297
+    endloop
+  endfacet
+  facet normal 0.671167 -0.741306 6.6407e-05
+    outer loop
+      vertex 12.6244 -15.3829 0
+      vertex 13.5646 -14.5308 9.56457
+      vertex 13.5288 -14.5632 9.70736
+    endloop
+  endfacet
+  facet normal 0.671845 -0.740692 -5.49228e-05
+    outer loop
+      vertex 12.6244 -15.3829 0
+      vertex 13.6142 -14.4858 9.42597
+      vertex 13.5646 -14.5308 9.56457
+    endloop
+  endfacet
+  facet normal 0.67151 -0.740996 9.19334e-06
+    outer loop
+      vertex 12.6244 -15.3829 0
+      vertex 13.6771 -14.4288 9.2929
+      vertex 13.6142 -14.4858 9.42597
+    endloop
+  endfacet
+  facet normal 0.671511 -0.740995 8.99237e-06
+    outer loop
+      vertex 12.6244 -15.3829 0
+      vertex 13.7528 -14.3602 9.16664
+      vertex 13.6771 -14.4288 9.2929
+    endloop
+  endfacet
+  facet normal 0.671611 -0.740904 -1.34455e-05
+    outer loop
+      vertex 12.6244 -15.3829 0
+      vertex 13.8405 -14.2807 9.04841
+      vertex 13.7528 -14.3602 9.16664
+    endloop
+  endfacet
+  facet normal 0.671748 -0.74078 -4.70463e-05
+    outer loop
+      vertex 12.6244 -15.3829 0
+      vertex 13.9393 -14.1911 8.93934
+      vertex 13.8405 -14.2807 9.04841
+    endloop
+  endfacet
+  facet normal 0.671289 -0.741196 7.59521e-05
+    outer loop
+      vertex 12.6244 -15.3829 0
+      vertex 14.0484 -14.0923 8.84048
+      vertex 13.9393 -14.1911 8.93934
+    endloop
+  endfacet
+  facet normal 0.67241 -0.740179 -0.000252971
+    outer loop
+      vertex 12.6244 -15.3829 0
+      vertex 14.0714 -14.0714 8.82341
+      vertex 14.0484 -14.0923 8.84048
+    endloop
+  endfacet
+  facet normal 0.671563 -0.740947 0
+    outer loop
+      vertex 14.0714 -14.0714 8.82341
+      vertex 12.6244 -15.3829 0
+      vertex 14.0714 -14.0714 0
+    endloop
+  endfacet
+  facet normal 0.740961 0.671548 0
+    outer loop
+      vertex 19.3253 15.8598 75
+      vertex 17.6777 17.6777 60
+      vertex 17.6777 17.6777 75
+    endloop
+  endfacet
+  facet normal 0.740961 0.671548 0
+    outer loop
+      vertex 17.6777 17.6777 60
+      vertex 19.3253 15.8598 75
+      vertex 19.3253 15.8598 60
+    endloop
+  endfacet
+  facet normal 0.989176 0.146736 0
+    outer loop
+      vertex 24.8796 2.45043 75
+      vertex 24.5196 4.87726 60
+      vertex 24.5196 4.87726 75
+    endloop
+  endfacet
+  facet normal 0.989176 0.146736 0
+    outer loop
+      vertex 24.5196 4.87726 60
+      vertex 24.8796 2.45043 75
+      vertex 24.8796 2.45043 60
+    endloop
+  endfacet
+  facet normal 0.998795 0.049075 0
+    outer loop
+      vertex 25 0 75
+      vertex 24.8796 2.45043 60
+      vertex 24.8796 2.45043 75
+    endloop
+  endfacet
+  facet normal 0.998795 0.049075 0
+    outer loop
+      vertex 24.8796 2.45043 60
+      vertex 25 0 75
+      vertex 25 0 60
+    endloop
+  endfacet
+  facet normal 0.595693 0.803212 -0
+    outer loop
+      vertex 15.8598 19.3253 60
+      vertex 13.8893 20.7867 75
+      vertex 15.8598 19.3253 75
+    endloop
+  endfacet
+  facet normal 0.595693 0.803212 0
+    outer loop
+      vertex 13.8893 20.7867 75
+      vertex 15.8598 19.3253 60
+      vertex 13.8893 20.7867 60
+    endloop
+  endfacet
+  facet normal -0.857734 0.514094 0
+    outer loop
+      vertex -22.048 11.7849 60
+      vertex -20.7867 13.8893 75
+      vertex -20.7867 13.8893 60
+    endloop
+  endfacet
+  facet normal -0.857734 0.514094 0
+    outer loop
+      vertex -20.7867 13.8893 75
+      vertex -22.048 11.7849 60
+      vertex -22.048 11.7849 75
+    endloop
+  endfacet
+  facet normal 0.336882 -0.941547 0
+    outer loop
+      vertex 7.25712 -23.9235 60
+      vertex 9.56709 -23.097 75
+      vertex 7.25712 -23.9235 75
+    endloop
+  endfacet
+  facet normal 0.336882 -0.941547 0
+    outer loop
+      vertex 9.56709 -23.097 75
+      vertex 7.25712 -23.9235 60
+      vertex 9.56709 -23.097 60
+    endloop
+  endfacet
+  facet normal -0.998795 -0.049075 0
+    outer loop
+      vertex -24.8796 -2.45043 60
+      vertex -25 0 75
+      vertex -25 0 60
+    endloop
+  endfacet
+  facet normal -0.998795 -0.049075 0
+    outer loop
+      vertex -25 0 75
+      vertex -24.8796 -2.45043 60
+      vertex -24.8796 -2.45043 75
+    endloop
+  endfacet
+  facet normal -0.671548 0.740961 0
+    outer loop
+      vertex -15.8598 19.3253 60
+      vertex -17.6777 17.6777 75
+      vertex -15.8598 19.3253 75
+    endloop
+  endfacet
+  facet normal -0.671548 0.740961 0
+    outer loop
+      vertex -17.6777 17.6777 75
+      vertex -15.8598 19.3253 60
+      vertex -17.6777 17.6777 60
+    endloop
+  endfacet
+  facet normal -0.970034 -0.242971 0
+    outer loop
+      vertex -23.9235 -7.25712 60
+      vertex -24.5196 -4.87726 75
+      vertex -24.5196 -4.87726 60
+    endloop
+  endfacet
+  facet normal -0.970034 -0.242971 0
+    outer loop
+      vertex -24.5196 -4.87726 75
+      vertex -23.9235 -7.25712 60
+      vertex -23.9235 -7.25712 75
+    endloop
+  endfacet
+  facet normal 0.989176 -0.146736 0
+    outer loop
+      vertex 24.5196 -4.87726 75
+      vertex 24.8796 -2.45043 60
+      vertex 24.8796 -2.45043 75
+    endloop
+  endfacet
+  facet normal 0.989176 -0.146736 0
+    outer loop
+      vertex 24.8796 -2.45043 60
+      vertex 24.5196 -4.87726 75
+      vertex 24.5196 -4.87726 60
+    endloop
+  endfacet
+  facet normal -0.427573 0.903981 0
+    outer loop
+      vertex -9.56709 23.097 60
+      vertex -11.7849 22.048 75
+      vertex -9.56709 23.097 75
+    endloop
+  endfacet
+  facet normal -0.427573 0.903981 0
+    outer loop
+      vertex -11.7849 22.048 75
+      vertex -9.56709 23.097 60
+      vertex -11.7849 22.048 60
+    endloop
+  endfacet
+  facet normal -0.941547 -0.336882 0
+    outer loop
+      vertex -23.097 -9.56709 60
+      vertex -23.9235 -7.25712 75
+      vertex -23.9235 -7.25712 60
+    endloop
+  endfacet
+  facet normal -0.941547 -0.336882 0
+    outer loop
+      vertex -23.9235 -7.25712 75
+      vertex -23.097 -9.56709 60
+      vertex -23.097 -9.56709 75
+    endloop
+  endfacet
+  facet normal -0.242971 0.970034 0
+    outer loop
+      vertex -4.87726 24.5196 60
+      vertex -7.25712 23.9235 75
+      vertex -4.87726 24.5196 75
+    endloop
+  endfacet
+  facet normal -0.242971 0.970034 0
+    outer loop
+      vertex -7.25712 23.9235 75
+      vertex -4.87726 24.5196 60
+      vertex -7.25712 23.9235 60
+    endloop
+  endfacet
+  facet normal -0.595693 -0.803212 0
+    outer loop
+      vertex -15.8598 -19.3253 60
+      vertex -13.8893 -20.7867 75
+      vertex -15.8598 -19.3253 75
+    endloop
+  endfacet
+  facet normal -0.595693 -0.803212 -0
+    outer loop
+      vertex -13.8893 -20.7867 75
+      vertex -15.8598 -19.3253 60
+      vertex -13.8893 -20.7867 60
+    endloop
+  endfacet
+  facet normal -0.970034 0.242971 0
+    outer loop
+      vertex -24.5196 4.87726 60
+      vertex -23.9235 7.25712 75
+      vertex -23.9235 7.25712 60
+    endloop
+  endfacet
+  facet normal -0.970034 0.242971 0
+    outer loop
+      vertex -23.9235 7.25712 75
+      vertex -24.5196 4.87726 60
+      vertex -24.5196 4.87726 75
+    endloop
+  endfacet
+  facet normal -0.941547 0.336882 0
+    outer loop
+      vertex -23.9235 7.25712 60
+      vertex -23.097 9.56709 75
+      vertex -23.097 9.56709 60
+    endloop
+  endfacet
+  facet normal -0.941547 0.336882 0
+    outer loop
+      vertex -23.097 9.56709 75
+      vertex -23.9235 7.25712 60
+      vertex -23.9235 7.25712 75
+    endloop
+  endfacet
+  facet normal 0.427573 0.903981 -0
+    outer loop
+      vertex 11.7849 22.048 60
+      vertex 9.56709 23.097 75
+      vertex 11.7849 22.048 75
+    endloop
+  endfacet
+  facet normal 0.427573 0.903981 0
+    outer loop
+      vertex 9.56709 23.097 75
+      vertex 11.7849 22.048 60
+      vertex 9.56709 23.097 60
+    endloop
+  endfacet
+  facet normal 0.671548 0.740961 -0
+    outer loop
+      vertex 17.6777 17.6777 60
+      vertex 15.8598 19.3253 75
+      vertex 17.6777 17.6777 75
+    endloop
+  endfacet
+  facet normal 0.671548 0.740961 0
+    outer loop
+      vertex 15.8598 19.3253 75
+      vertex 17.6777 17.6777 60
+      vertex 15.8598 19.3253 60
+    endloop
+  endfacet
+  facet normal 0.998795 -0.049075 0
+    outer loop
+      vertex 24.8796 -2.45043 75
+      vertex 25 0 60
+      vertex 25 0 75
+    endloop
+  endfacet
+  facet normal 0.998795 -0.049075 0
+    outer loop
+      vertex 25 0 60
+      vertex 24.8796 -2.45043 75
+      vertex 24.8796 -2.45043 60
+    endloop
+  endfacet
+  facet normal 0.857734 0.514094 0
+    outer loop
+      vertex 22.048 11.7849 75
+      vertex 20.7867 13.8893 60
+      vertex 20.7867 13.8893 75
+    endloop
+  endfacet
+  facet normal 0.857734 0.514094 0
+    outer loop
+      vertex 20.7867 13.8893 60
+      vertex 22.048 11.7849 75
+      vertex 22.048 11.7849 60
+    endloop
+  endfacet
+  facet normal 0.903981 0.427573 0
+    outer loop
+      vertex 23.097 9.56709 75
+      vertex 22.048 11.7849 60
+      vertex 22.048 11.7849 75
+    endloop
+  endfacet
+  facet normal 0.903981 0.427573 0
+    outer loop
+      vertex 22.048 11.7849 60
+      vertex 23.097 9.56709 75
+      vertex 23.097 9.56709 60
+    endloop
+  endfacet
+  facet normal 0.242971 0.970034 -0
+    outer loop
+      vertex 7.25712 23.9235 60
+      vertex 4.87726 24.5196 75
+      vertex 7.25712 23.9235 75
+    endloop
+  endfacet
+  facet normal 0.242971 0.970034 0
+    outer loop
+      vertex 4.87726 24.5196 75
+      vertex 7.25712 23.9235 60
+      vertex 4.87726 24.5196 60
+    endloop
+  endfacet
+  facet normal -0.427573 -0.903981 0
+    outer loop
+      vertex -11.7849 -22.048 60
+      vertex -9.56709 -23.097 75
+      vertex -11.7849 -22.048 75
+    endloop
+  endfacet
+  facet normal -0.427573 -0.903981 -0
+    outer loop
+      vertex -9.56709 -23.097 75
+      vertex -11.7849 -22.048 60
+      vertex -9.56709 -23.097 60
+    endloop
+  endfacet
+  facet normal 0.336882 0.941547 -0
+    outer loop
+      vertex 9.56709 23.097 60
+      vertex 7.25712 23.9235 75
+      vertex 9.56709 23.097 75
+    endloop
+  endfacet
+  facet normal 0.336882 0.941547 0
+    outer loop
+      vertex 7.25712 23.9235 75
+      vertex 9.56709 23.097 60
+      vertex 7.25712 23.9235 60
+    endloop
+  endfacet
+  facet normal 0.146736 -0.989176 0
+    outer loop
+      vertex 2.45043 -24.8796 60
+      vertex 4.87726 -24.5196 75
+      vertex 2.45043 -24.8796 75
+    endloop
+  endfacet
+  facet normal 0.146736 -0.989176 0
+    outer loop
+      vertex 4.87726 -24.5196 75
+      vertex 2.45043 -24.8796 60
+      vertex 4.87726 -24.5196 60
+    endloop
+  endfacet
+  facet normal 0.941547 0.336882 0
+    outer loop
+      vertex 23.9235 7.25712 75
+      vertex 23.097 9.56709 60
+      vertex 23.097 9.56709 75
+    endloop
+  endfacet
+  facet normal 0.941547 0.336882 0
+    outer loop
+      vertex 23.097 9.56709 60
+      vertex 23.9235 7.25712 75
+      vertex 23.9235 7.25712 60
+    endloop
+  endfacet
+  facet normal 0.427573 -0.903981 0
+    outer loop
+      vertex 9.56709 -23.097 60
+      vertex 11.7849 -22.048 75
+      vertex 9.56709 -23.097 75
+    endloop
+  endfacet
+  facet normal 0.427573 -0.903981 0
+    outer loop
+      vertex 11.7849 -22.048 75
+      vertex 9.56709 -23.097 60
+      vertex 11.7849 -22.048 60
+    endloop
+  endfacet
+  facet normal -0.336882 -0.941547 0
+    outer loop
+      vertex -9.56709 -23.097 60
+      vertex -7.25712 -23.9235 75
+      vertex -9.56709 -23.097 75
+    endloop
+  endfacet
+  facet normal -0.336882 -0.941547 -0
+    outer loop
+      vertex -7.25712 -23.9235 75
+      vertex -9.56709 -23.097 60
+      vertex -7.25712 -23.9235 60
+    endloop
+  endfacet
+  facet normal -0.049075 0.998795 0
+    outer loop
+      vertex 0 25 60
+      vertex -2.45043 24.8796 75
+      vertex 0 25 75
+    endloop
+  endfacet
+  facet normal -0.049075 0.998795 0
+    outer loop
+      vertex -2.45043 24.8796 75
+      vertex 0 25 60
+      vertex -2.45043 24.8796 60
+    endloop
+  endfacet
+  facet normal -0.595693 0.803212 0
+    outer loop
+      vertex -13.8893 20.7867 60
+      vertex -15.8598 19.3253 75
+      vertex -13.8893 20.7867 75
+    endloop
+  endfacet
+  facet normal -0.595693 0.803212 0
+    outer loop
+      vertex -15.8598 19.3253 75
+      vertex -13.8893 20.7867 60
+      vertex -15.8598 19.3253 60
+    endloop
+  endfacet
+  facet normal -0.903981 -0.427573 0
+    outer loop
+      vertex -22.048 -11.7849 60
+      vertex -23.097 -9.56709 75
+      vertex -23.097 -9.56709 60
+    endloop
+  endfacet
+  facet normal -0.903981 -0.427573 0
+    outer loop
+      vertex -23.097 -9.56709 75
+      vertex -22.048 -11.7849 60
+      vertex -22.048 -11.7849 75
+    endloop
+  endfacet
+  facet normal 0.803212 0.595693 0
+    outer loop
+      vertex 20.7867 13.8893 75
+      vertex 19.3253 15.8598 60
+      vertex 19.3253 15.8598 75
+    endloop
+  endfacet
+  facet normal 0.803212 0.595693 0
+    outer loop
+      vertex 19.3253 15.8598 60
+      vertex 20.7867 13.8893 75
+      vertex 20.7867 13.8893 60
+    endloop
+  endfacet
+  facet normal -0.740961 0.671548 0
+    outer loop
+      vertex -19.3253 15.8598 60
+      vertex -17.6777 17.6777 75
+      vertex -17.6777 17.6777 60
+    endloop
+  endfacet
+  facet normal -0.740961 0.671548 0
+    outer loop
+      vertex -17.6777 17.6777 75
+      vertex -19.3253 15.8598 60
+      vertex -19.3253 15.8598 75
+    endloop
+  endfacet
+  facet normal -0.146736 0.989176 0
+    outer loop
+      vertex -2.45043 24.8796 60
+      vertex -4.87726 24.5196 75
+      vertex -2.45043 24.8796 75
+    endloop
+  endfacet
+  facet normal -0.146736 0.989176 0
+    outer loop
+      vertex -4.87726 24.5196 75
+      vertex -2.45043 24.8796 60
+      vertex -4.87726 24.5196 60
+    endloop
+  endfacet
+  facet normal 0.049075 -0.998795 0
+    outer loop
+      vertex 0 -25 60
+      vertex 2.45043 -24.8796 75
+      vertex 0 -25 75
+    endloop
+  endfacet
+  facet normal 0.049075 -0.998795 0
+    outer loop
+      vertex 2.45043 -24.8796 75
+      vertex 0 -25 60
+      vertex 2.45043 -24.8796 60
+    endloop
+  endfacet
+  facet normal 0.857734 -0.514094 0
+    outer loop
+      vertex 20.7867 -13.8893 75
+      vertex 22.048 -11.7849 60
+      vertex 22.048 -11.7849 75
+    endloop
+  endfacet
+  facet normal 0.857734 -0.514094 0
+    outer loop
+      vertex 22.048 -11.7849 60
+      vertex 20.7867 -13.8893 75
+      vertex 20.7867 -13.8893 60
+    endloop
+  endfacet
+  facet normal 0.740961 -0.671548 0
+    outer loop
+      vertex 17.6777 -17.6777 75
+      vertex 19.3253 -15.8598 60
+      vertex 19.3253 -15.8598 75
+    endloop
+  endfacet
+  facet normal 0.740961 -0.671548 0
+    outer loop
+      vertex 19.3253 -15.8598 60
+      vertex 17.6777 -17.6777 75
+      vertex 17.6777 -17.6777 60
+    endloop
+  endfacet
+  facet normal 0.941547 -0.336882 0
+    outer loop
+      vertex 23.097 -9.56709 75
+      vertex 23.9235 -7.25712 60
+      vertex 23.9235 -7.25712 75
+    endloop
+  endfacet
+  facet normal 0.941547 -0.336882 0
+    outer loop
+      vertex 23.9235 -7.25712 60
+      vertex 23.097 -9.56709 75
+      vertex 23.097 -9.56709 60
+    endloop
+  endfacet
+  facet normal 0.803212 -0.595693 0
+    outer loop
+      vertex 19.3253 -15.8598 75
+      vertex 20.7867 -13.8893 60
+      vertex 20.7867 -13.8893 75
+    endloop
+  endfacet
+  facet normal 0.803212 -0.595693 0
+    outer loop
+      vertex 20.7867 -13.8893 60
+      vertex 19.3253 -15.8598 75
+      vertex 19.3253 -15.8598 60
+    endloop
+  endfacet
+  facet normal 0.514094 0.857734 -0
+    outer loop
+      vertex 13.8893 20.7867 60
+      vertex 11.7849 22.048 75
+      vertex 13.8893 20.7867 75
+    endloop
+  endfacet
+  facet normal 0.514094 0.857734 0
+    outer loop
+      vertex 11.7849 22.048 75
+      vertex 13.8893 20.7867 60
+      vertex 11.7849 22.048 60
+    endloop
+  endfacet
+  facet normal -0.146736 -0.989176 0
+    outer loop
+      vertex -4.87726 -24.5196 60
+      vertex -2.45043 -24.8796 75
+      vertex -4.87726 -24.5196 75
+    endloop
+  endfacet
+  facet normal -0.146736 -0.989176 -0
+    outer loop
+      vertex -2.45043 -24.8796 75
+      vertex -4.87726 -24.5196 60
+      vertex -2.45043 -24.8796 60
+    endloop
+  endfacet
+  facet normal 0.595693 -0.803212 0
+    outer loop
+      vertex 13.8893 -20.7867 60
+      vertex 15.8598 -19.3253 75
+      vertex 13.8893 -20.7867 75
+    endloop
+  endfacet
+  facet normal 0.595693 -0.803212 0
+    outer loop
+      vertex 15.8598 -19.3253 75
+      vertex 13.8893 -20.7867 60
+      vertex 15.8598 -19.3253 60
+    endloop
+  endfacet
+  facet normal -0.989176 0.146736 0
+    outer loop
+      vertex -24.8796 2.45043 60
+      vertex -24.5196 4.87726 75
+      vertex -24.5196 4.87726 60
+    endloop
+  endfacet
+  facet normal -0.989176 0.146736 0
+    outer loop
+      vertex -24.5196 4.87726 75
+      vertex -24.8796 2.45043 60
+      vertex -24.8796 2.45043 75
+    endloop
+  endfacet
+  facet normal 0.242971 -0.970034 0
+    outer loop
+      vertex 4.87726 -24.5196 60
+      vertex 7.25712 -23.9235 75
+      vertex 4.87726 -24.5196 75
+    endloop
+  endfacet
+  facet normal 0.242971 -0.970034 0
+    outer loop
+      vertex 7.25712 -23.9235 75
+      vertex 4.87726 -24.5196 60
+      vertex 7.25712 -23.9235 60
+    endloop
+  endfacet
+  facet normal 0.049075 0.998795 -0
+    outer loop
+      vertex 2.45043 24.8796 60
+      vertex 0 25 75
+      vertex 2.45043 24.8796 75
+    endloop
+  endfacet
+  facet normal 0.049075 0.998795 0
+    outer loop
+      vertex 0 25 75
+      vertex 2.45043 24.8796 60
+      vertex 0 25 60
+    endloop
+  endfacet
+  facet normal -0.242971 -0.970034 0
+    outer loop
+      vertex -7.25712 -23.9235 60
+      vertex -4.87726 -24.5196 75
+      vertex -7.25712 -23.9235 75
+    endloop
+  endfacet
+  facet normal -0.242971 -0.970034 -0
+    outer loop
+      vertex -4.87726 -24.5196 75
+      vertex -7.25712 -23.9235 60
+      vertex -4.87726 -24.5196 60
+    endloop
+  endfacet
+  facet normal 0.970034 0.242971 0
+    outer loop
+      vertex 24.5196 4.87726 75
+      vertex 23.9235 7.25712 60
+      vertex 23.9235 7.25712 75
+    endloop
+  endfacet
+  facet normal 0.970034 0.242971 0
+    outer loop
+      vertex 23.9235 7.25712 60
+      vertex 24.5196 4.87726 75
+      vertex 24.5196 4.87726 60
+    endloop
+  endfacet
+  facet normal 0.970034 -0.242971 0
+    outer loop
+      vertex 23.9235 -7.25712 75
+      vertex 24.5196 -4.87726 60
+      vertex 24.5196 -4.87726 75
+    endloop
+  endfacet
+  facet normal 0.970034 -0.242971 0
+    outer loop
+      vertex 24.5196 -4.87726 60
+      vertex 23.9235 -7.25712 75
+      vertex 23.9235 -7.25712 60
+    endloop
+  endfacet
+  facet normal 0.146736 0.989176 -0
+    outer loop
+      vertex 4.87726 24.5196 60
+      vertex 2.45043 24.8796 75
+      vertex 4.87726 24.5196 75
+    endloop
+  endfacet
+  facet normal 0.146736 0.989176 0
+    outer loop
+      vertex 2.45043 24.8796 75
+      vertex 4.87726 24.5196 60
+      vertex 2.45043 24.8796 60
+    endloop
+  endfacet
+  facet normal -0.740961 -0.671548 0
+    outer loop
+      vertex -17.6777 -17.6777 60
+      vertex -19.3253 -15.8598 75
+      vertex -19.3253 -15.8598 60
+    endloop
+  endfacet
+  facet normal -0.740961 -0.671548 0
+    outer loop
+      vertex -19.3253 -15.8598 75
+      vertex -17.6777 -17.6777 60
+      vertex -17.6777 -17.6777 75
+    endloop
+  endfacet
+  facet normal -0.857734 -0.514094 0
+    outer loop
+      vertex -20.7867 -13.8893 60
+      vertex -22.048 -11.7849 75
+      vertex -22.048 -11.7849 60
+    endloop
+  endfacet
+  facet normal -0.857734 -0.514094 0
+    outer loop
+      vertex -22.048 -11.7849 75
+      vertex -20.7867 -13.8893 60
+      vertex -20.7867 -13.8893 75
+    endloop
+  endfacet
+  facet normal -0.336882 0.941547 0
+    outer loop
+      vertex -7.25712 23.9235 60
+      vertex -9.56709 23.097 75
+      vertex -7.25712 23.9235 75
+    endloop
+  endfacet
+  facet normal -0.336882 0.941547 0
+    outer loop
+      vertex -9.56709 23.097 75
+      vertex -7.25712 23.9235 60
+      vertex -9.56709 23.097 60
+    endloop
+  endfacet
+  facet normal -0.514094 -0.857734 0
+    outer loop
+      vertex -13.8893 -20.7867 60
+      vertex -11.7849 -22.048 75
+      vertex -13.8893 -20.7867 75
+    endloop
+  endfacet
+  facet normal -0.514094 -0.857734 -0
+    outer loop
+      vertex -11.7849 -22.048 75
+      vertex -13.8893 -20.7867 60
+      vertex -11.7849 -22.048 60
+    endloop
+  endfacet
+  facet normal -0.803212 -0.595693 0
+    outer loop
+      vertex -19.3253 -15.8598 60
+      vertex -20.7867 -13.8893 75
+      vertex -20.7867 -13.8893 60
+    endloop
+  endfacet
+  facet normal -0.803212 -0.595693 0
+    outer loop
+      vertex -20.7867 -13.8893 75
+      vertex -19.3253 -15.8598 60
+      vertex -19.3253 -15.8598 75
+    endloop
+  endfacet
+  facet normal -0.514094 0.857734 0
+    outer loop
+      vertex -11.7849 22.048 60
+      vertex -13.8893 20.7867 75
+      vertex -11.7849 22.048 75
+    endloop
+  endfacet
+  facet normal -0.514094 0.857734 0
+    outer loop
+      vertex -13.8893 20.7867 75
+      vertex -11.7849 22.048 60
+      vertex -13.8893 20.7867 60
+    endloop
+  endfacet
+  facet normal -0.989176 -0.146736 0
+    outer loop
+      vertex -24.5196 -4.87726 60
+      vertex -24.8796 -2.45043 75
+      vertex -24.8796 -2.45043 60
+    endloop
+  endfacet
+  facet normal -0.989176 -0.146736 0
+    outer loop
+      vertex -24.8796 -2.45043 75
+      vertex -24.5196 -4.87726 60
+      vertex -24.5196 -4.87726 75
+    endloop
+  endfacet
+  facet normal -0.903981 0.427573 0
+    outer loop
+      vertex -23.097 9.56709 60
+      vertex -22.048 11.7849 75
+      vertex -22.048 11.7849 60
+    endloop
+  endfacet
+  facet normal -0.903981 0.427573 0
+    outer loop
+      vertex -22.048 11.7849 75
+      vertex -23.097 9.56709 60
+      vertex -23.097 9.56709 75
+    endloop
+  endfacet
+  facet normal 0.514094 -0.857734 0
+    outer loop
+      vertex 11.7849 -22.048 60
+      vertex 13.8893 -20.7867 75
+      vertex 11.7849 -22.048 75
+    endloop
+  endfacet
+  facet normal 0.514094 -0.857734 0
+    outer loop
+      vertex 13.8893 -20.7867 75
+      vertex 11.7849 -22.048 60
+      vertex 13.8893 -20.7867 60
+    endloop
+  endfacet
+  facet normal 0.903981 -0.427573 0
+    outer loop
+      vertex 22.048 -11.7849 75
+      vertex 23.097 -9.56709 60
+      vertex 23.097 -9.56709 75
+    endloop
+  endfacet
+  facet normal 0.903981 -0.427573 0
+    outer loop
+      vertex 23.097 -9.56709 60
+      vertex 22.048 -11.7849 75
+      vertex 22.048 -11.7849 60
+    endloop
+  endfacet
+  facet normal -0.671548 -0.740961 0
+    outer loop
+      vertex -17.6777 -17.6777 60
+      vertex -15.8598 -19.3253 75
+      vertex -17.6777 -17.6777 75
+    endloop
+  endfacet
+  facet normal -0.671548 -0.740961 -0
+    outer loop
+      vertex -15.8598 -19.3253 75
+      vertex -17.6777 -17.6777 60
+      vertex -15.8598 -19.3253 60
+    endloop
+  endfacet
+  facet normal -0.803212 0.595693 0
+    outer loop
+      vertex -20.7867 13.8893 60
+      vertex -19.3253 15.8598 75
+      vertex -19.3253 15.8598 60
+    endloop
+  endfacet
+  facet normal -0.803212 0.595693 0
+    outer loop
+      vertex -19.3253 15.8598 75
+      vertex -20.7867 13.8893 60
+      vertex -20.7867 13.8893 75
+    endloop
+  endfacet
+  facet normal -0.049075 -0.998795 0
+    outer loop
+      vertex -2.45043 -24.8796 60
+      vertex 0 -25 75
+      vertex -2.45043 -24.8796 75
+    endloop
+  endfacet
+  facet normal -0.049075 -0.998795 -0
+    outer loop
+      vertex 0 -25 75
+      vertex -2.45043 -24.8796 60
+      vertex 0 -25 60
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.8796 2.45043 75
+      vertex 24.8796 -2.45043 75
+      vertex 25 0 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.5196 4.87726 75
+      vertex 24.8796 -2.45043 75
+      vertex 24.8796 2.45043 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.5196 4.87726 75
+      vertex 24.5196 -4.87726 75
+      vertex 24.8796 -2.45043 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.9235 7.25712 75
+      vertex 24.5196 -4.87726 75
+      vertex 24.5196 4.87726 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.9235 7.25712 75
+      vertex 23.9235 -7.25712 75
+      vertex 24.5196 -4.87726 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.097 9.56709 75
+      vertex 23.9235 -7.25712 75
+      vertex 23.9235 7.25712 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.097 9.56709 75
+      vertex 23.097 -9.56709 75
+      vertex 23.9235 -7.25712 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.048 11.7849 75
+      vertex 23.097 -9.56709 75
+      vertex 23.097 9.56709 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.048 11.7849 75
+      vertex 22.048 -11.7849 75
+      vertex 23.097 -9.56709 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.7867 13.8893 75
+      vertex 22.048 -11.7849 75
+      vertex 22.048 11.7849 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.7867 13.8893 75
+      vertex 20.7867 -13.8893 75
+      vertex 22.048 -11.7849 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3253 15.8598 75
+      vertex 20.7867 -13.8893 75
+      vertex 20.7867 13.8893 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3253 15.8598 75
+      vertex 19.3253 -15.8598 75
+      vertex 20.7867 -13.8893 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6777 17.6777 75
+      vertex 19.3253 -15.8598 75
+      vertex 19.3253 15.8598 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6777 17.6777 75
+      vertex 17.6777 -17.6777 75
+      vertex 19.3253 -15.8598 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.8598 19.3253 75
+      vertex 17.6777 -17.6777 75
+      vertex 17.6777 17.6777 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.8598 19.3253 75
+      vertex 15.8598 -19.3253 75
+      vertex 17.6777 -17.6777 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8893 20.7867 75
+      vertex 15.8598 -19.3253 75
+      vertex 15.8598 19.3253 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8893 20.7867 75
+      vertex 13.8893 -20.7867 75
+      vertex 15.8598 -19.3253 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7849 22.048 75
+      vertex 13.8893 -20.7867 75
+      vertex 13.8893 20.7867 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7849 22.048 75
+      vertex 11.7849 -22.048 75
+      vertex 13.8893 -20.7867 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.56709 23.097 75
+      vertex 11.7849 -22.048 75
+      vertex 11.7849 22.048 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.56709 23.097 75
+      vertex 9.56709 -23.097 75
+      vertex 11.7849 -22.048 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.25712 23.9235 75
+      vertex 9.56709 -23.097 75
+      vertex 9.56709 23.097 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.25712 23.9235 75
+      vertex 7.25712 -23.9235 75
+      vertex 9.56709 -23.097 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.87726 24.5196 75
+      vertex 7.25712 -23.9235 75
+      vertex 7.25712 23.9235 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.87726 24.5196 75
+      vertex 4.87726 -24.5196 75
+      vertex 7.25712 -23.9235 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.45043 24.8796 75
+      vertex 4.87726 -24.5196 75
+      vertex 4.87726 24.5196 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.45043 24.8796 75
+      vertex 2.45043 -24.8796 75
+      vertex 4.87726 -24.5196 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 25 75
+      vertex 2.45043 -24.8796 75
+      vertex 2.45043 24.8796 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 25 75
+      vertex 0 -25 75
+      vertex 2.45043 -24.8796 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.45043 24.8796 75
+      vertex 0 -25 75
+      vertex 0 25 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.45043 24.8796 75
+      vertex -2.45043 -24.8796 75
+      vertex 0 -25 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -4.87726 24.5196 75
+      vertex -2.45043 -24.8796 75
+      vertex -2.45043 24.8796 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.87726 24.5196 75
+      vertex -4.87726 -24.5196 75
+      vertex -2.45043 -24.8796 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.25712 23.9235 75
+      vertex -4.87726 -24.5196 75
+      vertex -4.87726 24.5196 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.25712 23.9235 75
+      vertex -7.25712 -23.9235 75
+      vertex -4.87726 -24.5196 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.56709 23.097 75
+      vertex -7.25712 -23.9235 75
+      vertex -7.25712 23.9235 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.56709 23.097 75
+      vertex -9.56709 -23.097 75
+      vertex -7.25712 -23.9235 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.7849 22.048 75
+      vertex -9.56709 -23.097 75
+      vertex -9.56709 23.097 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7849 22.048 75
+      vertex -11.7849 -22.048 75
+      vertex -9.56709 -23.097 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.8893 20.7867 75
+      vertex -11.7849 -22.048 75
+      vertex -11.7849 22.048 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.8893 20.7867 75
+      vertex -13.8893 -20.7867 75
+      vertex -11.7849 -22.048 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.8598 19.3253 75
+      vertex -13.8893 -20.7867 75
+      vertex -13.8893 20.7867 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8598 19.3253 75
+      vertex -15.8598 -19.3253 75
+      vertex -13.8893 -20.7867 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.6777 17.6777 75
+      vertex -15.8598 -19.3253 75
+      vertex -15.8598 19.3253 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.6777 17.6777 75
+      vertex -17.6777 -17.6777 75
+      vertex -15.8598 -19.3253 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.3253 15.8598 75
+      vertex -17.6777 -17.6777 75
+      vertex -17.6777 17.6777 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3253 15.8598 75
+      vertex -19.3253 -15.8598 75
+      vertex -17.6777 -17.6777 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.7867 13.8893 75
+      vertex -19.3253 -15.8598 75
+      vertex -19.3253 15.8598 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.7867 13.8893 75
+      vertex -20.7867 -13.8893 75
+      vertex -19.3253 -15.8598 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.048 11.7849 75
+      vertex -20.7867 -13.8893 75
+      vertex -20.7867 13.8893 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.048 11.7849 75
+      vertex -22.048 -11.7849 75
+      vertex -20.7867 -13.8893 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.097 9.56709 75
+      vertex -22.048 -11.7849 75
+      vertex -22.048 11.7849 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.097 9.56709 75
+      vertex -23.097 -9.56709 75
+      vertex -22.048 -11.7849 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.9235 7.25712 75
+      vertex -23.097 -9.56709 75
+      vertex -23.097 9.56709 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.9235 7.25712 75
+      vertex -23.9235 -7.25712 75
+      vertex -23.097 -9.56709 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.5196 4.87726 75
+      vertex -23.9235 -7.25712 75
+      vertex -23.9235 7.25712 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.5196 4.87726 75
+      vertex -24.5196 -4.87726 75
+      vertex -23.9235 -7.25712 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.8796 2.45043 75
+      vertex -24.5196 -4.87726 75
+      vertex -24.5196 4.87726 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8796 2.45043 75
+      vertex -24.8796 -2.45043 75
+      vertex -24.5196 -4.87726 75
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -24.8796 -2.45043 75
+      vertex -24.8796 2.45043 75
+      vertex -25 0 75
+    endloop
+  endfacet
+  facet normal -0.998795 0.049075 0
+    outer loop
+      vertex -25 0 60
+      vertex -24.8796 2.45043 75
+      vertex -24.8796 2.45043 60
+    endloop
+  endfacet
+  facet normal -0.998795 0.049075 0
+    outer loop
+      vertex -24.8796 2.45043 75
+      vertex -25 0 60
+      vertex -25 0 75
+    endloop
+  endfacet
+  facet normal 0.671548 -0.740961 0
+    outer loop
+      vertex 15.8598 -19.3253 60
+      vertex 17.6777 -17.6777 75
+      vertex 15.8598 -19.3253 75
+    endloop
+  endfacet
+  facet normal 0.671548 -0.740961 0
+    outer loop
+      vertex 17.6777 -17.6777 75
+      vertex 15.8598 -19.3253 60
+      vertex 17.6777 -17.6777 60
+    endloop
+  endfacet
+  facet normal -0.989174 0 -0.146746
+    outer loop
+      vertex 16.4928 -11.1279 10.147
+      vertex 16.4712 0 10.2926
+      vertex 16.4928 0 10.147
+    endloop
+  endfacet
+  facet normal -0.989174 -0 -0.146746
+    outer loop
+      vertex 16.4712 0 10.2926
+      vertex 16.4928 -11.1279 10.147
+      vertex 16.4712 -11.1571 10.2926
+    endloop
+  endfacet
+  facet normal -0.998803 0 -0.0489209
+    outer loop
+      vertex 16.5 -11.1182 10
+      vertex 16.4928 0 10.147
+      vertex 16.5 0 10
+    endloop
+  endfacet
+  facet normal -0.998803 -0 -0.0489209
+    outer loop
+      vertex 16.4928 0 10.147
+      vertex 16.5 -11.1182 10
+      vertex 16.4928 -11.1279 10.147
+    endloop
+  endfacet
+  facet normal -0.969982 0 -0.243175
+    outer loop
+      vertex 16.4712 -11.1571 10.2926
+      vertex 16.4354 0 10.4354
+      vertex 16.4712 0 10.2926
+    endloop
+  endfacet
+  facet normal -0.969982 -0 -0.243175
+    outer loop
+      vertex 16.4354 0 10.4354
+      vertex 16.4712 -11.1571 10.2926
+      vertex 16.4354 -11.2053 10.4354
+    endloop
+  endfacet
+  facet normal 0.242983 0 0.970031
+    outer loop
+      vertex 14.5646 -3.51404 8.56459
+      vertex 14.7074 -13.3698 8.52882
+      vertex 14.7074 -2.94398 8.52882
+    endloop
+  endfacet
+  facet normal 0.242983 0 0.970031
+    outer loop
+      vertex 14.7074 -13.3698 8.52882
+      vertex 14.5646 -3.51404 8.56459
+      vertex 14.5646 -13.5273 8.56459
+    endloop
+  endfacet
+  facet normal -0.941527 0 -0.336939
+    outer loop
+      vertex 16.4354 -11.2053 10.4354
+      vertex 16.3858 0 10.574
+      vertex 16.4354 0 10.4354
+    endloop
+  endfacet
+  facet normal -0.941527 -0 -0.336939
+    outer loop
+      vertex 16.3858 0 10.574
+      vertex 16.4354 -11.2053 10.4354
+      vertex 16.3858 -11.2722 10.574
+    endloop
+  endfacet
+  facet normal -0.336939 -0 -0.941527
+    outer loop
+      vertex 15.4354 0 11.4354
+      vertex 15.574 -12.3667 11.3858
+      vertex 15.4354 -12.5536 11.4354
+    endloop
+  endfacet
+  facet normal -0.336939 0 -0.941527
+    outer loop
+      vertex 15.574 -12.3667 11.3858
+      vertex 15.4354 0 11.4354
+      vertex 15.574 0 11.3858
+    endloop
+  endfacet
+  facet normal 0.998803 0 0.048911
+    outer loop
+      vertex 13.5 -6.49759 10
+      vertex 13.5072 -14.5828 9.85297
+      vertex 13.5072 -6.48232 9.85297
+    endloop
+  endfacet
+  facet normal 0.998803 0 0.048911
+    outer loop
+      vertex 13.5072 -14.5828 9.85297
+      vertex 13.5 -6.49759 10
+      vertex 13.5 -14.5893 10
+    endloop
+  endfacet
+  facet normal 0.514096 0 -0.857733
+    outer loop
+      vertex 14.1666 -4.87819 11.2472
+      vertex 14.2929 -13.8271 11.3229
+      vertex 14.1666 -13.9664 11.2472
+    endloop
+  endfacet
+  facet normal 0.514096 0 -0.857733
+    outer loop
+      vertex 14.2929 -13.8271 11.3229
+      vertex 14.1666 -4.87819 11.2472
+      vertex 14.2929 -4.52531 11.3229
+    endloop
+  endfacet
+  facet normal -0.336879 0 0.941548
+    outer loop
+      vertex 15.4354 0 8.56459
+      vertex 15.574 -12.3667 8.61418
+      vertex 15.574 0 8.61418
+    endloop
+  endfacet
+  facet normal -0.336879 0 0.941548
+    outer loop
+      vertex 15.574 -12.3667 8.61418
+      vertex 15.4354 0 8.56459
+      vertex 15.4354 -12.5536 8.56459
+    endloop
+  endfacet
+  facet normal 0.80316 0 0.595764
+    outer loop
+      vertex 13.7528 -5.96309 9.16664
+      vertex 13.8405 -14.2807 9.04841
+      vertex 13.8405 -5.77769 9.04841
+    endloop
+  endfacet
+  facet normal 0.80316 0 0.595764
+    outer loop
+      vertex 13.8405 -14.2807 9.04841
+      vertex 13.7528 -5.96309 9.16664
+      vertex 13.7528 -14.3602 9.16664
+    endloop
+  endfacet
+  facet normal 0.904088 0 0.427347
+    outer loop
+      vertex 13.6142 -6.25617 9.42597
+      vertex 13.6771 -14.4288 9.2929
+      vertex 13.6771 -6.1231 9.2929
+    endloop
+  endfacet
+  facet normal 0.904088 0 0.427347
+    outer loop
+      vertex 13.6771 -14.4288 9.2929
+      vertex 13.6142 -6.25617 9.42597
+      vertex 13.6142 -14.4858 9.42597
+    endloop
+  endfacet
+  facet normal 0.243175 0 -0.969982
+    outer loop
+      vertex 14.5646 -3.51404 11.4354
+      vertex 14.7074 -13.3698 11.4712
+      vertex 14.5646 -13.5273 11.4354
+    endloop
+  endfacet
+  facet normal 0.243175 0 -0.969982
+    outer loop
+      vertex 14.7074 -13.3698 11.4712
+      vertex 14.5646 -3.51404 11.4354
+      vertex 14.7074 -2.94398 11.4712
+    endloop
+  endfacet
+  facet normal 0.857661 0 0.514216
+    outer loop
+      vertex 13.6771 -6.1231 9.2929
+      vertex 13.7528 -14.3602 9.16664
+      vertex 13.7528 -5.96309 9.16664
+    endloop
+  endfacet
+  facet normal 0.857661 0 0.514216
+    outer loop
+      vertex 13.7528 -14.3602 9.16664
+      vertex 13.6771 -6.1231 9.2929
+      vertex 13.6771 -14.4288 9.2929
+    endloop
+  endfacet
+  facet normal -0.904125 0 -0.427269
+    outer loop
+      vertex 16.3858 -11.2722 10.574
+      vertex 16.3229 0 10.7071
+      vertex 16.3858 0 10.574
+    endloop
+  endfacet
+  facet normal -0.904125 -0 -0.427269
+    outer loop
+      vertex 16.3229 0 10.7071
+      vertex 16.3858 -11.2722 10.574
+      vertex 16.3229 -11.357 10.7071
+    endloop
+  endfacet
+  facet normal 0.671251 0 -0.74123
+    outer loop
+      vertex 13.9393 -5.51346 11.0607
+      vertex 14.0484 -14.0923 11.1595
+      vertex 13.9393 -14.1911 11.0607
+    endloop
+  endfacet
+  facet normal 0.671251 0 -0.74123
+    outer loop
+      vertex 14.0484 -14.0923 11.1595
+      vertex 13.9393 -5.51346 11.0607
+      vertex 14.0484 -5.20863 11.1595
+    endloop
+  endfacet
+  facet normal 0.989176 0 0.146736
+    outer loop
+      vertex 13.5072 -6.48232 9.85297
+      vertex 13.5288 -14.5632 9.70736
+      vertex 13.5288 -6.43665 9.70736
+    endloop
+  endfacet
+  facet normal 0.989176 0 0.146736
+    outer loop
+      vertex 13.5288 -14.5632 9.70736
+      vertex 13.5072 -6.48232 9.85297
+      vertex 13.5072 -14.5828 9.85297
+    endloop
+  endfacet
+  facet normal 0.941527 0 0.336939
+    outer loop
+      vertex 13.5646 -6.36102 9.56457
+      vertex 13.6142 -14.4858 9.42597
+      vertex 13.6142 -6.25617 9.42597
+    endloop
+  endfacet
+  facet normal 0.941527 0 0.336939
+    outer loop
+      vertex 13.6142 -14.4858 9.42597
+      vertex 13.5646 -6.36102 9.56457
+      vertex 13.5646 -14.5308 9.56457
+    endloop
+  endfacet
+  facet normal -0.80316 0 0.595764
+    outer loop
+      vertex 16.1595 0 9.04841
+      vertex 16.2472 -11.4591 9.16664
+      vertex 16.2472 0 9.16664
+    endloop
+  endfacet
+  facet normal -0.80316 0 0.595764
+    outer loop
+      vertex 16.2472 -11.4591 9.16664
+      vertex 16.1595 0 9.04841
+      vertex 16.1595 -11.5773 9.04841
+    endloop
+  endfacet
+  facet normal -0.146746 -0 -0.989174
+    outer loop
+      vertex 15.147 0 11.4928
+      vertex 15.2926 -12.724 11.4712
+      vertex 15.147 -12.8847 11.4928
+    endloop
+  endfacet
+  facet normal -0.146746 0 -0.989174
+    outer loop
+      vertex 15.2926 -12.724 11.4712
+      vertex 15.147 0 11.4928
+      vertex 15.2926 0 11.4712
+    endloop
+  endfacet
+  facet normal -0.242983 0 0.970031
+    outer loop
+      vertex 15.2926 0 8.52882
+      vertex 15.4354 -12.5536 8.56459
+      vertex 15.4354 0 8.56459
+    endloop
+  endfacet
+  facet normal -0.242983 0 0.970031
+    outer loop
+      vertex 15.2926 -12.724 8.52882
+      vertex 15.4354 -12.5536 8.56459
+      vertex 15.2926 0 8.52882
+    endloop
+  endfacet
+  facet normal -0.241745 -0.00110266 0.970339
+    outer loop
+      vertex 15.4354 -12.5536 8.56459
+      vertex 15.2926 -12.724 8.52882
+      vertex 15.3829 -12.6244 8.55143
+    endloop
+  endfacet
+  facet normal -0.989176 0 0.146736
+    outer loop
+      vertex 16.4712 0 9.70736
+      vertex 16.4928 -11.1279 9.85297
+      vertex 16.4928 0 9.85297
+    endloop
+  endfacet
+  facet normal -0.989176 0 0.146736
+    outer loop
+      vertex 16.4928 -11.1279 9.85297
+      vertex 16.4712 0 9.70736
+      vertex 16.4712 -11.1571 9.70736
+    endloop
+  endfacet
+  facet normal -0.857661 0 0.514216
+    outer loop
+      vertex 16.2472 0 9.16664
+      vertex 16.3229 -11.357 9.2929
+      vertex 16.3229 0 9.2929
+    endloop
+  endfacet
+  facet normal -0.857661 0 0.514216
+    outer loop
+      vertex 16.3229 -11.357 9.2929
+      vertex 16.2472 0 9.16664
+      vertex 16.2472 -11.4591 9.16664
+    endloop
+  endfacet
+  facet normal -0.513996 0 0.857792
+    outer loop
+      vertex 15.7071 0 8.67712
+      vertex 15.8334 -12.0171 8.7528
+      vertex 15.8334 0 8.7528
+    endloop
+  endfacet
+  facet normal -0.513996 0 0.857792
+    outer loop
+      vertex 15.8334 -12.0171 8.7528
+      vertex 15.7071 0 8.67712
+      vertex 15.7071 -12.1873 8.67712
+    endloop
+  endfacet
+  facet normal 0.336879 0 0.941548
+    outer loop
+      vertex 14.426 -4.06735 8.61418
+      vertex 14.5646 -13.5273 8.56459
+      vertex 14.5646 -3.51404 8.56459
+    endloop
+  endfacet
+  facet normal 0.336879 0 0.941548
+    outer loop
+      vertex 14.5646 -13.5273 8.56459
+      vertex 14.426 -4.06735 8.61418
+      vertex 14.426 -13.6802 8.61418
+    endloop
+  endfacet
+  facet normal -0.427269 -0 -0.904125
+    outer loop
+      vertex 15.574 0 11.3858
+      vertex 15.7071 -12.1873 11.3229
+      vertex 15.574 -12.3667 11.3858
+    endloop
+  endfacet
+  facet normal -0.427269 0 -0.904125
+    outer loop
+      vertex 15.7071 -12.1873 11.3229
+      vertex 15.574 0 11.3858
+      vertex 15.7071 0 11.3229
+    endloop
+  endfacet
+  facet normal -0.671251 -0 -0.74123
+    outer loop
+      vertex 15.9516 0 11.1595
+      vertex 16.0607 -11.7106 11.0607
+      vertex 15.9516 -11.8576 11.1595
+    endloop
+  endfacet
+  facet normal -0.671251 0 -0.74123
+    outer loop
+      vertex 16.0607 -11.7106 11.0607
+      vertex 15.9516 0 11.1595
+      vertex 16.0607 0 11.0607
+    endloop
+  endfacet
+  facet normal 0.601148 -0.00774074 -0.7991
+    outer loop
+      vertex 14.0484 -14.0923 11.1595
+      vertex 14.1666 -13.9664 11.2472
+      vertex 14.0714 -14.0714 11.1766
+    endloop
+  endfacet
+  facet normal 0.595861 0 -0.803088
+    outer loop
+      vertex 14.1666 -13.9664 11.2472
+      vertex 14.0484 -14.0923 11.1595
+      vertex 14.0484 -5.20863 11.1595
+    endloop
+  endfacet
+  facet normal 0.595861 0 -0.803088
+    outer loop
+      vertex 14.1666 -13.9664 11.2472
+      vertex 14.0484 -5.20863 11.1595
+      vertex 14.1666 -4.87819 11.2472
+    endloop
+  endfacet
+  facet normal -0.803088 0 -0.595861
+    outer loop
+      vertex 16.2472 -11.4591 10.8334
+      vertex 16.1595 0 10.9516
+      vertex 16.2472 0 10.8334
+    endloop
+  endfacet
+  facet normal -0.803088 -0 -0.595861
+    outer loop
+      vertex 16.1595 0 10.9516
+      vertex 16.2472 -11.4591 10.8334
+      vertex 16.1595 -11.5773 10.9516
+    endloop
+  endfacet
+  facet normal 0.857733 0 -0.514096
+    outer loop
+      vertex 13.7528 -14.3602 10.8334
+      vertex 13.6771 -6.1231 10.7071
+      vertex 13.7528 -5.96309 10.8334
+    endloop
+  endfacet
+  facet normal 0.857733 0 -0.514096
+    outer loop
+      vertex 13.6771 -6.1231 10.7071
+      vertex 13.7528 -14.3602 10.8334
+      vertex 13.6771 -14.4288 10.7071
+    endloop
+  endfacet
+  facet normal -0.857733 0 -0.514096
+    outer loop
+      vertex 16.3229 -11.357 10.7071
+      vertex 16.2472 0 10.8334
+      vertex 16.3229 0 10.7071
+    endloop
+  endfacet
+  facet normal -0.857733 -0 -0.514096
+    outer loop
+      vertex 16.2472 0 10.8334
+      vertex 16.3229 -11.357 10.7071
+      vertex 16.2472 -11.4591 10.8334
+    endloop
+  endfacet
+  facet normal 0.595773 0 0.803153
+    outer loop
+      vertex 14.0484 -5.20863 8.84048
+      vertex 14.1666 -13.9664 8.7528
+      vertex 14.1666 -4.87819 8.7528
+    endloop
+  endfacet
+  facet normal 0.595773 -0 0.803153
+    outer loop
+      vertex 14.0484 -14.0923 8.84048
+      vertex 14.1666 -13.9664 8.7528
+      vertex 14.0484 -5.20863 8.84048
+    endloop
+  endfacet
+  facet normal 0.597111 -0.00195013 0.802156
+    outer loop
+      vertex 14.1666 -13.9664 8.7528
+      vertex 14.0484 -14.0923 8.84048
+      vertex 14.0714 -14.0714 8.82341
+    endloop
+  endfacet
+  facet normal 0.803088 0 -0.595861
+    outer loop
+      vertex 13.8405 -14.2807 10.9516
+      vertex 13.7528 -5.96309 10.8334
+      vertex 13.8405 -5.77769 10.9516
+    endloop
+  endfacet
+  facet normal 0.803088 0 -0.595861
+    outer loop
+      vertex 13.7528 -5.96309 10.8334
+      vertex 13.8405 -14.2807 10.9516
+      vertex 13.7528 -14.3602 10.8334
+    endloop
+  endfacet
+  facet normal 0.513996 0 0.857792
+    outer loop
+      vertex 14.1666 -4.87819 8.7528
+      vertex 14.2929 -13.8271 8.67712
+      vertex 14.2929 -4.52531 8.67712
+    endloop
+  endfacet
+  facet normal 0.513996 0 0.857792
+    outer loop
+      vertex 14.2929 -13.8271 8.67712
+      vertex 14.1666 -4.87819 8.7528
+      vertex 14.1666 -13.9664 8.7528
+    endloop
+  endfacet
+  facet normal -0.514096 -0 -0.857733
+    outer loop
+      vertex 15.7071 0 11.3229
+      vertex 15.8334 -12.0171 11.2472
+      vertex 15.7071 -12.1873 11.3229
+    endloop
+  endfacet
+  facet normal -0.514096 0 -0.857733
+    outer loop
+      vertex 15.8334 -12.0171 11.2472
+      vertex 15.7071 0 11.3229
+      vertex 15.8334 0 11.2472
+    endloop
+  endfacet
+  facet normal -0.595861 -0 -0.803088
+    outer loop
+      vertex 15.8334 0 11.2472
+      vertex 15.9516 -11.8576 11.1595
+      vertex 15.8334 -12.0171 11.2472
+    endloop
+  endfacet
+  facet normal -0.595861 0 -0.803088
+    outer loop
+      vertex 15.9516 -11.8576 11.1595
+      vertex 15.8334 0 11.2472
+      vertex 15.9516 0 11.1595
+    endloop
+  endfacet
+  facet normal -0.146746 0 0.989174
+    outer loop
+      vertex 15.147 0 8.50722
+      vertex 15.2926 -12.724 8.52882
+      vertex 15.2926 0 8.52882
+    endloop
+  endfacet
+  facet normal -0.146746 0 0.989174
+    outer loop
+      vertex 15.2926 -12.724 8.52882
+      vertex 15.147 0 8.50722
+      vertex 15.147 -12.8847 8.50722
+    endloop
+  endfacet
+  facet normal -0.969978 0 0.243191
+    outer loop
+      vertex 16.4354 0 9.56457
+      vertex 16.4712 -11.1571 9.70736
+      vertex 16.4712 0 9.70736
+    endloop
+  endfacet
+  facet normal -0.969978 0 0.243191
+    outer loop
+      vertex 16.4712 -11.1571 9.70736
+      vertex 16.4354 0 9.56457
+      vertex 16.4354 -11.2053 9.56457
+    endloop
+  endfacet
+  facet normal -0.941527 0 0.336939
+    outer loop
+      vertex 16.3858 0 9.42597
+      vertex 16.4354 -11.2053 9.56457
+      vertex 16.4354 0 9.56457
+    endloop
+  endfacet
+  facet normal -0.941527 0 0.336939
+    outer loop
+      vertex 16.4354 -11.2053 9.56457
+      vertex 16.3858 0 9.42597
+      vertex 16.3858 -11.2722 9.42597
+    endloop
+  endfacet
+  facet normal -0.74123 0 -0.671251
+    outer loop
+      vertex 16.1595 -11.5773 10.9516
+      vertex 16.0607 0 11.0607
+      vertex 16.1595 0 10.9516
+    endloop
+  endfacet
+  facet normal -0.74123 -0 -0.671251
+    outer loop
+      vertex 16.0607 0 11.0607
+      vertex 16.1595 -11.5773 10.9516
+      vertex 16.0607 -11.7106 11.0607
+    endloop
+  endfacet
+  facet normal 0.0484196 0 -0.998827
+    outer loop
+      vertex 15 -13.0469 11.5
+      vertex 14.9278 -1.47026 11.4965
+      vertex 15 0 11.5
+    endloop
+  endfacet
+  facet normal 0.0489209 0 -0.998803
+    outer loop
+      vertex 14.853 -1.97449 11.4928
+      vertex 15 -13.0469 11.5
+      vertex 14.853 -13.2091 11.4928
+    endloop
+  endfacet
+  facet normal 0.0493651 5.91074e-06 -0.998781
+    outer loop
+      vertex 15 -13.0469 11.5
+      vertex 14.853 -1.97449 11.4928
+      vertex 14.9278 -1.47026 11.4965
+    endloop
+  endfacet
+  facet normal -0.0489209 -0 -0.998803
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.147 -12.8847 11.4928
+      vertex 15 -13.0469 11.5
+    endloop
+  endfacet
+  facet normal -0.0489209 0 -0.998803
+    outer loop
+      vertex 15.147 -12.8847 11.4928
+      vertex 15 0 11.5
+      vertex 15.147 0 11.4928
+    endloop
+  endfacet
+  facet normal -0.671475 0 0.741027
+    outer loop
+      vertex 15.9516 0 8.84048
+      vertex 16.0607 -11.7106 8.93934
+      vertex 16.0607 0 8.93934
+    endloop
+  endfacet
+  facet normal -0.671475 0 0.741027
+    outer loop
+      vertex 16.0607 -11.7106 8.93934
+      vertex 15.9516 0 8.84048
+      vertex 15.9516 -11.8576 8.84048
+    endloop
+  endfacet
+  facet normal -0.998803 0 0.048911
+    outer loop
+      vertex 16.4928 0 9.85297
+      vertex 16.5 -11.1182 10
+      vertex 16.5 0 10
+    endloop
+  endfacet
+  facet normal -0.998803 0 0.048911
+    outer loop
+      vertex 16.5 -11.1182 10
+      vertex 16.4928 0 9.85297
+      vertex 16.4928 -11.1279 9.85297
+    endloop
+  endfacet
+  facet normal 0.0491096 0 0.998793
+    outer loop
+      vertex 14.9278 -1.47026 8.50355
+      vertex 15 -13.0469 8.5
+      vertex 15 0 8.5
+    endloop
+  endfacet
+  facet normal 0.0490094 -6.26506e-07 0.998798
+    outer loop
+      vertex 14.853 -1.97449 8.50722
+      vertex 15 -13.0469 8.5
+      vertex 14.9278 -1.47026 8.50355
+    endloop
+  endfacet
+  facet normal 0.0490565 0 0.998796
+    outer loop
+      vertex 15 -13.0469 8.5
+      vertex 14.853 -1.97449 8.50722
+      vertex 14.853 -13.2091 8.50722
+    endloop
+  endfacet
+  facet normal 0.741399 0 -0.671065
+    outer loop
+      vertex 13.9393 -14.1911 11.0607
+      vertex 13.8582 -5.74025 10.9711
+      vertex 13.9393 -5.51346 11.0607
+    endloop
+  endfacet
+  facet normal 0.740474 -1.96848e-05 -0.672085
+    outer loop
+      vertex 13.9393 -14.1911 11.0607
+      vertex 13.8405 -5.77769 10.9516
+      vertex 13.8582 -5.74025 10.9711
+    endloop
+  endfacet
+  facet normal 0.74123 0 -0.671251
+    outer loop
+      vertex 13.8405 -5.77769 10.9516
+      vertex 13.9393 -14.1911 11.0607
+      vertex 13.8405 -14.2807 10.9516
+    endloop
+  endfacet
+  facet normal 0.147107 0 -0.989121
+    outer loop
+      vertex 14.853 -13.2091 11.4928
+      vertex 14.7118 -2.92635 11.4718
+      vertex 14.853 -1.97449 11.4928
+    endloop
+  endfacet
+  facet normal 0.146746 0 -0.989174
+    outer loop
+      vertex 14.7074 -2.94398 11.4712
+      vertex 14.853 -13.2091 11.4928
+      vertex 14.7074 -13.3698 11.4712
+    endloop
+  endfacet
+  facet normal 0.13574 -0.000159404 -0.990744
+    outer loop
+      vertex 14.853 -13.2091 11.4928
+      vertex 14.7074 -2.94398 11.4712
+      vertex 14.7118 -2.92635 11.4718
+    endloop
+  endfacet
+  facet normal 0.336939 0 -0.941527
+    outer loop
+      vertex 14.426 -4.06735 11.3858
+      vertex 14.5646 -13.5273 11.4354
+      vertex 14.426 -13.6802 11.3858
+    endloop
+  endfacet
+  facet normal 0.336939 0 -0.941527
+    outer loop
+      vertex 14.5646 -13.5273 11.4354
+      vertex 14.426 -4.06735 11.3858
+      vertex 14.5646 -3.51404 11.4354
+    endloop
+  endfacet
+  facet normal 0.427492 0 -0.904019
+    outer loop
+      vertex 14.426 -13.6802 11.3858
+      vertex 14.3541 -4.35427 11.3518
+      vertex 14.426 -4.06735 11.3858
+    endloop
+  endfacet
+  facet normal 0.427269 0 -0.904125
+    outer loop
+      vertex 14.2929 -4.52531 11.3229
+      vertex 14.426 -13.6802 11.3858
+      vertex 14.2929 -13.8271 11.3229
+    endloop
+  endfacet
+  facet normal 0.427017 -4.4821e-06 -0.904244
+    outer loop
+      vertex 14.426 -13.6802 11.3858
+      vertex 14.2929 -4.52531 11.3229
+      vertex 14.3541 -4.35427 11.3518
+    endloop
+  endfacet
+  facet normal 0.904125 0 -0.427269
+    outer loop
+      vertex 13.6771 -14.4288 10.7071
+      vertex 13.6142 -6.25617 10.574
+      vertex 13.6771 -6.1231 10.7071
+    endloop
+  endfacet
+  facet normal 0.904125 0 -0.427269
+    outer loop
+      vertex 13.6142 -6.25617 10.574
+      vertex 13.6771 -14.4288 10.7071
+      vertex 13.6142 -14.4858 10.574
+    endloop
+  endfacet
+  facet normal 0.741138 0 0.671353
+    outer loop
+      vertex 13.8582 -5.74025 9.02887
+      vertex 13.9393 -14.1911 8.93934
+      vertex 13.9393 -5.51346 8.93934
+    endloop
+  endfacet
+  facet normal 0.74114 5.71862e-08 0.67135
+    outer loop
+      vertex 13.8405 -5.77769 9.04841
+      vertex 13.9393 -14.1911 8.93934
+      vertex 13.8582 -5.74025 9.02887
+    endloop
+  endfacet
+  facet normal 0.741138 0 0.671353
+    outer loop
+      vertex 13.9393 -14.1911 8.93934
+      vertex 13.8405 -5.77769 9.04841
+      vertex 13.8405 -14.2807 9.04841
+    endloop
+  endfacet
+  facet normal 0.671475 0 0.741027
+    outer loop
+      vertex 13.9393 -5.51346 8.93934
+      vertex 14.0484 -14.0923 8.84048
+      vertex 14.0484 -5.20863 8.84048
+    endloop
+  endfacet
+  facet normal 0.671475 0 0.741027
+    outer loop
+      vertex 14.0484 -14.0923 8.84048
+      vertex 13.9393 -5.51346 8.93934
+      vertex 13.9393 -14.1911 8.93934
+    endloop
+  endfacet
+  facet normal 0.989174 0 -0.146746
+    outer loop
+      vertex 13.5288 -14.5632 10.2926
+      vertex 13.5072 -6.48232 10.147
+      vertex 13.5288 -6.43665 10.2926
+    endloop
+  endfacet
+  facet normal 0.989174 0 -0.146746
+    outer loop
+      vertex 13.5072 -6.48232 10.147
+      vertex 13.5288 -14.5632 10.2926
+      vertex 13.5072 -14.5828 10.147
+    endloop
+  endfacet
+  facet normal 0.969982 0 -0.243175
+    outer loop
+      vertex 13.5646 -14.5308 10.4354
+      vertex 13.5288 -6.43665 10.2926
+      vertex 13.5646 -6.36102 10.4354
+    endloop
+  endfacet
+  facet normal 0.969982 0 -0.243175
+    outer loop
+      vertex 13.5288 -6.43665 10.2926
+      vertex 13.5646 -14.5308 10.4354
+      vertex 13.5288 -14.5632 10.2926
+    endloop
+  endfacet
+  facet normal 0.969978 0 0.243191
+    outer loop
+      vertex 13.5288 -6.43665 9.70736
+      vertex 13.5646 -14.5308 9.56457
+      vertex 13.5646 -6.36102 9.56457
+    endloop
+  endfacet
+  facet normal 0.969978 0 0.243191
+    outer loop
+      vertex 13.5646 -14.5308 9.56457
+      vertex 13.5288 -6.43665 9.70736
+      vertex 13.5288 -14.5632 9.70736
+    endloop
+  endfacet
+  facet normal 0.427389 0 0.904068
+    outer loop
+      vertex 14.3541 -4.35427 8.64817
+      vertex 14.426 -13.6802 8.61418
+      vertex 14.426 -4.06735 8.61418
+    endloop
+  endfacet
+  facet normal 0.427605 2.04191e-06 0.903965
+    outer loop
+      vertex 14.2929 -4.52531 8.67712
+      vertex 14.426 -13.6802 8.61418
+      vertex 14.3541 -4.35427 8.64817
+    endloop
+  endfacet
+  facet normal 0.427491 0 0.90402
+    outer loop
+      vertex 14.426 -13.6802 8.61418
+      vertex 14.2929 -4.52531 8.67712
+      vertex 14.2929 -13.8271 8.67712
+    endloop
+  endfacet
+  facet normal -0.427491 0 0.90402
+    outer loop
+      vertex 15.574 0 8.61418
+      vertex 15.7071 -12.1873 8.67712
+      vertex 15.7071 0 8.67712
+    endloop
+  endfacet
+  facet normal -0.427491 0 0.90402
+    outer loop
+      vertex 15.7071 -12.1873 8.67712
+      vertex 15.574 0 8.61418
+      vertex 15.574 -12.3667 8.61418
+    endloop
+  endfacet
+  facet normal -0.0490565 0 0.998796
+    outer loop
+      vertex 15 0 8.5
+      vertex 15.147 -12.8847 8.50722
+      vertex 15.147 0 8.50722
+    endloop
+  endfacet
+  facet normal -0.0490565 0 0.998796
+    outer loop
+      vertex 15.147 -12.8847 8.50722
+      vertex 15 0 8.5
+      vertex 15 -13.0469 8.5
+    endloop
+  endfacet
+  facet normal -0.904088 0 0.427347
+    outer loop
+      vertex 16.3229 0 9.2929
+      vertex 16.3858 -11.2722 9.42597
+      vertex 16.3858 0 9.42597
+    endloop
+  endfacet
+  facet normal -0.904088 0 0.427347
+    outer loop
+      vertex 16.3858 -11.2722 9.42597
+      vertex 16.3229 0 9.2929
+      vertex 16.3229 -11.357 9.2929
+    endloop
+  endfacet
+  facet normal 0.941527 0 -0.336939
+    outer loop
+      vertex 13.6142 -14.4858 10.574
+      vertex 13.5646 -6.36102 10.4354
+      vertex 13.6142 -6.25617 10.574
+    endloop
+  endfacet
+  facet normal 0.941527 0 -0.336939
+    outer loop
+      vertex 13.5646 -6.36102 10.4354
+      vertex 13.6142 -14.4858 10.574
+      vertex 13.5646 -14.5308 10.4354
+    endloop
+  endfacet
+  facet normal -0.238055 -0.00455488 -0.971241
+    outer loop
+      vertex 15.2926 -12.724 11.4712
+      vertex 15.4354 -12.5536 11.4354
+      vertex 15.3829 -12.6244 11.4486
+    endloop
+  endfacet
+  facet normal -0.243175 0 -0.969982
+    outer loop
+      vertex 15.4354 -12.5536 11.4354
+      vertex 15.2926 -12.724 11.4712
+      vertex 15.2926 0 11.4712
+    endloop
+  endfacet
+  facet normal -0.243175 0 -0.969982
+    outer loop
+      vertex 15.4354 -12.5536 11.4354
+      vertex 15.2926 0 11.4712
+      vertex 15.4354 0 11.4354
+    endloop
+  endfacet
+  facet normal -0.595773 0 0.803153
+    outer loop
+      vertex 15.8334 0 8.7528
+      vertex 15.9516 -11.8576 8.84048
+      vertex 15.9516 0 8.84048
+    endloop
+  endfacet
+  facet normal -0.595773 0 0.803153
+    outer loop
+      vertex 15.9516 -11.8576 8.84048
+      vertex 15.8334 0 8.7528
+      vertex 15.8334 -12.0171 8.7528
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.2926 0 11.4712
+      vertex 15.147 0 11.4928
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.4354 0 11.4354
+      vertex 15.2926 0 11.4712
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.574 0 11.3858
+      vertex 15.4354 0 11.4354
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.7071 0 11.3229
+      vertex 15.574 0 11.3858
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.8334 0 11.2472
+      vertex 15.7071 0 11.3229
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.9516 0 11.1595
+      vertex 15.8334 0 11.2472
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.0607 0 11.0607
+      vertex 15.9516 0 11.1595
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.1595 0 10.9516
+      vertex 16.0607 0 11.0607
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.2472 0 10.8334
+      vertex 16.1595 0 10.9516
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.3229 0 10.7071
+      vertex 16.2472 0 10.8334
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.3858 0 10.574
+      vertex 16.3229 0 10.7071
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.4354 0 10.4354
+      vertex 16.3858 0 10.574
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.4712 0 10.2926
+      vertex 16.4354 0 10.4354
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.4928 0 10.147
+      vertex 16.4712 0 10.2926
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.5 0 10
+      vertex 16.4928 0 10.147
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.4928 0 9.85297
+      vertex 16.5 0 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.4712 0 9.70736
+      vertex 16.4928 0 9.85297
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.4354 0 9.56457
+      vertex 16.4712 0 9.70736
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.3858 0 9.42597
+      vertex 16.4354 0 9.56457
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.3229 0 9.2929
+      vertex 16.3858 0 9.42597
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.2472 0 9.16664
+      vertex 16.3229 0 9.2929
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.1595 0 9.04841
+      vertex 16.2472 0 9.16664
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 16.0607 0 8.93934
+      vertex 16.1595 0 9.04841
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.9516 0 8.84048
+      vertex 16.0607 0 8.93934
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.8334 0 8.7528
+      vertex 15.9516 0 8.84048
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.7071 0 8.67712
+      vertex 15.8334 0 8.7528
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.574 0 8.61418
+      vertex 15.7071 0 8.67712
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.4354 0 8.56459
+      vertex 15.574 0 8.61418
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.2926 0 8.52882
+      vertex 15.4354 0 8.56459
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15 0 11.5
+      vertex 15.147 0 8.50722
+      vertex 15.2926 0 8.52882
+    endloop
+  endfacet
+  facet normal -0 -1 0
+    outer loop
+      vertex 15.147 0 8.50722
+      vertex 15 0 11.5
+      vertex 15 0 8.5
+    endloop
+  endfacet
+  facet normal 0.146764 0 0.989171
+    outer loop
+      vertex 14.7118 -2.92635 8.52817
+      vertex 14.853 -13.2091 8.50722
+      vertex 14.853 -1.97449 8.50722
+    endloop
+  endfacet
+  facet normal 0.146174 -8.28986e-06 0.989259
+    outer loop
+      vertex 14.7074 -2.94398 8.52882
+      vertex 14.853 -13.2091 8.50722
+      vertex 14.7118 -2.92635 8.52817
+    endloop
+  endfacet
+  facet normal 0.146746 0 0.989174
+    outer loop
+      vertex 14.853 -13.2091 8.50722
+      vertex 14.7074 -2.94398 8.52882
+      vertex 14.7074 -13.3698 8.52882
+    endloop
+  endfacet
+  facet normal 0.998803 0 -0.0489209
+    outer loop
+      vertex 13.5072 -14.5828 10.147
+      vertex 13.5 -6.49759 10
+      vertex 13.5072 -6.48232 10.147
+    endloop
+  endfacet
+  facet normal 0.998803 0 -0.0489209
+    outer loop
+      vertex 13.5 -6.49759 10
+      vertex 13.5072 -14.5828 10.147
+      vertex 13.5 -14.5893 10
+    endloop
+  endfacet
+  facet normal -0.741138 0 0.671353
+    outer loop
+      vertex 16.0607 0 8.93934
+      vertex 16.1595 -11.5773 9.04841
+      vertex 16.1595 0 9.04841
+    endloop
+  endfacet
+  facet normal -0.741138 0 0.671353
+    outer loop
+      vertex 16.1595 -11.5773 9.04841
+      vertex 16.0607 0 8.93934
+      vertex 16.0607 -11.7106 8.93934
+    endloop
+  endfacet
+  facet normal -0.308654 -0.949936 -0.0485192
+    outer loop
+      vertex 15.6535 12.2596 10.0654
+      vertex 15.6576 12.2541 10.147
+      vertex 5.09655 15.6856 10.147
+    endloop
+  endfacet
+  facet normal 0.299737 0.922466 0.243339
+    outer loop
+      vertex 18.0088 8.41124 9.56457
+      vertex 10.2898 10.8938 9.66153
+      vertex 18.0145 8.3991 9.60357
+    endloop
+  endfacet
+  facet normal 0.29978 0.922626 0.242679
+    outer loop
+      vertex 10.2898 10.8938 9.66153
+      vertex 18.0088 8.41124 9.56457
+      vertex 10.2458 10.9336 9.56457
+    endloop
+  endfacet
+  facet normal -0.290932 -0.895396 -0.337083
+    outer loop
+      vertex 15.7165 12.1746 10.4354
+      vertex 5.0635 15.5838 10.574
+      vertex 5.07882 15.631 10.4354
+    endloop
+  endfacet
+  facet normal -0.290938 -0.895417 -0.337021
+    outer loop
+      vertex 5.0635 15.5838 10.574
+      vertex 15.7165 12.1746 10.4354
+      vertex 15.7389 12.1444 10.4963
+    endloop
+  endfacet
+  facet normal -0.308646 -0.949933 -0.0486247
+    outer loop
+      vertex 15.6502 12.2641 10
+      vertex 5.09655 15.6856 10.147
+      vertex 5.09878 15.6924 10
+    endloop
+  endfacet
+  facet normal -0.308643 -0.949874 -0.0497846
+    outer loop
+      vertex 5.09655 15.6856 10.147
+      vertex 15.6502 12.2641 10
+      vertex 15.6535 12.2596 10.0654
+    endloop
+  endfacet
+  facet normal 0.0150718 0.0463868 -0.99881
+    outer loop
+      vertex 6.45606 13.5196 11.4928
+      vertex 17.0773 10.1698 11.4975
+      vertex 17.1527 10.0441 11.4928
+    endloop
+  endfacet
+  facet normal 0.0136476 0.0418707 -0.99903
+    outer loop
+      vertex 17.0773 10.1698 11.4975
+      vertex 6.45606 13.5196 11.4928
+      vertex 6.35916 13.5655 11.4934
+    endloop
+  endfacet
+  facet normal -0.184022 -0.56636 0.803351
+    outer loop
+      vertex 4.89278 15.0584 8.7528
+      vertex 16.2136 11.5044 8.84048
+      vertex 4.92931 15.1709 8.84048
+    endloop
+  endfacet
+  facet normal -0.184064 -0.566497 0.803244
+    outer loop
+      vertex 16.2136 11.5044 8.84048
+      vertex 4.89278 15.0584 8.7528
+      vertex 16.3351 11.3406 8.7528
+    endloop
+  endfacet
+  facet normal -0.0151496 -0.0466256 0.998798
+    outer loop
+      vertex 4.63525 14.2658 8.5
+      vertex 16.9225 10.4281 8.50722
+      vertex 4.68069 14.4057 8.50722
+    endloop
+  endfacet
+  facet normal -0.0151362 -0.046583 0.9988
+    outer loop
+      vertex 16.9225 10.4281 8.50722
+      vertex 4.63525 14.2658 8.5
+      vertex 16.9632 10.3602 8.50467
+    endloop
+  endfacet
+  facet normal 0.951079 -0.308949 -3.22779e-05
+    outer loop
+      vertex 5.07882 15.631 9.56457
+      vertex 5.09878 15.6924 10
+      vertex 5.02066 15.452 9.16664
+    endloop
+  endfacet
+  facet normal 0.951046 -0.30905 0
+    outer loop
+      vertex 5.09878 15.6924 10
+      vertex 5.02066 15.452 10.8334
+      vertex 5.02066 15.452 9.16664
+    endloop
+  endfacet
+  facet normal -0.0453206 -0.139482 0.989187
+    outer loop
+      vertex 16.8816 10.4964 8.51499
+      vertex 16.8086 10.6182 8.52882
+      vertex 4.72568 14.5442 8.52882
+    endloop
+  endfacet
+  facet normal 0.950886 -0.309539 -0.000454055
+    outer loop
+      vertex 5.02066 15.452 10.8334
+      vertex 4.96302 15.2746 11.0607
+      vertex 4.92931 15.1709 11.1595
+    endloop
+  endfacet
+  facet normal 0.951067 -0.308984 2.67876e-05
+    outer loop
+      vertex 5.09878 15.6924 10
+      vertex 5.08987 15.665 10.2926
+      vertex 5.07882 15.631 10.4354
+    endloop
+  endfacet
+  facet normal 0.950371 -0.311117 -0.000902065
+    outer loop
+      vertex 5.07882 15.631 10.4354
+      vertex 5.0635 15.5838 10.574
+      vertex 5.04405 15.524 10.7071
+    endloop
+  endfacet
+  facet normal 0.951065 -0.308991 -5.59484e-05
+    outer loop
+      vertex 4.63168 14.2548 8.7848
+      vertex 4.76981 14.68 8.56459
+      vertex 5.02066 15.452 9.16664
+    endloop
+  endfacet
+  facet normal 0.951074 -0.308965 0
+    outer loop
+      vertex 4.76981 14.68 8.56459
+      vertex 4.63168 14.2548 8.7848
+      vertex 4.63168 14.2548 8.58655
+    endloop
+  endfacet
+  facet normal -0.308646 -0.949934 0.0486148
+    outer loop
+      vertex 5.09655 15.6856 9.85297
+      vertex 15.6502 12.2641 10
+      vertex 5.09878 15.6924 10
+    endloop
+  endfacet
+  facet normal -0.308643 -0.949875 0.0497618
+    outer loop
+      vertex 15.6502 12.2641 10
+      vertex 5.09655 15.6856 9.85297
+      vertex 15.6535 12.2596 9.93457
+    endloop
+  endfacet
+  facet normal 0.951074 -0.308963 -9.52119e-05
+    outer loop
+      vertex 4.92931 15.1709 8.84048
+      vertex 5.02066 15.452 9.16664
+      vertex 4.76981 14.68 8.56459
+    endloop
+  endfacet
+  facet normal -0.104112 -0.320422 0.941536
+    outer loop
+      vertex 4.76981 14.68 8.56459
+      vertex 16.656 10.8727 8.58323
+      vertex 4.81264 14.8118 8.61418
+    endloop
+  endfacet
+  facet normal -0.103995 -0.320056 0.941674
+    outer loop
+      vertex 16.656 10.8727 8.58323
+      vertex 4.76981 14.68 8.56459
+      vertex 16.6968 10.8046 8.56459
+    endloop
+  endfacet
+  facet normal 0.950938 -0.30938 0.000724418
+    outer loop
+      vertex 4.85376 14.9383 8.67712
+      vertex 4.92931 15.1709 8.84048
+      vertex 4.76981 14.68 8.56459
+    endloop
+  endfacet
+  facet normal -0.248196 -0.763874 0.595731
+    outer loop
+      vertex 4.99356 15.3686 9.04841
+      vertex 15.9099 11.9139 9.16664
+      vertex 5.02066 15.452 9.16664
+    endloop
+  endfacet
+  facet normal -0.248178 -0.763817 0.595812
+    outer loop
+      vertex 15.9099 11.9139 9.16664
+      vertex 4.99356 15.3686 9.04841
+      vertex 16 11.7924 9.04841
+    endloop
+  endfacet
+  facet normal 0.0452418 0.139238 -0.989225
+    outer loop
+      vertex 7.29711 13.0933 11.4712
+      vertex 17.2286 9.91747 11.4784
+      vertex 17.2666 9.85397 11.4712
+    endloop
+  endfacet
+  facet normal 0.0451002 0.138795 -0.989294
+    outer loop
+      vertex 7.07095 13.2288 11.4799
+      vertex 17.2286 9.91747 11.4784
+      vertex 7.29711 13.0933 11.4712
+    endloop
+  endfacet
+  facet normal 0.0453394 0.139529 -0.989179
+    outer loop
+      vertex 17.2286 9.91747 11.4784
+      vertex 7.07095 13.2288 11.4799
+      vertex 6.56363 13.4688 11.4905
+    endloop
+  endfacet
+  facet normal 0.265158 0.816109 -0.513476
+    outer loop
+      vertex 10.0008 11.1556 10.7454
+      vertex 17.8982 8.64506 10.8334
+      vertex 17.9107 8.6186 10.7978
+    endloop
+  endfacet
+  facet normal 0.264971 0.815481 -0.514569
+    outer loop
+      vertex 17.8982 8.64506 10.8334
+      vertex 10.0008 11.1556 10.7454
+      vertex 9.90548 11.2421 10.8334
+    endloop
+  endfacet
+  facet normal -0.279395 -0.859877 -0.42726
+    outer loop
+      vertex 5.04405 15.524 10.7071
+      vertex 15.804 12.0566 10.6492
+      vertex 15.8321 12.0187 10.7071
+    endloop
+  endfacet
+  facet normal -0.279406 -0.859914 -0.427177
+    outer loop
+      vertex 15.804 12.0566 10.6492
+      vertex 5.04405 15.524 10.7071
+      vertex 5.0635 15.5838 10.574
+    endloop
+  endfacet
+  facet normal 0.95113 -0.308789 0.000111652
+    outer loop
+      vertex 5.07882 15.631 10.4354
+      vertex 5.04405 15.524 10.7071
+      vertex 5.02066 15.452 10.8334
+    endloop
+  endfacet
+  facet normal -0.103797 -0.319446 -0.941903
+    outer loop
+      vertex 4.76981 14.68 11.4354
+      vertex 16.656 10.8727 11.4168
+      vertex 16.6968 10.8046 11.4354
+    endloop
+  endfacet
+  facet normal -0.104127 -0.320481 -0.941515
+    outer loop
+      vertex 16.656 10.8727 11.4168
+      vertex 4.76981 14.68 11.4354
+      vertex 4.81264 14.8118 11.3858
+    endloop
+  endfacet
+  facet normal -0.13447 -0.407466 -0.903266
+    outer loop
+      vertex 16.5883 10.9856 11.3858
+      vertex 16.5176 11.0945 11.3472
+      vertex 16.5462 11.0558 11.3604
+    endloop
+  endfacet
+  facet normal -0.131979 -0.406184 -0.90421
+    outer loop
+      vertex 16.5176 11.0945 11.3472
+      vertex 16.5883 10.9856 11.3858
+      vertex 4.81264 14.8118 11.3858
+    endloop
+  endfacet
+  facet normal 0.951067 -0.308984 -2.67804e-05
+    outer loop
+      vertex 5.08987 15.665 9.70736
+      vertex 5.09878 15.6924 10
+      vertex 5.07882 15.631 9.56457
+    endloop
+  endfacet
+  facet normal -0.299758 -0.922582 0.242875
+    outer loop
+      vertex 5.07882 15.631 9.56457
+      vertex 15.6798 12.2242 9.70736
+      vertex 5.08987 15.665 9.70736
+    endloop
+  endfacet
+  facet normal -0.299725 -0.922456 0.243392
+    outer loop
+      vertex 15.6798 12.2242 9.70736
+      vertex 5.07882 15.631 9.56457
+      vertex 15.7165 12.1746 9.56457
+    endloop
+  endfacet
+  facet normal -0.279286 -0.859564 -0.42796
+    outer loop
+      vertex 15.7675 12.1059 10.574
+      vertex 15.804 12.0566 10.6492
+      vertex 5.0635 15.5838 10.574
+    endloop
+  endfacet
+  facet normal -0.279394 -0.859879 0.427256
+    outer loop
+      vertex 5.04405 15.524 9.2929
+      vertex 15.804 12.0566 9.35076
+      vertex 5.0635 15.5838 9.42597
+    endloop
+  endfacet
+  facet normal -0.27936 -0.859768 0.427501
+    outer loop
+      vertex 15.804 12.0566 9.35076
+      vertex 5.04405 15.524 9.2929
+      vertex 15.8321 12.0187 9.2929
+    endloop
+  endfacet
+  facet normal 0.950844 -0.309667 0.00117749
+    outer loop
+      vertex 4.89278 15.0584 8.7528
+      vertex 4.92931 15.1709 8.84048
+      vertex 4.85376 14.9383 8.67712
+    endloop
+  endfacet
+  facet normal 0.951129 -0.308794 -0.000762368
+    outer loop
+      vertex 4.81264 14.8118 8.61418
+      vertex 4.85376 14.9383 8.67712
+      vertex 4.76981 14.68 8.56459
+    endloop
+  endfacet
+  facet normal 0.308646 0.949929 0.0487045
+    outer loop
+      vertex 18.0456 8.33342 9.96021
+      vertex 10.3626 10.8277 10
+      vertex 18.0468 8.33099 10
+    endloop
+  endfacet
+  facet normal 0.308641 0.949905 0.049201
+    outer loop
+      vertex 10.3626 10.8277 10
+      vertex 18.0456 8.33342 9.96021
+      vertex 10.3538 10.8357 9.90075
+    endloop
+  endfacet
+  facet normal -0.290932 -0.895396 0.337083
+    outer loop
+      vertex 5.0635 15.5838 9.42597
+      vertex 15.7165 12.1746 9.56457
+      vertex 5.07882 15.631 9.56457
+    endloop
+  endfacet
+  facet normal -0.290924 -0.895367 0.337167
+    outer loop
+      vertex 15.7165 12.1746 9.56457
+      vertex 5.0635 15.5838 9.42597
+      vertex 15.7389 12.1444 9.5037
+    endloop
+  endfacet
+  facet normal 0.95113 -0.30879 -0.000111613
+    outer loop
+      vertex 5.04405 15.524 9.2929
+      vertex 5.07882 15.631 9.56457
+      vertex 5.02066 15.452 9.16664
+    endloop
+  endfacet
+  facet normal 0.308643 0.94991 0.0490966
+    outer loop
+      vertex 18.0425 8.33997 9.85297
+      vertex 10.3538 10.8357 9.90075
+      vertex 18.0456 8.33342 9.96021
+    endloop
+  endfacet
+  facet normal 0.30863 0.949846 0.0504008
+    outer loop
+      vertex 10.3538 10.8357 9.90075
+      vertex 18.0425 8.33997 9.85297
+      vertex 10.3496 10.8396 9.85297
+    endloop
+  endfacet
+  facet normal 0.951734 -0.306924 -0.000239956
+    outer loop
+      vertex 5.09655 15.6856 9.85297
+      vertex 5.09878 15.6924 10
+      vertex 5.08987 15.665 9.70736
+    endloop
+  endfacet
+  facet normal 0.104109 0.320416 -0.941539
+    outer loop
+      vertex 8.36094 12.4517 11.3858
+      vertex 17.3784 9.66752 11.4354
+      vertex 17.4868 9.48655 11.3858
+    endloop
+  endfacet
+  facet normal 0.104547 0.321845 -0.941003
+    outer loop
+      vertex 8.33355 12.472 11.3897
+      vertex 17.3784 9.66752 11.4354
+      vertex 8.36094 12.4517 11.3858
+    endloop
+  endfacet
+  facet normal 0.104043 0.320209 -0.941616
+    outer loop
+      vertex 17.3784 9.66752 11.4354
+      vertex 8.33355 12.472 11.3897
+      vertex 7.84416 12.7654 11.4354
+    endloop
+  endfacet
+  facet normal 0.265047 0.815743 -0.514114
+    outer loop
+      vertex 10.0423 11.118 10.7071
+      vertex 17.9107 8.6186 10.7978
+      vertex 17.9427 8.55104 10.7071
+    endloop
+  endfacet
+  facet normal 0.265106 0.81594 -0.513771
+    outer loop
+      vertex 17.9107 8.6186 10.7978
+      vertex 10.0423 11.118 10.7071
+      vertex 10.0008 11.1556 10.7454
+    endloop
+  endfacet
+  facet normal 0.0753846 0.232038 -0.969781
+    outer loop
+      vertex 7.7509 12.8213 11.4415
+      vertex 17.2666 9.85397 11.4712
+      vertex 17.3033 9.79273 11.4594
+    endloop
+  endfacet
+  facet normal 0.0751532 0.231294 -0.969977
+    outer loop
+      vertex 17.2666 9.85397 11.4712
+      vertex 7.7509 12.8213 11.4415
+      vertex 7.29711 13.0933 11.4712
+    endloop
+  endfacet
+  facet normal -0.229014 -0.704834 -0.671388
+    outer loop
+      vertex 16 11.7924 10.9516
+      vertex 4.96302 15.2746 11.0607
+      vertex 4.99356 15.3686 10.9516
+    endloop
+  endfacet
+  facet normal -0.229016 -0.704841 -0.67138
+    outer loop
+      vertex 4.96302 15.2746 11.0607
+      vertex 16 11.7924 10.9516
+      vertex 16.1015 11.6555 11.0607
+    endloop
+  endfacet
+  facet normal 0.951129 -0.308793 0.00076484
+    outer loop
+      vertex 4.85376 14.9383 11.3229
+      vertex 4.81264 14.8118 11.3858
+      vertex 4.76981 14.68 11.4354
+    endloop
+  endfacet
+  facet normal 0.951074 -0.308963 9.52491e-05
+    outer loop
+      vertex 5.02066 15.452 10.8334
+      vertex 4.92931 15.1709 11.1595
+      vertex 4.76981 14.68 11.4354
+    endloop
+  endfacet
+  facet normal 0.950938 -0.309379 -0.000723637
+    outer loop
+      vertex 4.92931 15.1709 11.1595
+      vertex 4.85376 14.9383 11.3229
+      vertex 4.76981 14.68 11.4354
+    endloop
+  endfacet
+  facet normal 0.951079 -0.308949 3.22837e-05
+    outer loop
+      vertex 5.09878 15.6924 10
+      vertex 5.07882 15.631 10.4354
+      vertex 5.02066 15.452 10.8334
+    endloop
+  endfacet
+  facet normal 0.951734 -0.306924 0.000240021
+    outer loop
+      vertex 5.09878 15.6924 10
+      vertex 5.09655 15.6856 10.147
+      vertex 5.08987 15.665 10.2926
+    endloop
+  endfacet
+  facet normal 0.299766 0.922568 0.242919
+    outer loop
+      vertex 18.0145 8.3991 9.60357
+      vertex 10.3105 10.875 9.70736
+      vertex 18.0298 8.3668 9.70736
+    endloop
+  endfacet
+  facet normal 0.299758 0.922537 0.243044
+    outer loop
+      vertex 10.3105 10.875 9.70736
+      vertex 18.0145 8.3991 9.60357
+      vertex 10.2898 10.8938 9.66153
+    endloop
+  endfacet
+  facet normal -0.0453402 -0.139541 0.989178
+    outer loop
+      vertex 4.68069 14.4057 8.50722
+      vertex 16.8816 10.4964 8.51499
+      vertex 4.72568 14.5442 8.52882
+    endloop
+  endfacet
+  facet normal -0.0453953 -0.139713 0.989151
+    outer loop
+      vertex 16.8816 10.4964 8.51499
+      vertex 4.68069 14.4057 8.50722
+      vertex 16.9225 10.4281 8.50722
+    endloop
+  endfacet
+  facet normal -0.136355 -0.408792 0.902384
+    outer loop
+      vertex 16.5176 11.0945 8.65283
+      vertex 16.5883 10.9856 8.61418
+      vertex 16.5462 11.0558 8.63962
+    endloop
+  endfacet
+  facet normal -0.132119 -0.406614 0.903996
+    outer loop
+      vertex 16.5883 10.9856 8.61418
+      vertex 16.5176 11.0945 8.65283
+      vertex 4.81264 14.8118 8.61418
+    endloop
+  endfacet
+  facet normal -0.132169 -0.40678 0.903915
+    outer loop
+      vertex 4.81264 14.8118 8.61418
+      vertex 16.4648 11.1657 8.67712
+      vertex 4.85376 14.9383 8.67712
+    endloop
+  endfacet
+  facet normal -0.132038 -0.406359 0.904123
+    outer loop
+      vertex 16.4648 11.1657 8.67712
+      vertex 4.81264 14.8118 8.61418
+      vertex 16.5176 11.0945 8.65283
+    endloop
+  endfacet
+  facet normal -0.158851 -0.488898 0.857756
+    outer loop
+      vertex 4.85376 14.9383 8.67712
+      vertex 16.3351 11.3406 8.7528
+      vertex 4.89278 15.0584 8.7528
+    endloop
+  endfacet
+  facet normal -0.158868 -0.488951 0.857722
+    outer loop
+      vertex 16.3351 11.3406 8.7528
+      vertex 4.85376 14.9383 8.67712
+      vertex 16.4648 11.1657 8.67712
+    endloop
+  endfacet
+  facet normal 0.95106 -0.309007 0
+    outer loop
+      vertex 4.63168 14.2548 11.2152
+      vertex 5.02066 15.452 9.16664
+      vertex 5.02066 15.452 10.8334
+    endloop
+  endfacet
+  facet normal 0.95106 -0.309007 0
+    outer loop
+      vertex 5.02066 15.452 9.16664
+      vertex 4.63168 14.2548 11.2152
+      vertex 4.63168 14.2548 8.7848
+    endloop
+  endfacet
+  facet normal -0.308654 -0.949936 0.0485192
+    outer loop
+      vertex 15.6576 12.2541 9.85297
+      vertex 15.6535 12.2596 9.93457
+      vertex 5.09655 15.6856 9.85297
+    endloop
+  endfacet
+  facet normal -0.265031 -0.815671 0.514236
+    outer loop
+      vertex 5.02066 15.452 9.16664
+      vertex 15.8321 12.0187 9.2929
+      vertex 5.04405 15.524 9.2929
+    endloop
+  endfacet
+  facet normal -0.265095 -0.815885 0.513863
+    outer loop
+      vertex 15.8321 12.0187 9.2929
+      vertex 5.02066 15.452 9.16664
+      vertex 15.9099 11.9139 9.16664
+    endloop
+  endfacet
+  facet normal 0.950372 -0.311115 0.000901429
+    outer loop
+      vertex 5.0635 15.5838 9.42597
+      vertex 5.07882 15.631 9.56457
+      vertex 5.04405 15.524 9.2929
+    endloop
+  endfacet
+  facet normal -0.305659 -0.940708 0.147108
+    outer loop
+      vertex 5.08987 15.665 9.70736
+      vertex 15.6699 12.2374 9.77201
+      vertex 5.09655 15.6856 9.85297
+    endloop
+  endfacet
+  facet normal -0.305731 -0.940965 0.145305
+    outer loop
+      vertex 15.6699 12.2374 9.77201
+      vertex 5.08987 15.665 9.70736
+      vertex 15.6798 12.2242 9.70736
+    endloop
+  endfacet
+  facet normal -0.305633 -0.94064 0.147596
+    outer loop
+      vertex 15.6699 12.2374 9.77201
+      vertex 15.6576 12.2541 9.85297
+      vertex 5.09655 15.6856 9.85297
+    endloop
+  endfacet
+  facet normal 0.30568 0.940766 -0.146694
+    outer loop
+      vertex 10.3496 10.8396 10.147
+      vertex 18.0298 8.3668 10.2926
+      vertex 18.0425 8.33997 10.147
+    endloop
+  endfacet
+  facet normal 0.305682 0.940773 -0.146643
+    outer loop
+      vertex 18.0298 8.3668 10.2926
+      vertex 10.3496 10.8396 10.147
+      vertex 10.3105 10.875 10.2926
+    endloop
+  endfacet
+  facet normal 0.308629 0.949842 -0.0504851
+    outer loop
+      vertex 18.0425 8.33997 10.147
+      vertex 10.3538 10.8357 10.0993
+      vertex 10.3496 10.8396 10.147
+    endloop
+  endfacet
+  facet normal 0.308643 0.949909 -0.0491149
+    outer loop
+      vertex 10.3538 10.8357 10.0993
+      vertex 18.0425 8.33997 10.147
+      vertex 18.0456 8.33342 10.0398
+    endloop
+  endfacet
+  facet normal 0.27958 0.86047 -0.425943
+    outer loop
+      vertex 17.9427 8.55104 10.7071
+      vertex 10.0774 11.0863 10.6661
+      vertex 10.0423 11.118 10.7071
+    endloop
+  endfacet
+  facet normal 0.279319 0.859632 -0.4278
+    outer loop
+      vertex 10.0774 11.0863 10.6661
+      vertex 17.9427 8.55104 10.7071
+      vertex 17.9694 8.49449 10.6109
+    endloop
+  endfacet
+  facet normal 0.0453938 0.139692 -0.989154
+    outer loop
+      vertex 6.56363 13.4688 11.4905
+      vertex 17.1527 10.0441 11.4928
+      vertex 17.2286 9.91747 11.4784
+    endloop
+  endfacet
+  facet normal 0.0466124 0.14346 -0.988558
+    outer loop
+      vertex 17.1527 10.0441 11.4928
+      vertex 6.56363 13.4688 11.4905
+      vertex 6.45606 13.5196 11.4928
+    endloop
+  endfacet
+  facet normal 0.248101 0.763561 -0.596172
+    outer loop
+      vertex 9.90548 11.2421 10.8334
+      vertex 17.8836 8.67596 10.8669
+      vertex 17.8982 8.64506 10.8334
+    endloop
+  endfacet
+  facet normal 0.248319 0.764254 -0.595192
+    outer loop
+      vertex 17.8836 8.67596 10.8669
+      vertex 9.90548 11.2421 10.8334
+      vertex 9.79296 11.344 10.9173
+    endloop
+  endfacet
+  facet normal -0.0455668 -0.14024 -0.989068
+    outer loop
+      vertex 4.68069 14.4057 11.4928
+      vertex 16.8816 10.4964 11.485
+      vertex 16.9225 10.4281 11.4928
+    endloop
+  endfacet
+  facet normal -0.0453424 -0.13954 -0.989178
+    outer loop
+      vertex 16.8816 10.4964 11.485
+      vertex 4.68069 14.4057 11.4928
+      vertex 4.72568 14.5442 11.4712
+    endloop
+  endfacet
+  facet normal -0.0152636 -0.0469772 -0.998779
+    outer loop
+      vertex 16.9632 10.3602 11.4953
+      vertex 17.0376 10.2361 11.5
+      vertex 4.63525 14.2658 11.5
+    endloop
+  endfacet
+  facet normal -0.0148523 -0.045679 -0.998846
+    outer loop
+      vertex 4.63525 14.2658 11.5
+      vertex 16.9225 10.4281 11.4928
+      vertex 16.9632 10.3602 11.4953
+    endloop
+  endfacet
+  facet normal -0.0151077 -0.0464968 -0.998804
+    outer loop
+      vertex 16.9225 10.4281 11.4928
+      vertex 4.63525 14.2658 11.5
+      vertex 4.68069 14.4057 11.4928
+    endloop
+  endfacet
+  facet normal -0.0452244 -0.139186 -0.989233
+    outer loop
+      vertex 16.8086 10.6182 11.4712
+      vertex 16.8816 10.4964 11.485
+      vertex 4.72568 14.5442 11.4712
+    endloop
+  endfacet
+  facet normal 0.950844 -0.309668 -0.0011774
+    outer loop
+      vertex 4.92931 15.1709 11.1595
+      vertex 4.89278 15.0584 11.2472
+      vertex 4.85376 14.9383 11.3229
+    endloop
+  endfacet
+  facet normal -0.132076 -0.406492 -0.904058
+    outer loop
+      vertex 4.81264 14.8118 11.3858
+      vertex 16.4648 11.1657 11.3229
+      vertex 16.5176 11.0945 11.3472
+    endloop
+  endfacet
+  facet normal -0.1321 -0.406568 -0.90402
+    outer loop
+      vertex 16.4648 11.1657 11.3229
+      vertex 4.81264 14.8118 11.3858
+      vertex 4.85376 14.9383 11.3229
+    endloop
+  endfacet
+  facet normal -0.305726 -0.940949 -0.145416
+    outer loop
+      vertex 5.08987 15.665 10.2926
+      vertex 15.6699 12.2374 10.228
+      vertex 15.6798 12.2242 10.2926
+    endloop
+  endfacet
+  facet normal -0.305658 -0.940707 -0.147118
+    outer loop
+      vertex 15.6699 12.2374 10.228
+      vertex 5.08987 15.665 10.2926
+      vertex 5.09655 15.6856 10.147
+    endloop
+  endfacet
+  facet normal -0.299759 -0.922585 -0.242859
+    outer loop
+      vertex 15.6798 12.2242 10.2926
+      vertex 5.07882 15.631 10.4354
+      vertex 5.08987 15.665 10.2926
+    endloop
+  endfacet
+  facet normal -0.299726 -0.92246 -0.243376
+    outer loop
+      vertex 5.07882 15.631 10.4354
+      vertex 15.6798 12.2242 10.2926
+      vertex 15.7165 12.1746 10.4354
+    endloop
+  endfacet
+  facet normal -0.0750922 -0.231105 0.970027
+    outer loop
+      vertex 4.72568 14.5442 8.52882
+      vertex 16.6968 10.8046 8.56459
+      vertex 4.76981 14.68 8.56459
+    endloop
+  endfacet
+  facet normal -0.0751531 -0.2313 0.969975
+    outer loop
+      vertex 16.6968 10.8046 8.56459
+      vertex 4.72568 14.5442 8.52882
+      vertex 16.7381 10.7357 8.55136
+    endloop
+  endfacet
+  facet normal 0.95113 -0.308789 -0.00111216
+    outer loop
+      vertex 4.72568 14.5442 8.52882
+      vertex 4.76981 14.68 8.56459
+      vertex 4.68069 14.4057 8.50722
+    endloop
+  endfacet
+  facet normal 0.10409 0.320359 0.94156
+    outer loop
+      vertex 17.3784 9.66752 8.56459
+      vertex 8.36094 12.4517 8.61418
+      vertex 17.4868 9.48655 8.61418
+    endloop
+  endfacet
+  facet normal 0.104113 0.320434 0.941532
+    outer loop
+      vertex 17.3784 9.66752 8.56459
+      vertex 8.33355 12.472 8.6103
+      vertex 8.36094 12.4517 8.61418
+    endloop
+  endfacet
+  facet normal 0.104063 0.320271 0.941593
+    outer loop
+      vertex 8.33355 12.472 8.6103
+      vertex 17.3784 9.66752 8.56459
+      vertex 7.84416 12.7654 8.56459
+    endloop
+  endfacet
+  facet normal 0.279401 0.859894 0.427221
+    outer loop
+      vertex 17.9694 8.49449 9.38915
+      vertex 10.1562 11.0149 9.42597
+      vertex 17.9797 8.47285 9.42597
+    endloop
+  endfacet
+  facet normal 0.279355 0.859747 0.427546
+    outer loop
+      vertex 10.1562 11.0149 9.42597
+      vertex 17.9694 8.49449 9.38915
+      vertex 10.0774 11.0863 9.33388
+    endloop
+  endfacet
+  facet normal -0.0751022 -0.23114 0.970018
+    outer loop
+      vertex 16.8086 10.6182 8.52882
+      vertex 16.7381 10.7357 8.55136
+      vertex 4.72568 14.5442 8.52882
+    endloop
+  endfacet
+  facet normal -0.207558 -0.638799 0.740848
+    outer loop
+      vertex 4.92931 15.1709 8.84048
+      vertex 16.1015 11.6555 8.93934
+      vertex 4.96302 15.2746 8.93934
+    endloop
+  endfacet
+  facet normal -0.207536 -0.638727 0.740916
+    outer loop
+      vertex 16.1015 11.6555 8.93934
+      vertex 4.92931 15.1709 8.84048
+      vertex 16.2136 11.5044 8.84048
+    endloop
+  endfacet
+  facet normal -0.228985 -0.704746 0.67149
+    outer loop
+      vertex 4.96302 15.2746 8.93934
+      vertex 16 11.7924 9.04841
+      vertex 4.99356 15.3686 9.04841
+    endloop
+  endfacet
+  facet normal -0.228987 -0.704753 0.671482
+    outer loop
+      vertex 16 11.7924 9.04841
+      vertex 4.96302 15.2746 8.93934
+      vertex 16.1015 11.6555 8.93934
+    endloop
+  endfacet
+  facet normal 0.950886 -0.30954 0.000454856
+    outer loop
+      vertex 4.96302 15.2746 8.93934
+      vertex 5.02066 15.452 9.16664
+      vertex 4.92931 15.1709 8.84048
+    endloop
+  endfacet
+  facet normal 0.951122 -0.308814 -0.00017163
+    outer loop
+      vertex 4.99356 15.3686 9.04841
+      vertex 5.02066 15.452 9.16664
+      vertex 4.96302 15.2746 8.93934
+    endloop
+  endfacet
+  facet normal 0.951161 -0.308695 0
+    outer loop
+      vertex 4.63168 14.2548 11.4928
+      vertex 4.63525 14.2658 11.5
+      vertex 4.63168 14.2548 11.4994
+    endloop
+  endfacet
+  facet normal 0.951094 -0.308901 0.00034753
+    outer loop
+      vertex 4.63525 14.2658 11.5
+      vertex 4.63168 14.2548 11.4928
+      vertex 4.68069 14.4057 11.4928
+    endloop
+  endfacet
+  facet normal 0.229006 0.704806 -0.67142
+    outer loop
+      vertex 9.74691 11.3858 10.9516
+      vertex 17.7886 8.87682 11.0607
+      vertex 17.8467 8.75401 10.9516
+    endloop
+  endfacet
+  facet normal 0.229025 0.70487 -0.671346
+    outer loop
+      vertex 17.7886 8.87682 11.0607
+      vertex 9.74691 11.3858 10.9516
+      vertex 9.56813 11.5478 11.0607
+    endloop
+  endfacet
+  facet normal 0.207459 0.638495 -0.741137
+    outer loop
+      vertex 9.56813 11.5478 11.0607
+      vertex 17.7245 9.01233 11.1595
+      vertex 17.7886 8.87682 11.0607
+    endloop
+  endfacet
+  facet normal 0.207005 0.63698 -0.742567
+    outer loop
+      vertex 9.5159 11.5952 11.0868
+      vertex 17.7245 9.01233 11.1595
+      vertex 9.56813 11.5478 11.0607
+    endloop
+  endfacet
+  facet normal 0.207628 0.639013 -0.740643
+    outer loop
+      vertex 17.7245 9.01233 11.1595
+      vertex 9.5159 11.5952 11.0868
+      vertex 9.31358 11.7452 11.1595
+    endloop
+  endfacet
+  facet normal -0.290978 -0.895549 -0.336636
+    outer loop
+      vertex 15.7389 12.1444 10.4963
+      vertex 15.7675 12.1059 10.574
+      vertex 5.0635 15.5838 10.574
+    endloop
+  endfacet
+  facet normal -0.265054 -0.81574 -0.514116
+    outer loop
+      vertex 15.8321 12.0187 10.7071
+      vertex 5.02066 15.452 10.8334
+      vertex 5.04405 15.524 10.7071
+    endloop
+  endfacet
+  facet normal -0.265117 -0.815954 -0.513744
+    outer loop
+      vertex 5.02066 15.452 10.8334
+      vertex 15.8321 12.0187 10.7071
+      vertex 15.9099 11.9139 10.8334
+    endloop
+  endfacet
+  facet normal -0.248173 -0.763805 -0.595828
+    outer loop
+      vertex 15.9099 11.9139 10.8334
+      vertex 4.99356 15.3686 10.9516
+      vertex 5.02066 15.452 10.8334
+    endloop
+  endfacet
+  facet normal -0.248156 -0.763748 -0.595909
+    outer loop
+      vertex 4.99356 15.3686 10.9516
+      vertex 15.9099 11.9139 10.8334
+      vertex 16 11.7924 10.9516
+    endloop
+  endfacet
+  facet normal 0.0750404 0.230949 -0.970068
+    outer loop
+      vertex 7.84416 12.7654 11.4354
+      vertex 17.3033 9.79273 11.4594
+      vertex 17.3784 9.66752 11.4354
+    endloop
+  endfacet
+  facet normal 0.0751027 0.231148 -0.970016
+    outer loop
+      vertex 17.3033 9.79273 11.4594
+      vertex 7.84416 12.7654 11.4354
+      vertex 7.7509 12.8213 11.4415
+    endloop
+  endfacet
+  facet normal 0.015197 0.0467616 -0.99879
+    outer loop
+      vertex 6.35916 13.5655 11.4934
+      vertex 17.0376 10.2361 11.5
+      vertex 17.0773 10.1698 11.4975
+    endloop
+  endfacet
+  facet normal 0.0152383 0.0468941 -0.998784
+    outer loop
+      vertex 5.74025 13.8582 11.4977
+      vertex 17.0376 10.2361 11.5
+      vertex 6.35916 13.5655 11.4934
+    endloop
+  endfacet
+  facet normal 0.0153671 0.047296 -0.998763
+    outer loop
+      vertex 5.74025 13.8582 11.4977
+      vertex 4.63525 14.2658 11.5
+      vertex 17.0376 10.2361 11.5
+    endloop
+  endfacet
+  facet normal 0.0160884 0.0492508 -0.998657
+    outer loop
+      vertex 4.63525 14.2658 11.5
+      vertex 5.74025 13.8582 11.4977
+      vertex 4.63168 14.2548 11.4994
+    endloop
+  endfacet
+  facet normal -0.0750037 -0.230813 -0.970103
+    outer loop
+      vertex 4.72568 14.5442 11.4712
+      vertex 16.6968 10.8046 11.4354
+      vertex 16.7381 10.7357 11.4486
+    endloop
+  endfacet
+  facet normal -0.0751514 -0.231287 -0.969979
+    outer loop
+      vertex 16.6968 10.8046 11.4354
+      vertex 4.72568 14.5442 11.4712
+      vertex 4.76981 14.68 11.4354
+    endloop
+  endfacet
+  facet normal -0.184091 -0.566581 -0.803179
+    outer loop
+      vertex 4.89278 15.0584 11.2472
+      vertex 16.2136 11.5044 11.1595
+      vertex 16.3351 11.3406 11.2472
+    endloop
+  endfacet
+  facet normal -0.184049 -0.566443 -0.803286
+    outer loop
+      vertex 16.2136 11.5044 11.1595
+      vertex 4.89278 15.0584 11.2472
+      vertex 4.92931 15.1709 11.1595
+    endloop
+  endfacet
+  facet normal 0.951065 -0.308991 5.59522e-05
+    outer loop
+      vertex 4.76981 14.68 11.4354
+      vertex 4.63168 14.2548 11.2152
+      vertex 5.02066 15.452 10.8334
+    endloop
+  endfacet
+  facet normal 0.951074 -0.308965 0
+    outer loop
+      vertex 4.63168 14.2548 11.2152
+      vertex 4.76981 14.68 11.4354
+      vertex 4.63168 14.2548 11.4135
+    endloop
+  endfacet
+  facet normal 0.951074 -0.308965 0
+    outer loop
+      vertex 4.76981 14.68 11.4354
+      vertex 4.63168 14.2548 11.4794
+      vertex 4.63168 14.2548 11.4135
+    endloop
+  endfacet
+  facet normal -0.305636 -0.94065 -0.147525
+    outer loop
+      vertex 15.6576 12.2541 10.147
+      vertex 15.6699 12.2374 10.228
+      vertex 5.09655 15.6856 10.147
+    endloop
+  endfacet
+  facet normal 0.951074 -0.308965 0
+    outer loop
+      vertex 4.63168 14.2548 8.52056
+      vertex 4.76981 14.68 8.56459
+      vertex 4.63168 14.2548 8.58655
+    endloop
+  endfacet
+  facet normal 0.951085 -0.30893 -0.000367961
+    outer loop
+      vertex 4.63168 14.2548 8.52056
+      vertex 4.68069 14.4057 8.50722
+      vertex 4.76981 14.68 8.56459
+    endloop
+  endfacet
+  facet normal 0.951094 -0.308901 0
+    outer loop
+      vertex 4.68069 14.4057 8.50722
+      vertex 4.63168 14.2548 8.52056
+      vertex 4.63168 14.2548 8.50722
+    endloop
+  endfacet
+  facet normal 0.18408 0.56654 0.803211
+    outer loop
+      vertex 17.655 9.15922 8.7528
+      vertex 9.31358 11.7452 8.84048
+      vertex 17.7245 9.01233 8.84048
+    endloop
+  endfacet
+  facet normal 0.184027 0.566364 0.803347
+    outer loop
+      vertex 9.31358 11.7452 8.84048
+      vertex 17.655 9.15922 8.7528
+      vertex 9.01526 11.9665 8.7528
+    endloop
+  endfacet
+  facet normal 0.228978 0.704718 0.671522
+    outer loop
+      vertex 17.7886 8.87682 8.93934
+      vertex 9.74691 11.3858 9.04841
+      vertex 17.8467 8.75401 9.04841
+    endloop
+  endfacet
+  facet normal 0.228997 0.704783 0.671447
+    outer loop
+      vertex 9.74691 11.3858 9.04841
+      vertex 17.7886 8.87682 8.93934
+      vertex 9.56813 11.5478 8.93934
+    endloop
+  endfacet
+  facet normal 0.207528 0.638708 0.740935
+    outer loop
+      vertex 17.7245 9.01233 8.84048
+      vertex 9.56813 11.5478 8.93934
+      vertex 17.7886 8.87682 8.93934
+    endloop
+  endfacet
+  facet normal 0.207327 0.638037 0.741569
+    outer loop
+      vertex 17.7245 9.01233 8.84048
+      vertex 9.5159 11.5952 8.91316
+      vertex 9.56813 11.5478 8.93934
+    endloop
+  endfacet
+  facet normal 0.207596 0.638917 0.740735
+    outer loop
+      vertex 9.5159 11.5952 8.91316
+      vertex 17.7245 9.01233 8.84048
+      vertex 9.31358 11.7452 8.84048
+    endloop
+  endfacet
+  facet normal 0.265063 0.815791 0.51403
+    outer loop
+      vertex 17.9107 8.6186 9.20218
+      vertex 10.0423 11.118 9.2929
+      vertex 17.9427 8.55104 9.2929
+    endloop
+  endfacet
+  facet normal 0.265074 0.815828 0.513965
+    outer loop
+      vertex 10.0423 11.118 9.2929
+      vertex 17.9107 8.6186 9.20218
+      vertex 10.0008 11.1556 9.25462
+    endloop
+  endfacet
+  facet normal 0.279344 0.859714 0.427619
+    outer loop
+      vertex 17.9427 8.55104 9.2929
+      vertex 10.0774 11.0863 9.33388
+      vertex 17.9694 8.49449 9.38915
+    endloop
+  endfacet
+  facet normal 0.279555 0.860394 0.426113
+    outer loop
+      vertex 10.0774 11.0863 9.33388
+      vertex 17.9427 8.55104 9.2929
+      vertex 10.0423 11.118 9.2929
+    endloop
+  endfacet
+  facet normal 0.305681 0.940767 0.146684
+    outer loop
+      vertex 18.0298 8.3668 9.70736
+      vertex 10.3496 10.8396 9.85297
+      vertex 18.0425 8.33997 9.85297
+    endloop
+  endfacet
+  facet normal 0.305682 0.940775 0.146633
+    outer loop
+      vertex 10.3496 10.8396 9.85297
+      vertex 18.0298 8.3668 9.70736
+      vertex 10.3105 10.875 9.70736
+    endloop
+  endfacet
+  facet normal -0.104155 -0.320552 0.941487
+    outer loop
+      vertex 16.656 10.8727 8.58323
+      vertex 16.5883 10.9856 8.61418
+      vertex 4.81264 14.8118 8.61418
+    endloop
+  endfacet
+  facet normal -0.279293 -0.859585 0.427913
+    outer loop
+      vertex 15.804 12.0566 9.35076
+      vertex 15.7675 12.1059 9.42597
+      vertex 5.0635 15.5838 9.42597
+    endloop
+  endfacet
+  facet normal -0.290991 -0.895588 0.336521
+    outer loop
+      vertex 15.7675 12.1059 9.42597
+      vertex 15.7389 12.1444 9.5037
+      vertex 5.0635 15.5838 9.42597
+    endloop
+  endfacet
+  facet normal 0.184107 0.566623 -0.803146
+    outer loop
+      vertex 9.31358 11.7452 11.1595
+      vertex 17.655 9.15922 11.2472
+      vertex 17.7245 9.01233 11.1595
+    endloop
+  endfacet
+  facet normal 0.184054 0.566447 -0.803282
+    outer loop
+      vertex 17.655 9.15922 11.2472
+      vertex 9.31358 11.7452 11.1595
+      vertex 9.01526 11.9665 11.2472
+    endloop
+  endfacet
+  facet normal 0.129299 0.405254 -0.905014
+    outer loop
+      vertex 17.5808 9.31609 11.3229
+      vertex 17.4868 9.48655 11.3858
+      vertex 17.5502 9.38079 11.3475
+    endloop
+  endfacet
+  facet normal 0.132057 0.406432 -0.904087
+    outer loop
+      vertex 8.69669 12.2027 11.3229
+      vertex 17.4868 9.48655 11.3858
+      vertex 17.5808 9.31609 11.3229
+    endloop
+  endfacet
+  facet normal 0.132064 0.406453 -0.904077
+    outer loop
+      vertex 17.4868 9.48655 11.3858
+      vertex 8.69669 12.2027 11.3229
+      vertex 8.36094 12.4517 11.3858
+    endloop
+  endfacet
+  facet normal 0.951122 -0.308814 0.000172084
+    outer loop
+      vertex 5.02066 15.452 10.8334
+      vertex 4.99356 15.3686 10.9516
+      vertex 4.96302 15.2746 11.0607
+    endloop
+  endfacet
+  facet normal -0.0752903 -0.231718 -0.969865
+    outer loop
+      vertex 16.7381 10.7357 11.4486
+      vertex 16.8086 10.6182 11.4712
+      vertex 4.72568 14.5442 11.4712
+    endloop
+  endfacet
+  facet normal 0.95113 -0.30879 0.00110988
+    outer loop
+      vertex 4.76981 14.68 11.4354
+      vertex 4.72568 14.5442 11.4712
+      vertex 4.68069 14.4057 11.4928
+    endloop
+  endfacet
+  facet normal 0.951094 -0.308901 0
+    outer loop
+      vertex 4.63168 14.2548 11.4794
+      vertex 4.68069 14.4057 11.4928
+      vertex 4.63168 14.2548 11.4928
+    endloop
+  endfacet
+  facet normal 0.951085 -0.30893 0.000367335
+    outer loop
+      vertex 4.68069 14.4057 11.4928
+      vertex 4.63168 14.2548 11.4794
+      vertex 4.76981 14.68 11.4354
+    endloop
+  endfacet
+  facet normal -0.104304 -0.321011 -0.941314
+    outer loop
+      vertex 16.5883 10.9856 11.3858
+      vertex 16.656 10.8727 11.4168
+      vertex 4.81264 14.8118 11.3858
+    endloop
+  endfacet
+  facet normal 0.0151677 0.0466821 0.998795
+    outer loop
+      vertex 17.0773 10.1698 8.50249
+      vertex 6.45606 13.5196 8.50722
+      vertex 17.1527 10.0441 8.50722
+    endloop
+  endfacet
+  facet normal 0.0150905 0.0464373 0.998807
+    outer loop
+      vertex 6.45606 13.5196 8.50722
+      vertex 17.0773 10.1698 8.50249
+      vertex 6.35916 13.5655 8.50655
+    endloop
+  endfacet
+  facet normal 0.951094 -0.308901 -0.000346567
+    outer loop
+      vertex 4.63168 14.2548 8.50722
+      vertex 4.63525 14.2658 8.5
+      vertex 4.68069 14.4057 8.50722
+    endloop
+  endfacet
+  facet normal 0.951161 -0.308695 0
+    outer loop
+      vertex 4.63525 14.2658 8.5
+      vertex 4.63168 14.2548 8.50722
+      vertex 4.63168 14.2548 8.50057
+    endloop
+  endfacet
+  facet normal 0.158871 0.488946 0.857725
+    outer loop
+      vertex 17.5808 9.31609 8.67712
+      vertex 9.01526 11.9665 8.7528
+      vertex 17.655 9.15922 8.7528
+    endloop
+  endfacet
+  facet normal 0.158929 0.489135 0.857606
+    outer loop
+      vertex 9.01526 11.9665 8.7528
+      vertex 17.5808 9.31609 8.67712
+      vertex 8.69669 12.2027 8.67712
+    endloop
+  endfacet
+  facet normal 0.0750992 0.23113 0.97002
+    outer loop
+      vertex 17.3033 9.79273 8.54057
+      vertex 7.84416 12.7654 8.56459
+      vertex 17.3784 9.66752 8.56459
+    endloop
+  endfacet
+  facet normal 0.0751069 0.231155 0.970014
+    outer loop
+      vertex 7.84416 12.7654 8.56459
+      vertex 17.3033 9.79273 8.54057
+      vertex 7.7509 12.8213 8.55849
+    endloop
+  endfacet
+  facet normal 0.248179 0.763804 0.595828
+    outer loop
+      vertex 17.8836 8.67596 9.13311
+      vertex 9.90548 11.2421 9.16664
+      vertex 17.8982 8.64506 9.16664
+    endloop
+  endfacet
+  facet normal 0.248312 0.764223 0.595235
+    outer loop
+      vertex 9.90548 11.2421 9.16664
+      vertex 17.8836 8.67596 9.13311
+      vertex 9.79296 11.344 9.08275
+    endloop
+  endfacet
+  facet normal 0.265048 0.815745 0.514111
+    outer loop
+      vertex 17.8982 8.64506 9.16664
+      vertex 10.0008 11.1556 9.25462
+      vertex 17.9107 8.6186 9.20218
+    endloop
+  endfacet
+  facet normal 0.264955 0.815432 0.514655
+    outer loop
+      vertex 10.0008 11.1556 9.25462
+      vertex 17.8982 8.64506 9.16664
+      vertex 9.90548 11.2421 9.16664
+    endloop
+  endfacet
+  facet normal 0.248187 0.763855 0.595759
+    outer loop
+      vertex 17.8467 8.75401 9.04841
+      vertex 9.79296 11.344 9.08275
+      vertex 17.8836 8.67596 9.13311
+    endloop
+  endfacet
+  facet normal 0.248013 0.763304 0.596537
+    outer loop
+      vertex 9.79296 11.344 9.08275
+      vertex 17.8467 8.75401 9.04841
+      vertex 9.74691 11.3858 9.04841
+    endloop
+  endfacet
+  facet normal 0.290947 0.89544 0.336952
+    outer loop
+      vertex 17.9797 8.47285 9.42597
+      vertex 10.2458 10.9336 9.56457
+      vertex 18.0088 8.41124 9.56457
+    endloop
+  endfacet
+  facet normal 0.29093 0.895377 0.337134
+    outer loop
+      vertex 10.2458 10.9336 9.56457
+      vertex 17.9797 8.47285 9.42597
+      vertex 10.1562 11.0149 9.42597
+    endloop
+  endfacet
+  facet normal 0.24791 0.762987 -0.596985
+    outer loop
+      vertex 17.8467 8.75401 10.9516
+      vertex 9.79296 11.344 10.9173
+      vertex 9.74691 11.3858 10.9516
+    endloop
+  endfacet
+  facet normal 0.248184 0.763855 -0.59576
+    outer loop
+      vertex 9.79296 11.344 10.9173
+      vertex 17.8467 8.75401 10.9516
+      vertex 17.8836 8.67596 10.8669
+    endloop
+  endfacet
+  facet normal 0.158902 0.489041 -0.857665
+    outer loop
+      vertex 9.01526 11.9665 11.2472
+      vertex 17.5808 9.31609 11.3229
+      vertex 17.655 9.15922 11.2472
+    endloop
+  endfacet
+  facet normal 0.15896 0.48923 -0.857547
+    outer loop
+      vertex 17.5808 9.31609 11.3229
+      vertex 9.01526 11.9665 11.2472
+      vertex 8.69669 12.2027 11.3229
+    endloop
+  endfacet
+  facet normal 0.299735 0.922466 -0.24334
+    outer loop
+      vertex 10.2898 10.8938 10.3385
+      vertex 18.0088 8.41124 10.4354
+      vertex 18.0145 8.3991 10.3964
+    endloop
+  endfacet
+  facet normal 0.299769 0.922592 -0.242821
+    outer loop
+      vertex 18.0088 8.41124 10.4354
+      vertex 10.2898 10.8938 10.3385
+      vertex 10.2458 10.9336 10.4354
+    endloop
+  endfacet
+  facet normal 0.299768 0.922573 -0.242896
+    outer loop
+      vertex 10.3105 10.875 10.2926
+      vertex 18.0145 8.3991 10.3964
+      vertex 18.0298 8.3668 10.2926
+    endloop
+  endfacet
+  facet normal 0.299781 0.922621 -0.242698
+    outer loop
+      vertex 18.0145 8.3991 10.3964
+      vertex 10.3105 10.875 10.2926
+      vertex 10.2898 10.8938 10.3385
+    endloop
+  endfacet
+  facet normal 0.308646 0.94993 -0.0486923
+    outer loop
+      vertex 10.3626 10.8277 10
+      vertex 18.0456 8.33342 10.0398
+      vertex 18.0468 8.33099 10
+    endloop
+  endfacet
+  facet normal 0.308641 0.949906 -0.0491763
+    outer loop
+      vertex 18.0456 8.33342 10.0398
+      vertex 10.3626 10.8277 10
+      vertex 10.3538 10.8357 10.0993
+    endloop
+  endfacet
+  facet normal -0.207467 -0.638514 -0.741119
+    outer loop
+      vertex 4.92931 15.1709 11.1595
+      vertex 16.1015 11.6555 11.0607
+      vertex 16.2136 11.5044 11.1595
+    endloop
+  endfacet
+  facet normal -0.207489 -0.638586 -0.741051
+    outer loop
+      vertex 16.1015 11.6555 11.0607
+      vertex 4.92931 15.1709 11.1595
+      vertex 4.96302 15.2746 11.0607
+    endloop
+  endfacet
+  facet normal -0.158898 -0.489046 -0.857663
+    outer loop
+      vertex 4.85376 14.9383 11.3229
+      vertex 16.3351 11.3406 11.2472
+      vertex 16.4648 11.1657 11.3229
+    endloop
+  endfacet
+  facet normal -0.158882 -0.488993 -0.857696
+    outer loop
+      vertex 16.3351 11.3406 11.2472
+      vertex 4.85376 14.9383 11.3229
+      vertex 4.89278 15.0584 11.2472
+    endloop
+  endfacet
+  facet normal 0.0151336 0.0465734 0.9988
+    outer loop
+      vertex 17.0376 10.2361 8.5
+      vertex 6.35916 13.5655 8.50655
+      vertex 17.0773 10.1698 8.50249
+    endloop
+  endfacet
+  facet normal 0.0151623 0.0466653 0.998796
+    outer loop
+      vertex 17.0376 10.2361 8.5
+      vertex 5.74025 13.8582 8.50227
+      vertex 6.35916 13.5655 8.50655
+    endloop
+  endfacet
+  facet normal 0.0151672 0.0466806 0.998795
+    outer loop
+      vertex 4.63525 14.2658 8.5
+      vertex 5.74025 13.8582 8.50227
+      vertex 17.0376 10.2361 8.5
+    endloop
+  endfacet
+  facet normal 0.0152174 0.0468166 0.998788
+    outer loop
+      vertex 5.74025 13.8582 8.50227
+      vertex 4.63525 14.2658 8.5
+      vertex 4.63168 14.2548 8.50057
+    endloop
+  endfacet
+  facet normal -0.0151664 -0.0466781 0.998795
+    outer loop
+      vertex 17.0376 10.2361 8.5
+      vertex 16.9632 10.3602 8.50467
+      vertex 4.63525 14.2658 8.5
+    endloop
+  endfacet
+  facet normal 0.1335 0.40723 0.903516
+    outer loop
+      vertex 17.4868 9.48655 8.61418
+      vertex 17.5808 9.31609 8.67712
+      vertex 17.5502 9.38079 8.65248
+    endloop
+  endfacet
+  facet normal 0.132126 0.406644 0.903982
+    outer loop
+      vertex 17.4868 9.48655 8.61418
+      vertex 8.69669 12.2027 8.67712
+      vertex 17.5808 9.31609 8.67712
+    endloop
+  endfacet
+  facet normal 0.132132 0.406664 0.903972
+    outer loop
+      vertex 8.69669 12.2027 8.67712
+      vertex 17.4868 9.48655 8.61418
+      vertex 8.36094 12.4517 8.61418
+    endloop
+  endfacet
+  facet normal 0.0453033 0.139427 0.989195
+    outer loop
+      vertex 17.2286 9.91747 8.52161
+      vertex 7.29711 13.0933 8.52882
+      vertex 17.2666 9.85397 8.52882
+    endloop
+  endfacet
+  facet normal 0.0453962 0.139718 0.98915
+    outer loop
+      vertex 17.2286 9.91747 8.52161
+      vertex 7.07095 13.2288 8.52006
+      vertex 7.29711 13.0933 8.52882
+    endloop
+  endfacet
+  facet normal 0.0452817 0.139367 0.989205
+    outer loop
+      vertex 7.07095 13.2288 8.52006
+      vertex 17.2286 9.91747 8.52161
+      vertex 6.56363 13.4688 8.50947
+    endloop
+  endfacet
+  facet normal 0.0453574 0.139594 0.989169
+    outer loop
+      vertex 17.1527 10.0441 8.50722
+      vertex 6.56363 13.4688 8.50947
+      vertex 17.2286 9.91747 8.52161
+    endloop
+  endfacet
+  facet normal 0.0456214 0.14041 0.989042
+    outer loop
+      vertex 6.56363 13.4688 8.50947
+      vertex 17.1527 10.0441 8.50722
+      vertex 6.45606 13.5196 8.50722
+    endloop
+  endfacet
+  facet normal 0.290947 0.89544 -0.336952
+    outer loop
+      vertex 10.2458 10.9336 10.4354
+      vertex 17.9797 8.47285 10.574
+      vertex 18.0088 8.41124 10.4354
+    endloop
+  endfacet
+  facet normal 0.29093 0.895377 -0.337134
+    outer loop
+      vertex 17.9797 8.47285 10.574
+      vertex 10.2458 10.9336 10.4354
+      vertex 10.1562 11.0149 10.574
+    endloop
+  endfacet
+  facet normal 0.0750959 0.23112 0.970023
+    outer loop
+      vertex 17.2666 9.85397 8.52882
+      vertex 7.7509 12.8213 8.55849
+      vertex 17.3033 9.79273 8.54057
+    endloop
+  endfacet
+  facet normal 0.0750817 0.231075 0.970035
+    outer loop
+      vertex 7.7509 12.8213 8.55849
+      vertex 17.2666 9.85397 8.52882
+      vertex 7.29711 13.0933 8.52882
+    endloop
+  endfacet
+  facet normal 0.279511 0.860234 -0.426463
+    outer loop
+      vertex 10.1562 11.0149 10.574
+      vertex 17.9694 8.49449 10.6109
+      vertex 17.9797 8.47285 10.574
+    endloop
+  endfacet
+  facet normal 0.279365 0.859764 -0.427505
+    outer loop
+      vertex 17.9694 8.49449 10.6109
+      vertex 10.1562 11.0149 10.574
+      vertex 10.0774 11.0863 10.6661
+    endloop
+  endfacet
+  facet normal -0.784734 0.570143 0.243165
+    outer loop
+      vertex -2.42983 19.7331 9.56457
+      vertex -7.14233 13.186 9.70736
+      vertex -2.38028 19.7404 9.70736
+    endloop
+  endfacet
+  facet normal -0.784746 0.57015 0.243108
+    outer loop
+      vertex -7.14233 13.186 9.70736
+      vertex -2.42983 19.7331 9.56457
+      vertex -7.22064 13.1391 9.56457
+    endloop
+  endfacet
+  facet normal 0.693921 -0.504162 -0.514096
+    outer loop
+      vertex -6.41224 18.8157 10.8334
+      vertex -13.2055 9.59435 10.7071
+      vertex -6.53865 18.7705 10.7071
+    endloop
+  endfacet
+  facet normal 0.694024 -0.504241 -0.513879
+    outer loop
+      vertex -13.2055 9.59435 10.7071
+      vertex -6.41224 18.8157 10.8334
+      vertex -13.1443 9.54987 10.8334
+    endloop
+  endfacet
+  facet normal 0.58612 0.810224 0
+    outer loop
+      vertex -12.1212 8.80658 11.4983
+      vertex -12.1212 8.80658 11.4974
+      vertex -12.1353 8.81678 11.5
+    endloop
+  endfacet
+  facet normal -0.345379 0.250938 -0.904292
+    outer loop
+      vertex -9.20589 11.8251 11.3727
+      vertex -3.62317 19.5561 11.3858
+      vertex -3.49614 19.5749 11.3425
+    endloop
+  endfacet
+  facet normal -0.346609 0.251825 -0.903574
+    outer loop
+      vertex -3.62317 19.5561 11.3858
+      vertex -9.20589 11.8251 11.3727
+      vertex -9.28 11.7701 11.3858
+    endloop
+  endfacet
+  facet normal 0.592086 0.805875 0.000464776
+    outer loop
+      vertex -13.3255 9.68151 9.70736
+      vertex -13.3429 9.69421 9.85297
+      vertex -13.3488 9.69846 10
+    endloop
+  endfacet
+  facet normal 0.588025 0.808839 -0.0022637
+    outer loop
+      vertex -12.2542 8.9032 11.4928
+      vertex -12.1353 8.81678 11.5
+      vertex -12.372 8.98878 11.4712
+    endloop
+  endfacet
+  facet normal -0.0398262 0.0289277 -0.998788
+    outer loop
+      vertex -10.9269 10.2532 11.4935
+      vertex -4.46705 19.3712 11.5
+      vertex -4.39048 19.3903 11.4975
+    endloop
+  endfacet
+  facet normal -0.0391856 0.028474 -0.998826
+    outer loop
+      vertex -11.5952 9.5159 11.4987
+      vertex -4.46705 19.3712 11.5
+      vertex -10.9269 10.2532 11.4935
+    endloop
+  endfacet
+  facet normal -0.0417535 0.0303994 -0.998665
+    outer loop
+      vertex -12.1353 8.81678 11.5
+      vertex -11.5952 9.5159 11.4987
+      vertex -12.1212 8.80658 11.4991
+    endloop
+  endfacet
+  facet normal -0.0403743 0.0293337 -0.998754
+    outer loop
+      vertex -11.5952 9.5159 11.4987
+      vertex -12.1353 8.81678 11.5
+      vertex -4.46705 19.3712 11.5
+    endloop
+  endfacet
+  facet normal 0.0396737 -0.0288249 0.998797
+    outer loop
+      vertex -4.68922 19.3155 8.50722
+      vertex -12.1353 8.81678 8.5
+      vertex -4.61071 19.3352 8.50467
+    endloop
+  endfacet
+  facet normal 0.0396906 -0.0288369 0.998796
+    outer loop
+      vertex -12.1353 8.81678 8.5
+      vertex -4.68922 19.3155 8.50722
+      vertex -12.2542 8.9032 8.50722
+    endloop
+  endfacet
+  facet normal 0.589037 0.808104 -0.00157761
+    outer loop
+      vertex -12.9933 9.44022 11.0607
+      vertex -12.8095 9.30661 11.2472
+      vertex -13.0733 9.49832 10.9516
+    endloop
+  endfacet
+  facet normal -0.543306 0.394734 0.740948
+    outer loop
+      vertex -3.05548 19.6403 8.86968
+      vertex -8.04118 12.6473 8.93934
+      vertex -2.949 19.6561 8.93934
+    endloop
+  endfacet
+  facet normal -0.543283 0.394718 0.740974
+    outer loop
+      vertex -8.04118 12.6473 8.93934
+      vertex -3.05548 19.6403 8.86968
+      vertex -8.10609 12.6084 8.91247
+    endloop
+  endfacet
+  facet normal 0.649799 -0.47211 0.595712
+    outer loop
+      vertex -13.1443 9.54987 9.16664
+      vertex -6.26578 18.8681 9.04841
+      vertex -6.41224 18.8157 9.16664
+    endloop
+  endfacet
+  facet normal 0.649664 -0.472007 0.595941
+    outer loop
+      vertex -6.26578 18.8681 9.04841
+      vertex -13.1443 9.54987 9.16664
+      vertex -13.0733 9.49832 9.04841
+    endloop
+  endfacet
+  facet normal 0.587901 0.808933 -1.38587e-05
+    outer loop
+      vertex -13.1443 9.54987 9.16664
+      vertex -13.2055 9.59435 9.2929
+      vertex -13.2965 9.66049 9.56457
+    endloop
+  endfacet
+  facet normal 0.587779 0.809021 -0
+    outer loop
+      vertex -12.1212 8.80658 8.78458
+      vertex -12.7073 9.2324 11.3229
+      vertex -12.1212 8.80658 11.2154
+    endloop
+  endfacet
+  facet normal 0.587779 0.809021 0
+    outer loop
+      vertex -12.7073 9.2324 11.3229
+      vertex -12.1212 8.80658 8.78458
+      vertex -12.7073 9.2324 8.67712
+    endloop
+  endfacet
+  facet normal -0.599505 0.435564 -0.671475
+    outer loop
+      vertex -7.9809 12.6834 11.0303
+      vertex -2.949 19.6561 11.0607
+      vertex -2.85151 19.6705 10.983
+    endloop
+  endfacet
+  facet normal -0.599486 0.435551 -0.6715
+    outer loop
+      vertex -2.949 19.6561 11.0607
+      vertex -7.9809 12.6834 11.0303
+      vertex -8.04118 12.6473 11.0607
+    endloop
+  endfacet
+  facet normal 0.58612 0.810224 0
+    outer loop
+      vertex -12.1212 8.80658 11.4974
+      vertex -12.1212 8.80658 11.4928
+      vertex -12.1353 8.81678 11.5
+    endloop
+  endfacet
+  facet normal 0.481648 -0.347877 -0.804361
+    outer loop
+      vertex -5.72631 19.0557 11.2472
+      vertex -5.91849 18.9924 11.1595
+      vertex -5.77666 19.0431 11.2225
+    endloop
+  endfacet
+  facet normal 0.481878 -0.350108 -0.803255
+    outer loop
+      vertex -12.8095 9.30661 11.2472
+      vertex -5.91849 18.9924 11.1595
+      vertex -5.72631 19.0557 11.2472
+    endloop
+  endfacet
+  facet normal 0.482081 -0.35025 -0.803071
+    outer loop
+      vertex -5.91849 18.9924 11.1595
+      vertex -12.8095 9.30661 11.2472
+      vertex -12.9051 9.37611 11.1595
+    endloop
+  endfacet
+  facet normal 0.0389011 -0.0282751 -0.998843
+    outer loop
+      vertex -12.1353 8.81678 11.5
+      vertex -4.68922 19.3155 11.4928
+      vertex -4.61071 19.3352 11.4953
+    endloop
+  endfacet
+  facet normal 0.039581 -0.0287573 -0.998802
+    outer loop
+      vertex -4.68922 19.3155 11.4928
+      vertex -12.1353 8.81678 11.5
+      vertex -12.2542 8.9032 11.4928
+    endloop
+  endfacet
+  facet normal 0.588206 0.808711 0.000622652
+    outer loop
+      vertex -12.7073 9.2324 8.67712
+      vertex -13.0733 9.49832 9.04841
+      vertex -13.1443 9.54987 9.16664
+    endloop
+  endfacet
+  facet normal -0.694048 0.50425 -0.513838
+    outer loop
+      vertex -7.46703 12.9914 10.7071
+      vertex -2.69057 19.6944 10.8334
+      vertex -2.58573 19.71 10.7071
+    endloop
+  endfacet
+  facet normal -0.693952 0.504185 -0.514031
+    outer loop
+      vertex -2.69057 19.6944 10.8334
+      vertex -7.46703 12.9914 10.7071
+      vertex -7.63273 12.8921 10.8334
+    endloop
+  endfacet
+  facet normal 0.416119 -0.302325 0.857581
+    outer loop
+      vertex -5.72631 19.0557 8.7528
+      vertex -12.7073 9.2324 8.67712
+      vertex -5.65104 19.0746 8.72294
+    endloop
+  endfacet
+  facet normal 0.415828 -0.302119 0.857794
+    outer loop
+      vertex -12.7073 9.2324 8.67712
+      vertex -5.72631 19.0557 8.7528
+      vertex -12.8095 9.30661 8.7528
+    endloop
+  endfacet
+  facet normal 0.58612 0.810224 0
+    outer loop
+      vertex -12.1212 8.80658 8.50718
+      vertex -12.1212 8.80658 8.50257
+      vertex -12.1353 8.81678 8.5
+    endloop
+  endfacet
+  facet normal 0.761656 -0.553374 0.337131
+    outer loop
+      vertex -13.2965 9.66049 9.56457
+      vertex -6.69019 18.7162 9.50365
+      vertex -6.7266 18.7032 9.56457
+    endloop
+  endfacet
+  facet normal 0.761753 -0.553447 0.336791
+    outer loop
+      vertex -6.69019 18.7162 9.50365
+      vertex -13.2965 9.66049 9.56457
+      vertex -13.2564 9.63134 9.42597
+    endloop
+  endfacet
+  facet normal 0.585971 0.810332 -0.000280185
+    outer loop
+      vertex -13.2965 9.66049 9.56457
+      vertex -13.3255 9.68151 9.70736
+      vertex -13.3488 9.69846 10
+    endloop
+  endfacet
+  facet normal 0.808039 -0.587078 -0.0491191
+    outer loop
+      vertex -6.82242 18.6689 10.147
+      vertex -13.3488 9.69846 10
+      vertex -6.83448 18.6646 10
+    endloop
+  endfacet
+  facet normal 0.80803 -0.587067 -0.0494041
+    outer loop
+      vertex -13.3488 9.69846 10
+      vertex -6.82242 18.6689 10.147
+      vertex -13.3429 9.69421 10.147
+    endloop
+  endfacet
+  facet normal 0.587619 0.809138 0.00017909
+    outer loop
+      vertex -13.1443 9.54987 10.8334
+      vertex -12.7073 9.2324 11.3229
+      vertex -13.2965 9.66049 10.4354
+    endloop
+  endfacet
+  facet normal 0.118709 -0.0862474 -0.989176
+    outer loop
+      vertex -12.2542 8.9032 11.4928
+      vertex -4.90924 19.2604 11.4712
+      vertex -4.68922 19.3155 11.4928
+    endloop
+  endfacet
+  facet normal 0.118716 -0.086252 -0.989175
+    outer loop
+      vertex -4.90924 19.2604 11.4712
+      vertex -12.2542 8.9032 11.4928
+      vertex -12.372 8.98878 11.4712
+    endloop
+  endfacet
+  facet normal 0.0399497 -0.0290252 -0.99878
+    outer loop
+      vertex -4.61071 19.3352 11.4953
+      vertex -4.46705 19.3712 11.5
+      vertex -12.1353 8.81678 11.5
+    endloop
+  endfacet
+  facet normal 0.587795 0.80901 0
+    outer loop
+      vertex -12.7073 9.2324 11.3229
+      vertex -13.2965 9.66049 9.56457
+      vertex -13.2965 9.66049 10.4354
+    endloop
+  endfacet
+  facet normal 0.587795 0.80901 0
+    outer loop
+      vertex -13.2965 9.66049 9.56457
+      vertex -12.7073 9.2324 11.3229
+      vertex -12.7073 9.2324 8.67712
+    endloop
+  endfacet
+  facet normal 0.592086 0.805875 -0.000464902
+    outer loop
+      vertex -13.3429 9.69421 10.147
+      vertex -13.3255 9.68151 10.2926
+      vertex -13.3488 9.69846 10
+    endloop
+  endfacet
+  facet normal -0.800292 0.581444 0.146475
+    outer loop
+      vertex -2.38028 19.7404 9.70736
+      vertex -7.09503 13.2144 9.85297
+      vertex -2.35036 19.7449 9.85297
+    endloop
+  endfacet
+  facet normal -0.800281 0.581438 0.146559
+    outer loop
+      vertex -7.09503 13.2144 9.85297
+      vertex -2.38028 19.7404 9.70736
+      vertex -7.14233 13.186 9.70736
+    endloop
+  endfacet
+  facet normal 0.0396953 -0.0288404 0.998796
+    outer loop
+      vertex -4.46705 19.3712 8.5
+      vertex -4.61071 19.3352 8.50467
+      vertex -12.1353 8.81678 8.5
+    endloop
+  endfacet
+  facet normal -0.599475 0.435542 -0.671516
+    outer loop
+      vertex -7.82473 12.777 10.9516
+      vertex -2.85151 19.6705 10.983
+      vertex -2.81205 19.6764 10.9516
+    endloop
+  endfacet
+  facet normal -0.599449 0.435523 -0.67155
+    outer loop
+      vertex -2.85151 19.6705 10.983
+      vertex -7.82473 12.777 10.9516
+      vertex -7.9809 12.6834 11.0303
+    endloop
+  endfacet
+  facet normal 0.58612 0.810224 0
+    outer loop
+      vertex -12.1212 8.80658 8.50171
+      vertex -12.1212 8.80658 8.50085
+      vertex -12.1353 8.81678 8.5
+    endloop
+  endfacet
+  facet normal 0.58612 0.810224 0
+    outer loop
+      vertex -12.1353 8.81678 8.5
+      vertex -12.1212 8.80658 8.78458
+      vertex -12.1212 8.80658 8.50718
+    endloop
+  endfacet
+  facet normal 0.587794 0.80901 -0.000126493
+    outer loop
+      vertex -12.1212 8.80658 8.78458
+      vertex -12.1353 8.81678 8.5
+      vertex -12.7073 9.2324 8.67712
+    endloop
+  endfacet
+  facet normal -0.118703 0.0862427 0.989177
+    outer loop
+      vertex -4.24489 19.4268 8.50722
+      vertex -10.2158 10.9608 8.52882
+      vertex -4.02486 19.4819 8.52882
+    endloop
+  endfacet
+  facet normal -0.118667 0.0862172 0.989184
+    outer loop
+      vertex -4.24489 19.4268 8.50722
+      vertex -10.6066 10.6066 8.51281
+      vertex -10.2158 10.9608 8.52882
+    endloop
+  endfacet
+  facet normal -0.118735 0.0862662 0.989171
+    outer loop
+      vertex -10.6066 10.6066 8.51281
+      vertex -4.24489 19.4268 8.50722
+      vertex -10.8412 10.3478 8.50722
+    endloop
+  endfacet
+  facet normal 0.58612 0.810224 -0
+    outer loop
+      vertex -12.1212 8.80658 11.2154
+      vertex -12.1353 8.81678 11.5
+      vertex -12.1212 8.80658 11.4928
+    endloop
+  endfacet
+  facet normal 0.587794 0.80901 0.000126485
+    outer loop
+      vertex -12.1353 8.81678 11.5
+      vertex -12.1212 8.80658 11.2154
+      vertex -12.7073 9.2324 11.3229
+    endloop
+  endfacet
+  facet normal 0.346009 -0.251391 0.903925
+    outer loop
+      vertex -5.41187 19.1345 8.63841
+      vertex -5.53552 19.1035 8.67712
+      vertex -12.7073 9.2324 8.67712
+    endloop
+  endfacet
+  facet normal 0.587619 0.809138 -0.000179151
+    outer loop
+      vertex -12.7073 9.2324 8.67712
+      vertex -13.1443 9.54987 9.16664
+      vertex -13.2965 9.66049 9.56457
+    endloop
+  endfacet
+  facet normal 0.5875 0.809224 0
+    outer loop
+      vertex -13.2965 9.66049 10.4354
+      vertex -13.2965 9.66049 9.56457
+      vertex -13.3488 9.69846 10
+    endloop
+  endfacet
+  facet normal -0.731335 0.531343 -0.427579
+    outer loop
+      vertex -7.32922 13.074 10.574
+      vertex -2.58573 19.71 10.7071
+      vertex -2.49854 19.7229 10.574
+    endloop
+  endfacet
+  facet normal -0.731369 0.531366 -0.427492
+    outer loop
+      vertex -2.58573 19.71 10.7071
+      vertex -7.32922 13.074 10.574
+      vertex -7.46703 12.9914 10.7071
+    endloop
+  endfacet
+  facet normal 0.588207 0.80871 -0.000623083
+    outer loop
+      vertex -13.0733 9.49832 10.9516
+      vertex -12.7073 9.2324 11.3229
+      vertex -13.1443 9.54987 10.8334
+    endloop
+  endfacet
+  facet normal 0.761922 -0.553565 -0.336215
+    outer loop
+      vertex -6.69019 18.7162 10.4963
+      vertex -6.64377 18.7329 10.574
+      vertex -13.2564 9.63134 10.574
+    endloop
+  endfacet
+  facet normal 0.587527 0.809204 0.000205431
+    outer loop
+      vertex -13.2564 9.63134 10.574
+      vertex -13.2055 9.59435 10.7071
+      vertex -13.2965 9.66049 10.4354
+    endloop
+  endfacet
+  facet normal 0.272533 -0.198007 -0.941551
+    outer loop
+      vertex -12.4875 9.07272 11.4354
+      vertex -5.33444 19.1539 11.3858
+      vertex -5.12501 19.2063 11.4354
+    endloop
+  endfacet
+  facet normal 0.272497 -0.197982 -0.941567
+    outer loop
+      vertex -5.33444 19.1539 11.3858
+      vertex -12.4875 9.07272 11.4354
+      vertex -12.5997 9.15418 11.3858
+    endloop
+  endfacet
+  facet normal 0.808039 -0.587078 0.0491091
+    outer loop
+      vertex -13.3488 9.69846 10
+      vertex -6.82242 18.6689 9.85297
+      vertex -6.83448 18.6646 10
+    endloop
+  endfacet
+  facet normal 0.80803 -0.587067 0.0493941
+    outer loop
+      vertex -6.82242 18.6689 9.85297
+      vertex -13.3488 9.69846 10
+      vertex -13.3429 9.69421 9.85297
+    endloop
+  endfacet
+  facet normal 0.585971 0.810332 0.000280261
+    outer loop
+      vertex -13.3255 9.68151 10.2926
+      vertex -13.2965 9.66049 10.4354
+      vertex -13.3488 9.69846 10
+    endloop
+  endfacet
+  facet normal 0.800255 -0.581418 0.146782
+    outer loop
+      vertex -13.3429 9.69421 9.85297
+      vertex -6.78634 18.6818 9.70736
+      vertex -6.82242 18.6689 9.85297
+    endloop
+  endfacet
+  facet normal 0.800304 -0.58146 0.146349
+    outer loop
+      vertex -6.78634 18.6818 9.70736
+      vertex -13.3429 9.69421 9.85297
+      vertex -13.3255 9.68151 9.70736
+    endloop
+  endfacet
+  facet normal 0.784708 -0.570122 0.243298
+    outer loop
+      vertex -13.2965 9.66049 9.56457
+      vertex -6.75302 18.6938 9.62773
+      vertex -13.3255 9.68151 9.70736
+    endloop
+  endfacet
+  facet normal 0.784689 -0.570109 0.243389
+    outer loop
+      vertex -6.75302 18.6938 9.62773
+      vertex -13.2965 9.66049 9.56457
+      vertex -6.7266 18.7032 9.56457
+    endloop
+  endfacet
+  facet normal -0.0394253 0.0286443 -0.998812
+    outer loop
+      vertex -10.8412 10.3478 11.4928
+      vertex -4.39048 19.3903 11.4975
+      vertex -4.24489 19.4268 11.4928
+    endloop
+  endfacet
+  facet normal -0.0410775 0.0298229 -0.998711
+    outer loop
+      vertex -4.39048 19.3903 11.4975
+      vertex -10.8412 10.3478 11.4928
+      vertex -10.9269 10.2532 11.4935
+    endloop
+  endfacet
+  facet normal -0.195159 0.134362 -0.971524
+    outer loop
+      vertex -3.81518 19.5276 11.4354
+      vertex -4.02486 19.4819 11.4712
+      vertex -3.8823 19.5176 11.4475
+    endloop
+  endfacet
+  facet normal -0.196768 0.14296 -0.969972
+    outer loop
+      vertex -9.699 11.4292 11.4354
+      vertex -4.02486 19.4819 11.4712
+      vertex -3.81518 19.5276 11.4354
+    endloop
+  endfacet
+  facet normal -0.196757 0.142952 -0.969975
+    outer loop
+      vertex -4.02486 19.4819 11.4712
+      vertex -9.699 11.4292 11.4354
+      vertex -10.2158 10.9608 11.4712
+    endloop
+  endfacet
+  facet normal -0.761725 0.553424 -0.336892
+    outer loop
+      vertex -7.22064 13.1391 10.4354
+      vertex -2.49854 19.7229 10.574
+      vertex -2.42983 19.7331 10.4354
+    endloop
+  endfacet
+  facet normal -0.76175 0.55344 -0.33681
+    outer loop
+      vertex -2.49854 19.7229 10.574
+      vertex -7.22064 13.1391 10.4354
+      vertex -7.32922 13.074 10.574
+    endloop
+  endfacet
+  facet normal -0.415691 0.302014 -0.857898
+    outer loop
+      vertex -8.5849 12.2856 11.2472
+      vertex -3.38512 19.5914 11.2996
+      vertex -3.2639 19.6094 11.2472
+    endloop
+  endfacet
+  facet normal -0.416717 0.302739 -0.857144
+    outer loop
+      vertex -3.38512 19.5914 11.2996
+      vertex -8.5849 12.2856 11.2472
+      vertex -8.66607 12.2254 11.2654
+    endloop
+  endfacet
+  facet normal 0.587864 0.80896 0.000214521
+    outer loop
+      vertex -12.1353 8.81678 8.5
+      vertex -12.372 8.98878 8.52882
+      vertex -12.7073 9.2324 8.67712
+    endloop
+  endfacet
+  facet normal 0.588026 0.808839 0.00226681
+    outer loop
+      vertex -12.1353 8.81678 8.5
+      vertex -12.2542 8.9032 8.50722
+      vertex -12.372 8.98878 8.52882
+    endloop
+  endfacet
+  facet normal 0.58612 0.810224 0
+    outer loop
+      vertex -12.1212 8.80658 8.50257
+      vertex -12.1212 8.80658 8.50171
+      vertex -12.1353 8.81678 8.5
+    endloop
+  endfacet
+  facet normal -0.416036 0.302264 0.857642
+    outer loop
+      vertex -3.43882 19.5834 8.67712
+      vertex -8.66607 12.2254 8.73464
+      vertex -3.38512 19.5914 8.70035
+    endloop
+  endfacet
+  facet normal -0.415904 0.302171 0.857739
+    outer loop
+      vertex -8.66607 12.2254 8.73464
+      vertex -3.43882 19.5834 8.67712
+      vertex -8.92332 12.0346 8.67712
+    endloop
+  endfacet
+  facet normal -0.272487 0.197974 0.941572
+    outer loop
+      vertex -3.81518 19.5276 8.56459
+      vertex -9.35392 11.7153 8.60431
+      vertex -3.75373 19.5367 8.58046
+    endloop
+  endfacet
+  facet normal -0.272441 0.197942 0.941592
+    outer loop
+      vertex -3.81518 19.5276 8.56459
+      vertex -9.5159 11.5952 8.58269
+      vertex -9.35392 11.7153 8.60431
+    endloop
+  endfacet
+  facet normal -0.27268 0.198113 0.941487
+    outer loop
+      vertex -9.5159 11.5952 8.58269
+      vertex -3.81518 19.5276 8.56459
+      vertex -9.699 11.4292 8.56459
+    endloop
+  endfacet
+  facet normal 0.272484 -0.197972 0.941573
+    outer loop
+      vertex -5.33444 19.1539 8.61418
+      vertex -12.4875 9.07272 8.56459
+      vertex -5.12501 19.2063 8.56459
+    endloop
+  endfacet
+  facet normal 0.272448 -0.197946 0.941589
+    outer loop
+      vertex -12.4875 9.07272 8.56459
+      vertex -5.33444 19.1539 8.61418
+      vertex -12.5997 9.15418 8.61418
+    endloop
+  endfacet
+  facet normal 0.196781 -0.14297 -0.969967
+    outer loop
+      vertex -12.372 8.98878 11.4712
+      vertex -5.12501 19.2063 11.4354
+      vertex -4.90924 19.2604 11.4712
+    endloop
+  endfacet
+  facet normal 0.196758 -0.142953 -0.969974
+    outer loop
+      vertex -5.12501 19.2063 11.4354
+      vertex -12.372 8.98878 11.4712
+      vertex -12.4875 9.07272 11.4354
+    endloop
+  endfacet
+  facet normal 0.587864 0.80896 -0.000214464
+    outer loop
+      vertex -12.372 8.98878 11.4712
+      vertex -12.1353 8.81678 11.5
+      vertex -12.7073 9.2324 11.3229
+    endloop
+  endfacet
+  facet normal 0.345936 -0.251338 -0.903968
+    outer loop
+      vertex -5.53552 19.1035 11.3229
+      vertex -5.41187 19.1345 11.3616
+      vertex -12.7073 9.2324 11.3229
+    endloop
+  endfacet
+  facet normal 0.588794 0.808271 -0.00445577
+    outer loop
+      vertex -12.4875 9.07272 11.4354
+      vertex -12.372 8.98878 11.4712
+      vertex -12.5997 9.15418 11.3858
+    endloop
+  endfacet
+  facet normal 0.415686 -0.302014 -0.8579
+    outer loop
+      vertex -5.65104 19.0746 11.2771
+      vertex -5.53552 19.1035 11.3229
+      vertex -12.7073 9.2324 11.3229
+    endloop
+  endfacet
+  facet normal 0.586944 0.809627 0.00127793
+    outer loop
+      vertex -12.8095 9.30661 11.2472
+      vertex -12.7073 9.2324 11.3229
+      vertex -13.0733 9.49832 10.9516
+    endloop
+  endfacet
+  facet normal 0.693862 -0.50412 0.514216
+    outer loop
+      vertex -13.2055 9.59435 9.2929
+      vertex -6.41224 18.8157 9.16664
+      vertex -6.53865 18.7705 9.2929
+    endloop
+  endfacet
+  facet normal 0.693966 -0.504199 0.513999
+    outer loop
+      vertex -6.41224 18.8157 9.16664
+      vertex -13.2055 9.59435 9.2929
+      vertex -13.1443 9.54987 9.16664
+    endloop
+  endfacet
+  facet normal 0.587527 0.809204 -0.000205287
+    outer loop
+      vertex -13.2055 9.59435 9.2929
+      vertex -13.2564 9.63134 9.42597
+      vertex -13.2965 9.66049 9.56457
+    endloop
+  endfacet
+  facet normal 0.761627 -0.553354 -0.337229
+    outer loop
+      vertex -6.69019 18.7162 10.4963
+      vertex -13.2965 9.66049 10.4354
+      vertex -6.7266 18.7032 10.4354
+    endloop
+  endfacet
+  facet normal 0.761753 -0.553448 -0.336791
+    outer loop
+      vertex -13.2965 9.66049 10.4354
+      vertex -6.69019 18.7162 10.4963
+      vertex -13.2564 9.63134 10.574
+    endloop
+  endfacet
+  facet normal 0.784645 -0.570077 -0.243607
+    outer loop
+      vertex -13.2965 9.66049 10.4354
+      vertex -6.75302 18.6938 10.3723
+      vertex -6.7266 18.7032 10.4354
+    endloop
+  endfacet
+  facet normal 0.784712 -0.570123 -0.243282
+    outer loop
+      vertex -6.75302 18.6938 10.3723
+      vertex -13.2965 9.66049 10.4354
+      vertex -13.3255 9.68151 10.2926
+    endloop
+  endfacet
+  facet normal 0.59954 -0.435588 -0.671428
+    outer loop
+      vertex -12.9933 9.44022 11.0607
+      vertex -6.26578 18.8681 10.9516
+      vertex -6.10066 18.9272 11.0607
+    endloop
+  endfacet
+  facet normal 0.599472 -0.435541 -0.671519
+    outer loop
+      vertex -6.26578 18.8681 10.9516
+      vertex -12.9933 9.44022 11.0607
+      vertex -13.0733 9.49832 10.9516
+    endloop
+  endfacet
+  facet normal 0.78491 -0.570276 -0.242282
+    outer loop
+      vertex -6.78634 18.6818 10.2926
+      vertex -6.75302 18.6938 10.3723
+      vertex -13.3255 9.68151 10.2926
+    endloop
+  endfacet
+  facet normal 0.7619 -0.553549 0.336291
+    outer loop
+      vertex -6.64377 18.7329 9.42597
+      vertex -6.69019 18.7162 9.50365
+      vertex -13.2564 9.63134 9.42597
+    endloop
+  endfacet
+  facet normal 0.118709 -0.0862474 0.989176
+    outer loop
+      vertex -4.90924 19.2604 8.52882
+      vertex -12.2542 8.9032 8.50722
+      vertex -4.68922 19.3155 8.50722
+    endloop
+  endfacet
+  facet normal 0.118716 -0.086252 0.989175
+    outer loop
+      vertex -12.2542 8.9032 8.50722
+      vertex -4.90924 19.2604 8.52882
+      vertex -12.372 8.98878 8.52882
+    endloop
+  endfacet
+  facet normal 0.415819 -0.302111 0.857801
+    outer loop
+      vertex -5.53552 19.1035 8.67712
+      vertex -5.65104 19.0746 8.72294
+      vertex -12.7073 9.2324 8.67712
+    endloop
+  endfacet
+  facet normal 0.586944 0.809626 -0.00127714
+    outer loop
+      vertex -12.7073 9.2324 8.67712
+      vertex -12.8095 9.30661 8.7528
+      vertex -13.0733 9.49832 9.04841
+    endloop
+  endfacet
+  facet normal 0.78487 -0.570247 0.242483
+    outer loop
+      vertex -6.75302 18.6938 9.62773
+      vertex -6.78634 18.6818 9.70736
+      vertex -13.3255 9.68151 9.70736
+    endloop
+  endfacet
+  facet normal 0.58612 0.810224 0
+    outer loop
+      vertex -12.1212 8.80658 11.4991
+      vertex -12.1212 8.80658 11.4983
+      vertex -12.1353 8.81678 11.5
+    endloop
+  endfacet
+  facet normal -0.808044 0.587078 0.0490234
+    outer loop
+      vertex -2.35036 19.7449 9.85297
+      vertex -7.07922 13.2239 10
+      vertex -2.34035 19.7464 10
+    endloop
+  endfacet
+  facet normal -0.808048 0.587079 0.0489559
+    outer loop
+      vertex -7.07922 13.2239 10
+      vertex -2.35036 19.7449 9.85297
+      vertex -7.09503 13.2144 9.85297
+    endloop
+  endfacet
+  facet normal -0.784738 0.570145 -0.243149
+    outer loop
+      vertex -7.14233 13.186 10.2926
+      vertex -2.42983 19.7331 10.4354
+      vertex -2.38028 19.7404 10.2926
+    endloop
+  endfacet
+  facet normal -0.78475 0.570153 -0.243092
+    outer loop
+      vertex -2.42983 19.7331 10.4354
+      vertex -7.14233 13.186 10.2926
+      vertex -7.22064 13.1391 10.4354
+    endloop
+  endfacet
+  facet normal -0.800291 0.581443 -0.146485
+    outer loop
+      vertex -7.09503 13.2144 10.147
+      vertex -2.38028 19.7404 10.2926
+      vertex -2.35036 19.7449 10.147
+    endloop
+  endfacet
+  facet normal -0.80028 0.581437 -0.146569
+    outer loop
+      vertex -2.38028 19.7404 10.2926
+      vertex -7.09503 13.2144 10.147
+      vertex -7.14233 13.186 10.2926
+    endloop
+  endfacet
+  facet normal -0.346337 0.251627 -0.903734
+    outer loop
+      vertex -8.92332 12.0346 11.3229
+      vertex -3.49614 19.5749 11.3425
+      vertex -3.43882 19.5834 11.3229
+    endloop
+  endfacet
+  facet normal -0.345452 0.250992 -0.904249
+    outer loop
+      vertex -3.49614 19.5749 11.3425
+      vertex -8.92332 12.0346 11.3229
+      vertex -9.20589 11.8251 11.3727
+    endloop
+  endfacet
+  facet normal -0.731305 0.531321 0.427658
+    outer loop
+      vertex -2.58573 19.71 9.2929
+      vertex -7.32922 13.074 9.42597
+      vertex -2.49854 19.7229 9.42597
+    endloop
+  endfacet
+  facet normal -0.731339 0.531344 0.427571
+    outer loop
+      vertex -7.32922 13.074 9.42597
+      vertex -2.58573 19.71 9.2929
+      vertex -7.46703 12.9914 9.2929
+    endloop
+  endfacet
+  facet normal -0.69399 0.504208 0.513957
+    outer loop
+      vertex -2.69057 19.6944 9.16664
+      vertex -7.46703 12.9914 9.2929
+      vertex -2.58573 19.71 9.2929
+    endloop
+  endfacet
+  facet normal -0.693893 0.504143 0.514151
+    outer loop
+      vertex -7.46703 12.9914 9.2929
+      vertex -2.69057 19.6944 9.16664
+      vertex -7.63273 12.8921 9.16664
+    endloop
+  endfacet
+  facet normal -0.599733 0.435729 0.671163
+    outer loop
+      vertex -2.85151 19.6705 9.01698
+      vertex -7.82473 12.777 9.04841
+      vertex -2.81205 19.6764 9.04841
+    endloop
+  endfacet
+  facet normal -0.599416 0.435502 0.671594
+    outer loop
+      vertex -7.82473 12.777 9.04841
+      vertex -2.85151 19.6705 9.01698
+      vertex -7.9809 12.6834 8.96972
+    endloop
+  endfacet
+  facet normal -0.599296 0.435413 0.671759
+    outer loop
+      vertex -2.949 19.6561 8.93934
+      vertex -7.9809 12.6834 8.96972
+      vertex -2.85151 19.6705 9.01698
+    endloop
+  endfacet
+  facet normal -0.599308 0.435422 0.671743
+    outer loop
+      vertex -7.9809 12.6834 8.96972
+      vertex -2.949 19.6561 8.93934
+      vertex -8.04118 12.6473 8.93934
+    endloop
+  endfacet
+  facet normal -0.761725 0.553424 0.336892
+    outer loop
+      vertex -2.49854 19.7229 9.42597
+      vertex -7.22064 13.1391 9.56457
+      vertex -2.42983 19.7331 9.56457
+    endloop
+  endfacet
+  facet normal -0.76175 0.55344 0.33681
+    outer loop
+      vertex -7.22064 13.1391 9.56457
+      vertex -2.49854 19.7229 9.42597
+      vertex -7.32922 13.074 9.42597
+    endloop
+  endfacet
+  facet normal -0.0396764 0.0288267 0.998797
+    outer loop
+      vertex -4.39048 19.3903 8.50249
+      vertex -10.8412 10.3478 8.50722
+      vertex -4.24489 19.4268 8.50722
+    endloop
+  endfacet
+  facet normal -0.0394537 0.0286679 0.99881
+    outer loop
+      vertex -10.8412 10.3478 8.50722
+      vertex -4.39048 19.3903 8.50249
+      vertex -10.9269 10.2532 8.50655
+    endloop
+  endfacet
+  facet normal -0.0396698 0.0288224 0.998797
+    outer loop
+      vertex -4.46705 19.3712 8.5
+      vertex -10.9269 10.2532 8.50655
+      vertex -4.39048 19.3903 8.50249
+    endloop
+  endfacet
+  facet normal -0.0396912 0.0288376 0.998796
+    outer loop
+      vertex -4.46705 19.3712 8.5
+      vertex -11.5952 9.5159 8.50128
+      vertex -10.9269 10.2532 8.50655
+    endloop
+  endfacet
+  facet normal -0.0397547 0.0288835 0.998792
+    outer loop
+      vertex -12.1353 8.81678 8.5
+      vertex -11.5952 9.5159 8.50128
+      vertex -4.46705 19.3712 8.5
+    endloop
+  endfacet
+  facet normal -0.0394742 0.0286668 0.998809
+    outer loop
+      vertex -11.5952 9.5159 8.50128
+      vertex -12.1353 8.81678 8.5
+      vertex -12.1212 8.80658 8.50085
+    endloop
+  endfacet
+  facet normal -0.481923 0.350133 0.803216
+    outer loop
+      vertex -3.2639 19.6094 8.7528
+      vertex -8.28 12.5041 8.84048
+      vertex -3.10011 19.6337 8.84048
+    endloop
+  endfacet
+  facet normal -0.481979 0.350172 0.803167
+    outer loop
+      vertex -3.2639 19.6094 8.7528
+      vertex -8.33355 12.472 8.82234
+      vertex -8.28 12.5041 8.84048
+    endloop
+  endfacet
+  facet normal -0.481864 0.350091 0.803271
+    outer loop
+      vertex -8.33355 12.472 8.82234
+      vertex -3.2639 19.6094 8.7528
+      vertex -8.5849 12.2856 8.7528
+    endloop
+  endfacet
+  facet normal -0.196921 0.144503 0.969712
+    outer loop
+      vertex -4.02486 19.4819 8.52882
+      vertex -3.81518 19.5276 8.56459
+      vertex -3.8823 19.5176 8.55245
+    endloop
+  endfacet
+  facet normal -0.196613 0.142847 0.97002
+    outer loop
+      vertex -4.02486 19.4819 8.52882
+      vertex -9.699 11.4292 8.56459
+      vertex -3.81518 19.5276 8.56459
+    endloop
+  endfacet
+  facet normal -0.196602 0.142839 0.970023
+    outer loop
+      vertex -9.699 11.4292 8.56459
+      vertex -4.02486 19.4819 8.52882
+      vertex -10.2158 10.9608 8.52882
+    endloop
+  endfacet
+  facet normal -0.345903 0.251312 0.903987
+    outer loop
+      vertex -3.49614 19.5749 8.65755
+      vertex -8.92332 12.0346 8.67712
+      vertex -3.43882 19.5834 8.67712
+    endloop
+  endfacet
+  facet normal -0.345784 0.251227 0.904056
+    outer loop
+      vertex -8.92332 12.0346 8.67712
+      vertex -3.49614 19.5749 8.65755
+      vertex -9.20589 11.8251 8.62726
+    endloop
+  endfacet
+  facet normal 0.196626 -0.142857 0.970015
+    outer loop
+      vertex -5.12501 19.2063 8.56459
+      vertex -12.372 8.98878 8.52882
+      vertex -4.90924 19.2604 8.52882
+    endloop
+  endfacet
+  facet normal 0.196603 -0.142841 0.970023
+    outer loop
+      vertex -12.372 8.98878 8.52882
+      vertex -5.12501 19.2063 8.56459
+      vertex -12.4875 9.07272 8.56459
+    endloop
+  endfacet
+  facet normal 0.588792 0.808272 0.00445003
+    outer loop
+      vertex -12.372 8.98878 8.52882
+      vertex -12.4875 9.07272 8.56459
+      vertex -12.5997 9.15418 8.61418
+    endloop
+  endfacet
+  facet normal 0.587178 0.809455 -0.00214745
+    outer loop
+      vertex -12.372 8.98878 8.52882
+      vertex -12.5997 9.15418 8.61418
+      vertex -12.7073 9.2324 8.67712
+    endloop
+  endfacet
+  facet normal 0.345849 -0.251275 0.904018
+    outer loop
+      vertex -5.41187 19.1345 8.63841
+      vertex -12.5997 9.15418 8.61418
+      vertex -5.33444 19.1539 8.61418
+    endloop
+  endfacet
+  facet normal 0.346003 -0.251386 0.903929
+    outer loop
+      vertex -12.5997 9.15418 8.61418
+      vertex -5.41187 19.1345 8.63841
+      vertex -12.7073 9.2324 8.67712
+    endloop
+  endfacet
+  facet normal 0.416528 -0.302615 -0.85728
+    outer loop
+      vertex -12.7073 9.2324 11.3229
+      vertex -5.72631 19.0557 11.2472
+      vertex -5.65104 19.0746 11.2771
+    endloop
+  endfacet
+  facet normal 0.415909 -0.302178 -0.857734
+    outer loop
+      vertex -5.72631 19.0557 11.2472
+      vertex -12.7073 9.2324 11.3229
+      vertex -12.8095 9.30661 11.2472
+    endloop
+  endfacet
+  facet normal 0.5883 0.808643 -0.000465286
+    outer loop
+      vertex -12.9051 9.37611 11.1595
+      vertex -12.8095 9.30661 11.2472
+      vertex -12.9933 9.44022 11.0607
+    endloop
+  endfacet
+  facet normal 0.800254 -0.581417 -0.146792
+    outer loop
+      vertex -6.78634 18.6818 10.2926
+      vertex -13.3429 9.69421 10.147
+      vertex -6.82242 18.6689 10.147
+    endloop
+  endfacet
+  facet normal 0.800302 -0.58146 -0.146359
+    outer loop
+      vertex -13.3429 9.69421 10.147
+      vertex -6.78634 18.6818 10.2926
+      vertex -13.3255 9.68151 10.2926
+    endloop
+  endfacet
+  facet normal 0.587901 0.808933 1.38636e-05
+    outer loop
+      vertex -13.2055 9.59435 10.7071
+      vertex -13.1443 9.54987 10.8334
+      vertex -13.2965 9.66049 10.4354
+    endloop
+  endfacet
+  facet normal 0.731362 -0.531362 -0.42751
+    outer loop
+      vertex -6.53865 18.7705 10.7071
+      vertex -13.2564 9.63134 10.574
+      vertex -6.64377 18.7329 10.574
+    endloop
+  endfacet
+  facet normal 0.731408 -0.531398 -0.427386
+    outer loop
+      vertex -13.2564 9.63134 10.574
+      vertex -6.53865 18.7705 10.7071
+      vertex -13.2055 9.59435 10.7071
+    endloop
+  endfacet
+  facet normal 0.649741 -0.472067 -0.59581
+    outer loop
+      vertex -6.26578 18.8681 10.9516
+      vertex -13.1443 9.54987 10.8334
+      vertex -6.41224 18.8157 10.8334
+    endloop
+  endfacet
+  facet normal 0.649606 -0.471964 -0.596039
+    outer loop
+      vertex -13.1443 9.54987 10.8334
+      vertex -6.26578 18.8681 10.9516
+      vertex -13.0733 9.49832 10.9516
+    endloop
+  endfacet
+  facet normal 0.588299 0.808644 0.000463255
+    outer loop
+      vertex -12.8095 9.30661 8.7528
+      vertex -12.9051 9.37611 8.84048
+      vertex -12.9933 9.44022 8.93934
+    endloop
+  endfacet
+  facet normal 0.589039 0.808103 0.00158029
+    outer loop
+      vertex -12.8095 9.30661 8.7528
+      vertex -12.9933 9.44022 8.93934
+      vertex -13.0733 9.49832 9.04841
+    endloop
+  endfacet
+  facet normal 0.543358 -0.394771 0.74089
+    outer loop
+      vertex -6.10066 18.9272 8.93934
+      vertex -12.9051 9.37611 8.84048
+      vertex -5.91849 18.9924 8.84048
+    endloop
+  endfacet
+  facet normal 0.543405 -0.394804 0.740838
+    outer loop
+      vertex -12.9051 9.37611 8.84048
+      vertex -6.10066 18.9272 8.93934
+      vertex -12.9933 9.44022 8.93934
+    endloop
+  endfacet
+  facet normal 0.599465 -0.435534 0.671529
+    outer loop
+      vertex -6.26578 18.8681 9.04841
+      vertex -12.9933 9.44022 8.93934
+      vertex -6.10066 18.9272 8.93934
+    endloop
+  endfacet
+  facet normal 0.599398 -0.435487 0.67162
+    outer loop
+      vertex -12.9933 9.44022 8.93934
+      vertex -6.26578 18.8681 9.04841
+      vertex -13.0733 9.49832 9.04841
+    endloop
+  endfacet
+  facet normal 0.731332 -0.53134 0.427588
+    outer loop
+      vertex -13.2564 9.63134 9.42597
+      vertex -6.53865 18.7705 9.2929
+      vertex -6.64377 18.7329 9.42597
+    endloop
+  endfacet
+  facet normal 0.731378 -0.531376 0.427465
+    outer loop
+      vertex -6.53865 18.7705 9.2929
+      vertex -13.2564 9.63134 9.42597
+      vertex -13.2055 9.59435 9.2929
+    endloop
+  endfacet
+  facet normal 0.481844 -0.35042 0.803139
+    outer loop
+      vertex -5.91849 18.9924 8.84048
+      vertex -5.72631 19.0557 8.7528
+      vertex -5.77666 19.0431 8.77751
+    endloop
+  endfacet
+  facet normal 0.481807 -0.350056 0.80332
+    outer loop
+      vertex -5.91849 18.9924 8.84048
+      vertex -12.8095 9.30661 8.7528
+      vertex -5.72631 19.0557 8.7528
+    endloop
+  endfacet
+  facet normal 0.48201 -0.350199 0.803136
+    outer loop
+      vertex -12.8095 9.30661 8.7528
+      vertex -5.91849 18.9924 8.84048
+      vertex -12.9051 9.37611 8.84048
+    endloop
+  endfacet
+  facet normal -0.808044 0.587078 -0.0490334
+    outer loop
+      vertex -7.07922 13.2239 10
+      vertex -2.35036 19.7449 10.147
+      vertex -2.34035 19.7464 10
+    endloop
+  endfacet
+  facet normal -0.808047 0.587079 -0.0489659
+    outer loop
+      vertex -2.35036 19.7449 10.147
+      vertex -7.07922 13.2239 10
+      vertex -7.09503 13.2144 10.147
+    endloop
+  endfacet
+  facet normal -0.649713 0.472044 -0.595858
+    outer loop
+      vertex -7.63273 12.8921 10.8334
+      vertex -2.81205 19.6764 10.9516
+      vertex -2.69057 19.6944 10.8334
+    endloop
+  endfacet
+  facet normal -0.649771 0.472084 -0.595763
+    outer loop
+      vertex -2.81205 19.6764 10.9516
+      vertex -7.63273 12.8921 10.8334
+      vertex -7.82473 12.777 10.9516
+    endloop
+  endfacet
+  facet normal -0.118703 0.0862427 -0.989177
+    outer loop
+      vertex -10.2158 10.9608 11.4712
+      vertex -4.24489 19.4268 11.4928
+      vertex -4.02486 19.4819 11.4712
+    endloop
+  endfacet
+  facet normal -0.118598 0.0861688 -0.989196
+    outer loop
+      vertex -10.6066 10.6066 11.4872
+      vertex -4.24489 19.4268 11.4928
+      vertex -10.2158 10.9608 11.4712
+    endloop
+  endfacet
+  facet normal -0.118943 0.0864172 -0.989133
+    outer loop
+      vertex -4.24489 19.4268 11.4928
+      vertex -10.6066 10.6066 11.4872
+      vertex -10.8412 10.3478 11.4928
+    endloop
+  endfacet
+  facet normal -0.416957 0.302911 -0.856967
+    outer loop
+      vertex -8.66607 12.2254 11.2654
+      vertex -3.43882 19.5834 11.3229
+      vertex -3.38512 19.5914 11.2996
+    endloop
+  endfacet
+  facet normal -0.415798 0.302093 -0.857818
+    outer loop
+      vertex -3.43882 19.5834 11.3229
+      vertex -8.66607 12.2254 11.2654
+      vertex -8.92332 12.0346 11.3229
+    endloop
+  endfacet
+  facet normal -0.649772 0.472087 0.59576
+    outer loop
+      vertex -2.81205 19.6764 9.04841
+      vertex -7.63273 12.8921 9.16664
+      vertex -2.69057 19.6944 9.16664
+    endloop
+  endfacet
+  facet normal -0.64983 0.472126 0.595666
+    outer loop
+      vertex -7.63273 12.8921 9.16664
+      vertex -2.81205 19.6764 9.04841
+      vertex -7.82473 12.777 9.04841
+    endloop
+  endfacet
+  facet normal -0.415983 0.302226 0.857681
+    outer loop
+      vertex -3.38512 19.5914 8.70035
+      vertex -8.5849 12.2856 8.7528
+      vertex -3.2639 19.6094 8.7528
+    endloop
+  endfacet
+  facet normal -0.416063 0.302283 0.857622
+    outer loop
+      vertex -8.5849 12.2856 8.7528
+      vertex -3.38512 19.5914 8.70035
+      vertex -8.66607 12.2254 8.73464
+    endloop
+  endfacet
+  facet normal -0.543212 0.394667 0.741053
+    outer loop
+      vertex -3.10011 19.6337 8.84048
+      vertex -8.10609 12.6084 8.91247
+      vertex -3.05548 19.6403 8.86968
+    endloop
+  endfacet
+  facet normal -0.543446 0.394831 0.740794
+    outer loop
+      vertex -8.10609 12.6084 8.91247
+      vertex -3.10011 19.6337 8.84048
+      vertex -8.28 12.5041 8.84048
+    endloop
+  endfacet
+  facet normal -0.345835 0.251264 0.904027
+    outer loop
+      vertex -3.62317 19.5561 8.61418
+      vertex -9.20589 11.8251 8.62726
+      vertex -3.49614 19.5749 8.65755
+    endloop
+  endfacet
+  facet normal -0.346177 0.251511 0.903827
+    outer loop
+      vertex -9.20589 11.8251 8.62726
+      vertex -3.62317 19.5561 8.61418
+      vertex -9.28 11.7701 8.61418
+    endloop
+  endfacet
+  facet normal -0.272598 0.198053 0.941523
+    outer loop
+      vertex -3.75373 19.5367 8.58046
+      vertex -9.28 11.7701 8.61418
+      vertex -3.62317 19.5561 8.61418
+    endloop
+  endfacet
+  facet normal -0.272489 0.197975 0.941571
+    outer loop
+      vertex -9.28 11.7701 8.61418
+      vertex -3.75373 19.5367 8.58046
+      vertex -9.35392 11.7153 8.60431
+    endloop
+  endfacet
+  facet normal 0.345499 -0.251021 -0.904223
+    outer loop
+      vertex -12.5997 9.15418 11.3858
+      vertex -5.41187 19.1345 11.3616
+      vertex -5.33444 19.1539 11.3858
+    endloop
+  endfacet
+  facet normal 0.345824 -0.251254 -0.904034
+    outer loop
+      vertex -5.41187 19.1345 11.3616
+      vertex -12.5997 9.15418 11.3858
+      vertex -12.7073 9.2324 11.3229
+    endloop
+  endfacet
+  facet normal 0.587177 0.809456 0.00215307
+    outer loop
+      vertex -12.5997 9.15418 11.3858
+      vertex -12.372 8.98878 11.4712
+      vertex -12.7073 9.2324 11.3229
+    endloop
+  endfacet
+  facet normal 0.543177 -0.394639 -0.741093
+    outer loop
+      vertex -12.9051 9.37611 11.1595
+      vertex -6.10066 18.9272 11.0607
+      vertex -5.91849 18.9924 11.1595
+    endloop
+  endfacet
+  facet normal 0.543224 -0.394672 -0.741041
+    outer loop
+      vertex -6.10066 18.9272 11.0607
+      vertex -12.9051 9.37611 11.1595
+      vertex -12.9933 9.44022 11.0607
+    endloop
+  endfacet
+  facet normal -0.543212 0.394668 -0.741052
+    outer loop
+      vertex -8.10609 12.6084 11.0875
+      vertex -3.10011 19.6337 11.1595
+      vertex -3.05548 19.6403 11.1303
+    endloop
+  endfacet
+  facet normal -0.543487 0.394861 -0.740747
+    outer loop
+      vertex -3.10011 19.6337 11.1595
+      vertex -8.10609 12.6084 11.0875
+      vertex -8.28 12.5041 11.1595
+    endloop
+  endfacet
+  facet normal -0.543049 0.394547 -0.741236
+    outer loop
+      vertex -8.04118 12.6473 11.0607
+      vertex -3.05548 19.6403 11.1303
+      vertex -2.949 19.6561 11.0607
+    endloop
+  endfacet
+  facet normal -0.542509 0.394168 -0.741833
+    outer loop
+      vertex -3.05548 19.6403 11.1303
+      vertex -8.04118 12.6473 11.0607
+      vertex -8.10609 12.6084 11.0875
+    endloop
+  endfacet
+  facet normal -0.481994 0.350185 -0.803151
+    outer loop
+      vertex -8.28 12.5041 11.1595
+      vertex -3.2639 19.6094 11.2472
+      vertex -3.10011 19.6337 11.1595
+    endloop
+  endfacet
+  facet normal -0.48299 0.350876 -0.802251
+    outer loop
+      vertex -8.33355 12.472 11.1777
+      vertex -3.2639 19.6094 11.2472
+      vertex -8.28 12.5041 11.1595
+    endloop
+  endfacet
+  facet normal -0.481685 0.349961 -0.803435
+    outer loop
+      vertex -3.2639 19.6094 11.2472
+      vertex -8.33355 12.472 11.1777
+      vertex -8.5849 12.2856 11.2472
+    endloop
+  endfacet
+  facet normal -0.272942 0.198293 -0.941373
+    outer loop
+      vertex -9.35392 11.7153 11.3957
+      vertex -3.81518 19.5276 11.4354
+      vertex -3.75373 19.5367 11.4195
+    endloop
+  endfacet
+  facet normal -0.27222 0.197783 -0.941689
+    outer loop
+      vertex -9.5159 11.5952 11.4173
+      vertex -3.81518 19.5276 11.4354
+      vertex -9.35392 11.7153 11.3957
+    endloop
+  endfacet
+  facet normal -0.27268 0.198113 -0.941487
+    outer loop
+      vertex -3.81518 19.5276 11.4354
+      vertex -9.5159 11.5952 11.4173
+      vertex -9.699 11.4292 11.4354
+    endloop
+  endfacet
+  facet normal -0.272455 0.197949 -0.941586
+    outer loop
+      vertex -9.28 11.7701 11.3858
+      vertex -3.75373 19.5367 11.4195
+      vertex -3.62317 19.5561 11.3858
+    endloop
+  endfacet
+  facet normal -0.273203 0.19848 -0.941258
+    outer loop
+      vertex -3.75373 19.5367 11.4195
+      vertex -9.28 11.7701 11.3858
+      vertex -9.35392 11.7153 11.3957
+    endloop
+  endfacet
+  facet normal 0.808032 0.587069 -0.0493305
+    outer loop
+      vertex -13.3429 -9.69421 10.147
+      vertex -19.8641 -0.730897 10
+      vertex -19.8647 -0.717719 10.147
+    endloop
+  endfacet
+  facet normal 0.80803 0.587067 -0.0494041
+    outer loop
+      vertex -19.8641 -0.730897 10
+      vertex -13.3429 -9.69421 10.147
+      vertex -13.3488 -9.69846 10
+    endloop
+  endfacet
+  facet normal 0.731546 0.531501 0.427022
+    outer loop
+      vertex -19.8775 -0.457592 9.3507
+      vertex -13.2055 -9.59435 9.2929
+      vertex -19.88 -0.407713 9.2929
+    endloop
+  endfacet
+  facet normal 0.731378 0.531375 0.427465
+    outer loop
+      vertex -13.2055 -9.59435 9.2929
+      vertex -19.8775 -0.457592 9.3507
+      vertex -13.2564 -9.63134 9.42597
+    endloop
+  endfacet
+  facet normal -0.64991 -0.472187 0.59553
+    outer loop
+      vertex -19.582 3.44805 9.08211
+      vertex -14.6268 -3.26558 9.16664
+      vertex -19.5689 3.53663 9.16664
+    endloop
+  endfacet
+  facet normal -0.649751 -0.472067 0.595799
+    outer loop
+      vertex -14.6268 -3.26558 9.16664
+      vertex -19.582 3.44805 9.08211
+      vertex -14.61 -3.33265 9.13182
+    endloop
+  endfacet
+  facet normal -0.272539 -0.198009 -0.941549
+    outer loop
+      vertex -19.739 2.38971 11.4354
+      vertex -14.0496 -5.20533 11.3858
+      vertex -13.8834 -5.66994 11.4354
+    endloop
+  endfacet
+  facet normal -0.272656 -0.198096 -0.941497
+    outer loop
+      vertex -14.0496 -5.20533 11.3858
+      vertex -19.739 2.38971 11.4354
+      vertex -19.71 2.58553 11.3858
+    endloop
+  endfacet
+  facet normal -0.542946 -0.394464 0.741355
+    outer loop
+      vertex -19.6309 3.11897 8.84048
+      vertex -14.4863 -3.82667 8.91255
+      vertex -19.6241 3.16447 8.86967
+    endloop
+  endfacet
+  facet normal -0.543534 -0.394907 0.740688
+    outer loop
+      vertex -14.4863 -3.82667 8.91255
+      vertex -19.6309 3.11897 8.84048
+      vertex -14.4345 -4.03314 8.84048
+    endloop
+  endfacet
+  facet normal 0.118716 0.0862519 -0.989175
+    outer loop
+      vertex -19.8368 1.28568 11.4712
+      vertex -12.2542 -8.9032 11.4928
+      vertex -12.372 -8.98878 11.4712
+    endloop
+  endfacet
+  facet normal 0.11871 0.0862476 -0.989176
+    outer loop
+      vertex -12.2542 -8.9032 11.4928
+      vertex -19.8368 1.28568 11.4712
+      vertex -19.8254 1.51772 11.4928
+    endloop
+  endfacet
+  facet normal -0.590606 0.806959 -0.00115761
+    outer loop
+      vertex -13.2564 -9.63134 9.42597
+      vertex -13.2965 -9.66049 9.56457
+      vertex -13.3255 -9.68151 9.70736
+    endloop
+  endfacet
+  facet normal -0.587933 0.80891 0
+    outer loop
+      vertex -13.2564 -9.63134 10.574
+      vertex -13.3429 -9.69421 9.85297
+      vertex -13.3429 -9.69421 10.147
+    endloop
+  endfacet
+  facet normal -0.587933 0.80891 0
+    outer loop
+      vertex -13.3429 -9.69421 9.85297
+      vertex -13.2564 -9.63134 10.574
+      vertex -13.2564 -9.63134 9.42597
+    endloop
+  endfacet
+  facet normal -0.585592 0.810605 0.000723751
+    outer loop
+      vertex -13.2564 -9.63134 9.42597
+      vertex -13.3255 -9.68151 9.70736
+      vertex -13.3429 -9.69421 9.85297
+    endloop
+  endfacet
+  facet normal 0.345823 0.251256 -0.904034
+    outer loop
+      vertex -19.8693 0.625218 11.3229
+      vertex -12.5997 -9.15418 11.3858
+      vertex -12.7073 -9.2324 11.3229
+    endloop
+  endfacet
+  facet normal 0.345762 0.25121 -0.90407
+    outer loop
+      vertex -12.5997 -9.15418 11.3858
+      vertex -19.8693 0.625218 11.3229
+      vertex -19.8589 0.837272 11.3858
+    endloop
+  endfacet
+  facet normal -0.585592 0.810606 -0.000723873
+    outer loop
+      vertex -13.3255 -9.68151 10.2926
+      vertex -13.2564 -9.63134 10.574
+      vertex -13.3429 -9.69421 10.147
+    endloop
+  endfacet
+  facet normal -0.586992 0.809591 -0.00179117
+    outer loop
+      vertex -12.5997 -9.15418 11.3858
+      vertex -12.4875 -9.07272 11.4354
+      vertex -12.9051 -9.37611 11.1595
+    endloop
+  endfacet
+  facet normal -0.58612 0.810224 0
+    outer loop
+      vertex -12.1353 -8.81678 8.5
+      vertex -12.1212 -8.80658 8.50722
+      vertex -12.1212 -8.80658 8.50085
+    endloop
+  endfacet
+  facet normal -0.587738 0.809037 0.00483774
+    outer loop
+      vertex -12.1212 -8.80658 8.50722
+      vertex -12.1353 -8.81678 8.5
+      vertex -12.2542 -8.9032 8.50722
+    endloop
+  endfacet
+  facet normal -0.588093 0.808793 -0.000518932
+    outer loop
+      vertex -12.9933 -9.44022 8.93934
+      vertex -13.0733 -9.49832 9.04841
+      vertex -13.1443 -9.54987 9.16664
+    endloop
+  endfacet
+  facet normal 0.599641 0.435665 -0.671287
+    outer loop
+      vertex -13.0733 -9.49832 10.9516
+      vertex -19.8946 -0.109622 10.9516
+      vertex -19.8998 -0.00415969 11.0154
+    endloop
+  endfacet
+  facet normal -0.590605 0.80696 0.00115734
+    outer loop
+      vertex -13.2965 -9.66049 10.4354
+      vertex -13.2564 -9.63134 10.574
+      vertex -13.3255 -9.68151 10.2926
+    endloop
+  endfacet
+  facet normal -0.58786 0.808963 0.000213569
+    outer loop
+      vertex -12.4875 -9.07272 11.4354
+      vertex -12.2542 -8.9032 11.4928
+      vertex -12.9051 -9.37611 11.1595
+    endloop
+  endfacet
+  facet normal 0.731546 0.531501 -0.427022
+    outer loop
+      vertex -13.2055 -9.59435 10.7071
+      vertex -19.8775 -0.457592 10.6493
+      vertex -19.88 -0.407713 10.7071
+    endloop
+  endfacet
+  facet normal 0.731408 0.531398 -0.427386
+    outer loop
+      vertex -19.8775 -0.457592 10.6493
+      vertex -13.2055 -9.59435 10.7071
+      vertex -13.2564 -9.63134 10.574
+    endloop
+  endfacet
+  facet normal 0.761709 0.553412 -0.336948
+    outer loop
+      vertex -13.2564 -9.63134 10.574
+      vertex -19.8718 -0.573303 10.4963
+      vertex -19.8743 -0.522554 10.574
+    endloop
+  endfacet
+  facet normal -0.586668 0.809827 0.000926953
+    outer loop
+      vertex -12.9933 -9.44022 8.93934
+      vertex -13.1443 -9.54987 9.16664
+      vertex -13.2055 -9.59435 9.2929
+    endloop
+  endfacet
+  facet normal -0.543658 -0.394997 -0.740549
+    outer loop
+      vertex -19.6309 3.11897 11.1595
+      vertex -14.4863 -3.82667 11.0874
+      vertex -14.4345 -4.03314 11.1595
+    endloop
+  endfacet
+  facet normal -0.543048 -0.394539 -0.741241
+    outer loop
+      vertex -14.4863 -3.82667 11.0874
+      vertex -19.6309 3.11897 11.1595
+      vertex -19.6241 3.16447 11.1303
+    endloop
+  endfacet
+  facet normal -0.808041 -0.587072 -0.0491451
+    outer loop
+      vertex -14.7505 -2.66523 10
+      vertex -19.5173 3.88345 10.147
+      vertex -19.515 3.89259 10
+    endloop
+  endfacet
+  facet normal -0.808045 -0.587078 -0.0490202
+    outer loop
+      vertex -19.5173 3.88345 10.147
+      vertex -14.7505 -2.66523 10
+      vertex -14.7482 -2.68067 10.147
+    endloop
+  endfacet
+  facet normal 0.761566 0.553302 0.337452
+    outer loop
+      vertex -19.8699 -0.613042 9.56457
+      vertex -13.2564 -9.63134 9.42597
+      vertex -19.8718 -0.573303 9.5037
+    endloop
+  endfacet
+  facet normal 0.761752 0.553449 0.336791
+    outer loop
+      vertex -13.2564 -9.63134 9.42597
+      vertex -19.8699 -0.613042 9.56457
+      vertex -13.2965 -9.66049 9.56457
+    endloop
+  endfacet
+  facet normal -0.543344 -0.394761 0.740906
+    outer loop
+      vertex -19.6241 3.16447 8.86967
+      vertex -14.5055 -3.74994 8.93934
+      vertex -19.608 3.27307 8.93934
+    endloop
+  endfacet
+  facet normal -0.543214 -0.394663 0.741053
+    outer loop
+      vertex -14.5055 -3.74994 8.93934
+      vertex -19.6241 3.16447 8.86967
+      vertex -14.4863 -3.82667 8.91255
+    endloop
+  endfacet
+  facet normal -0.588328 0.808622 0.000504151
+    outer loop
+      vertex -12.9933 -9.44022 11.0607
+      vertex -12.9051 -9.37611 11.1595
+      vertex -13.2564 -9.63134 10.574
+    endloop
+  endfacet
+  facet normal -0.58733 0.809348 -0.000320798
+    outer loop
+      vertex -13.2055 -9.59435 10.7071
+      vertex -12.9933 -9.44022 11.0607
+      vertex -13.2564 -9.63134 10.574
+    endloop
+  endfacet
+  facet normal -0.587745 0.809046 0
+    outer loop
+      vertex -12.1212 -8.80658 11.4534
+      vertex -12.2542 -8.9032 11.4928
+      vertex -12.1212 -8.80658 11.4928
+    endloop
+  endfacet
+  facet normal -0.587761 0.809035 -8.17656e-05
+    outer loop
+      vertex -12.2542 -8.9032 11.4928
+      vertex -12.1212 -8.80658 11.4534
+      vertex -12.9051 -9.37611 11.1595
+    endloop
+  endfacet
+  facet normal -0.58612 0.810224 0
+    outer loop
+      vertex -12.1212 -8.80658 11.4928
+      vertex -12.1353 -8.81678 11.5
+      vertex -12.1212 -8.80658 11.4991
+    endloop
+  endfacet
+  facet normal -0.587738 0.809037 -0.00485118
+    outer loop
+      vertex -12.1353 -8.81678 11.5
+      vertex -12.1212 -8.80658 11.4928
+      vertex -12.2542 -8.9032 11.4928
+    endloop
+  endfacet
+  facet normal 0.731417 0.531404 -0.427364
+    outer loop
+      vertex -13.2564 -9.63134 10.574
+      vertex -19.8743 -0.522554 10.574
+      vertex -19.8775 -0.457592 10.6493
+    endloop
+  endfacet
+  facet normal 0.761607 0.553335 -0.337306
+    outer loop
+      vertex -13.2564 -9.63134 10.574
+      vertex -19.8699 -0.613042 10.4354
+      vertex -19.8718 -0.573303 10.4963
+    endloop
+  endfacet
+  facet normal 0.761752 0.553449 -0.336791
+    outer loop
+      vertex -19.8699 -0.613042 10.4354
+      vertex -13.2564 -9.63134 10.574
+      vertex -13.2965 -9.66049 10.4354
+    endloop
+  endfacet
+  facet normal 0.59947 0.435544 -0.671519
+    outer loop
+      vertex -19.8998 -0.00415969 11.0154
+      vertex -12.9933 -9.44022 11.0607
+      vertex -13.0733 -9.49832 10.9516
+    endloop
+  endfacet
+  facet normal 0.599606 0.435644 -0.671333
+    outer loop
+      vertex -12.9933 -9.44022 11.0607
+      vertex -19.8998 -0.00415969 11.0154
+      vertex -19.897 0.0617943 11.0607
+    endloop
+  endfacet
+  facet normal 0.622867 0.424784 -0.656959
+    outer loop
+      vertex -19.897 0.0617943 11.0607
+      vertex -19.8998 -0.00415969 11.0154
+      vertex -19.9 0 11.0179
+    endloop
+  endfacet
+  facet normal 0.196571 0.142817 0.970033
+    outer loop
+      vertex -19.848 1.05814 8.56459
+      vertex -12.372 -8.98878 8.52882
+      vertex -19.8368 1.28568 8.52882
+    endloop
+  endfacet
+  facet normal 0.196603 0.142841 0.970023
+    outer loop
+      vertex -12.372 -8.98878 8.52882
+      vertex -19.848 1.05814 8.56459
+      vertex -12.4875 -9.07272 8.56459
+    endloop
+  endfacet
+  facet normal -0.589637 0.807657 -0.00429063
+    outer loop
+      vertex -12.5997 -9.15418 8.61418
+      vertex -12.7073 -9.2324 8.67712
+      vertex -12.8095 -9.30661 8.7528
+    endloop
+  endfacet
+  facet normal -0.542233 -0.393933 -0.742159
+    outer loop
+      vertex -19.6241 3.16447 11.1303
+      vertex -14.5055 -3.74994 11.0607
+      vertex -14.4863 -3.82667 11.0874
+    endloop
+  endfacet
+  facet normal -0.543044 -0.394543 -0.741241
+    outer loop
+      vertex -14.5055 -3.74994 11.0607
+      vertex -19.6241 3.16447 11.1303
+      vertex -19.608 3.27307 11.0607
+    endloop
+  endfacet
+  facet normal -0.731525 -0.53149 -0.427071
+    outer loop
+      vertex -14.7143 -2.90932 10.574
+      vertex -19.553 3.64355 10.7071
+      vertex -19.5399 3.73247 10.574
+    endloop
+  endfacet
+  facet normal -0.731437 -0.531421 -0.427308
+    outer loop
+      vertex -14.7118 -2.92635 10.5909
+      vertex -19.553 3.64355 10.7071
+      vertex -14.7143 -2.90932 10.574
+    endloop
+  endfacet
+  facet normal -0.731409 -0.531398 -0.427384
+    outer loop
+      vertex -19.553 3.64355 10.7071
+      vertex -14.7118 -2.92635 10.5909
+      vertex -14.676 -3.06908 10.7071
+    endloop
+  endfacet
+  facet normal 0.800302 0.581452 0.146392
+    outer loop
+      vertex -19.8647 -0.717719 9.85297
+      vertex -13.3255 -9.68151 9.70736
+      vertex -19.8667 -0.678306 9.70736
+    endloop
+  endfacet
+  facet normal 0.800306 0.581456 0.146349
+    outer loop
+      vertex -13.3255 -9.68151 9.70736
+      vertex -19.8647 -0.717719 9.85297
+      vertex -13.3429 -9.69421 9.85297
+    endloop
+  endfacet
+  facet normal -0.584486 0.811404 0
+    outer loop
+      vertex -13.3429 -9.69421 10.147
+      vertex -13.3429 -9.69421 9.85297
+      vertex -13.3488 -9.69846 10
+    endloop
+  endfacet
+  facet normal -0.808042 -0.587072 0.0491351
+    outer loop
+      vertex -19.5173 3.88345 9.85297
+      vertex -14.7505 -2.66523 10
+      vertex -19.515 3.89259 10
+    endloop
+  endfacet
+  facet normal -0.808046 -0.587078 0.0490103
+    outer loop
+      vertex -14.7505 -2.66523 10
+      vertex -19.5173 3.88345 9.85297
+      vertex -14.7482 -2.68067 9.85297
+    endloop
+  endfacet
+  facet normal -0.784769 -0.570169 0.242989
+    outer loop
+      vertex -19.5295 3.80254 9.56457
+      vertex -14.7414 -2.72685 9.70736
+      vertex -19.522 3.85307 9.70736
+    endloop
+  endfacet
+  facet normal -0.784829 -0.57022 0.242678
+    outer loop
+      vertex -14.7414 -2.72685 9.70736
+      vertex -19.5295 3.80254 9.56457
+      vertex -14.73 -2.80331 9.56457
+    endloop
+  endfacet
+  facet normal 0.482021 0.350208 0.803125
+    outer loop
+      vertex -12.8095 -9.30661 8.7528
+      vertex -19.8792 0.424017 8.7528
+      vertex -19.8847 0.311534 8.80515
+    endloop
+  endfacet
+  facet normal -0.0394666 -0.0286773 0.998809
+    outer loop
+      vertex -12.472 -8.33355 8.50057
+      vertex -12.1353 -8.81678 8.5
+      vertex -12.1212 -8.80658 8.50085
+    endloop
+  endfacet
+  facet normal -0.0396927 -0.0288383 0.998796
+    outer loop
+      vertex -19.8139 1.75201 8.5
+      vertex -13.2417 -7.04382 8.50722
+      vertex -19.7995 1.98225 8.50722
+    endloop
+  endfacet
+  facet normal -0.0396016 -0.0287702 0.998801
+    outer loop
+      vertex -13.2417 -7.04382 8.50722
+      vertex -19.8139 1.75201 8.5
+      vertex -13.2288 -7.07095 8.50695
+    endloop
+  endfacet
+  facet normal -0.0396958 -0.0288405 0.998796
+    outer loop
+      vertex -13.2288 -7.07095 8.50695
+      vertex -19.8139 1.75201 8.5
+      vertex -12.472 -8.33355 8.50057
+    endloop
+  endfacet
+  facet normal -0.0388316 -0.0288932 0.998828
+    outer loop
+      vertex -19.8139 1.75201 8.5
+      vertex -19.7995 1.98225 8.50722
+      vertex -19.8042 1.95054 8.50612
+    endloop
+  endfacet
+  facet normal -0.0395807 -0.0287568 0.998802
+    outer loop
+      vertex -12.472 -8.33355 8.50057
+      vertex -19.8139 1.75201 8.5
+      vertex -12.1353 -8.81678 8.5
+    endloop
+  endfacet
+  facet normal 0.196758 0.142953 -0.969974
+    outer loop
+      vertex -19.848 1.05814 11.4354
+      vertex -12.372 -8.98878 11.4712
+      vertex -12.4875 -9.07272 11.4354
+    endloop
+  endfacet
+  facet normal 0.196726 0.142929 -0.969985
+    outer loop
+      vertex -12.372 -8.98878 11.4712
+      vertex -19.848 1.05814 11.4354
+      vertex -19.8368 1.28568 11.4712
+    endloop
+  endfacet
+  facet normal 0.784766 0.57017 -0.242999
+    outer loop
+      vertex -13.2965 -9.66049 10.4354
+      vertex -19.8667 -0.678306 10.2926
+      vertex -19.8699 -0.613042 10.4354
+    endloop
+  endfacet
+  facet normal 0.784711 0.570125 -0.243282
+    outer loop
+      vertex -19.8667 -0.678306 10.2926
+      vertex -13.2965 -9.66049 10.4354
+      vertex -13.3255 -9.68151 10.2926
+    endloop
+  endfacet
+  facet normal 0.694008 0.504227 -0.513915
+    outer loop
+      vertex -13.1443 -9.54987 10.8334
+      vertex -19.88 -0.407713 10.7071
+      vertex -19.8868 -0.269627 10.8334
+    endloop
+  endfacet
+  facet normal 0.694025 0.50424 -0.513879
+    outer loop
+      vertex -19.88 -0.407713 10.7071
+      vertex -13.1443 -9.54987 10.8334
+      vertex -13.2055 -9.59435 10.7071
+    endloop
+  endfacet
+  facet normal 0.54322 0.394677 -0.741041
+    outer loop
+      vertex -19.897 0.0617943 11.0607
+      vertex -12.9051 -9.37611 11.1595
+      vertex -12.9933 -9.44022 11.0607
+    endloop
+  endfacet
+  facet normal 0.543001 0.394512 -0.74129
+    outer loop
+      vertex -12.9051 -9.37611 11.1595
+      vertex -19.897 0.0617943 11.0607
+      vertex -19.8884 0.235603 11.1595
+    endloop
+  endfacet
+  facet normal -0.58963 0.807662 0.00427507
+    outer loop
+      vertex -12.7073 -9.2324 11.3229
+      vertex -12.5997 -9.15418 11.3858
+      vertex -12.8095 -9.30661 11.2472
+    endloop
+  endfacet
+  facet normal 0.415898 0.302168 0.857743
+    outer loop
+      vertex -19.8792 0.424017 8.7528
+      vertex -12.7073 -9.2324 8.67712
+      vertex -19.8693 0.625218 8.67712
+    endloop
+  endfacet
+  facet normal 0.415829 0.302117 0.857794
+    outer loop
+      vertex -12.7073 -9.2324 8.67712
+      vertex -19.8792 0.424017 8.7528
+      vertex -12.8095 -9.30661 8.7528
+    endloop
+  endfacet
+  facet normal -0.58786 0.808963 -0.000213515
+    outer loop
+      vertex -12.2542 -8.9032 8.50722
+      vertex -12.4875 -9.07272 8.56459
+      vertex -12.9051 -9.37611 8.84048
+    endloop
+  endfacet
+  facet normal 0.272469 0.19796 0.94158
+    outer loop
+      vertex -19.8589 0.837272 8.61418
+      vertex -12.4875 -9.07272 8.56459
+      vertex -19.848 1.05814 8.56459
+    endloop
+  endfacet
+  facet normal 0.272449 0.197945 0.941589
+    outer loop
+      vertex -12.4875 -9.07272 8.56459
+      vertex -19.8589 0.837272 8.61418
+      vertex -12.5997 -9.15418 8.61418
+    endloop
+  endfacet
+  facet normal 0.345941 0.251341 0.903965
+    outer loop
+      vertex -19.8693 0.625218 8.67712
+      vertex -12.5997 -9.15418 8.61418
+      vertex -19.8589 0.837272 8.61418
+    endloop
+  endfacet
+  facet normal 0.346002 0.251386 0.903929
+    outer loop
+      vertex -12.5997 -9.15418 8.61418
+      vertex -19.8693 0.625218 8.67712
+      vertex -12.7073 -9.2324 8.67712
+    endloop
+  endfacet
+  facet normal 0.11871 0.0862476 0.989176
+    outer loop
+      vertex -19.8368 1.28568 8.52882
+      vertex -12.2542 -8.9032 8.50722
+      vertex -19.8254 1.51772 8.50722
+    endloop
+  endfacet
+  facet normal 0.118716 0.0862519 0.989175
+    outer loop
+      vertex -12.2542 -8.9032 8.50722
+      vertex -19.8368 1.28568 8.52882
+      vertex -12.372 -8.98878 8.52882
+    endloop
+  endfacet
+  facet normal -0.0417857 -0.030355 -0.998665
+    outer loop
+      vertex -12.1353 -8.81678 11.5
+      vertex -12.472 -8.33355 11.4994
+      vertex -12.1212 -8.80658 11.4991
+    endloop
+  endfacet
+  facet normal -0.0436468 -0.0317953 -0.998541
+    outer loop
+      vertex -19.8139 1.75201 11.5
+      vertex -13.2417 -7.04382 11.4928
+      vertex -13.2288 -7.07095 11.4931
+    endloop
+  endfacet
+  facet normal -0.0392277 -0.0284969 -0.998824
+    outer loop
+      vertex -19.8139 1.75201 11.5
+      vertex -13.2288 -7.07095 11.4931
+      vertex -12.472 -8.33355 11.4994
+    endloop
+  endfacet
+  facet normal -0.0416586 -0.0302664 -0.998673
+    outer loop
+      vertex -19.8139 1.75201 11.5
+      vertex -12.472 -8.33355 11.4994
+      vertex -12.1353 -8.81678 11.5
+    endloop
+  endfacet
+  facet normal -0.039583 -0.0287586 -0.998802
+    outer loop
+      vertex -13.2417 -7.04382 11.4928
+      vertex -19.8139 1.75201 11.5
+      vertex -19.7995 1.98225 11.4928
+    endloop
+  endfacet
+  facet normal -0.0398429 -0.028742 -0.998792
+    outer loop
+      vertex -19.7995 1.98225 11.4928
+      vertex -19.8139 1.75201 11.5
+      vertex -19.8042 1.95054 11.4939
+    endloop
+  endfacet
+  facet normal -0.694165 -0.504341 -0.51359
+    outer loop
+      vertex -14.6416 -3.20651 10.7954
+      vertex -19.5689 3.53663 10.8334
+      vertex -19.5575 3.61371 10.7423
+    endloop
+  endfacet
+  facet normal -0.694152 -0.504332 -0.513616
+    outer loop
+      vertex -19.5689 3.53663 10.8334
+      vertex -14.6416 -3.20651 10.7954
+      vertex -14.6268 -3.26558 10.8334
+    endloop
+  endfacet
+  facet normal 0.731363 0.531365 0.427503
+    outer loop
+      vertex -19.8743 -0.522554 9.42597
+      vertex -13.2564 -9.63134 9.42597
+      vertex -19.8775 -0.457592 9.3507
+    endloop
+  endfacet
+  facet normal 0.808033 0.58707 0.0493205
+    outer loop
+      vertex -19.8641 -0.730897 10
+      vertex -13.3429 -9.69421 9.85297
+      vertex -19.8647 -0.717719 9.85297
+    endloop
+  endfacet
+  facet normal 0.80803 0.587067 0.0493941
+    outer loop
+      vertex -13.3429 -9.69421 9.85297
+      vertex -19.8641 -0.730897 10
+      vertex -13.3488 -9.69846 10
+    endloop
+  endfacet
+  facet normal -0.731495 -0.531468 0.427149
+    outer loop
+      vertex -19.553 3.64355 9.2929
+      vertex -14.7143 -2.90932 9.42597
+      vertex -19.5399 3.73247 9.42597
+    endloop
+  endfacet
+  facet normal -0.730981 -0.531061 0.428534
+    outer loop
+      vertex -19.553 3.64355 9.2929
+      vertex -14.7118 -2.92635 9.40913
+      vertex -14.7143 -2.90932 9.42597
+    endloop
+  endfacet
+  facet normal -0.731443 -0.531423 0.427294
+    outer loop
+      vertex -14.7118 -2.92635 9.40913
+      vertex -19.553 3.64355 9.2929
+      vertex -14.676 -3.06908 9.2929
+    endloop
+  endfacet
+  facet normal -0.196514 -0.142774 0.97005
+    outer loop
+      vertex -19.769 2.18797 8.52882
+      vertex -13.8834 -5.66994 8.56459
+      vertex -19.739 2.38971 8.56459
+    endloop
+  endfacet
+  facet normal -0.197068 -0.14319 0.969877
+    outer loop
+      vertex -13.8834 -5.66994 8.56459
+      vertex -19.769 2.18797 8.52882
+      vertex -13.8582 -5.74025 8.55933
+    endloop
+  endfacet
+  facet normal -0.196619 -0.142855 0.970017
+    outer loop
+      vertex -13.8582 -5.74025 8.55933
+      vertex -19.769 2.18797 8.52882
+      vertex -13.5773 -6.33404 8.52882
+    endloop
+  endfacet
+  facet normal -0.588329 0.808621 -0.000504806
+    outer loop
+      vertex -12.9051 -9.37611 8.84048
+      vertex -12.9933 -9.44022 8.93934
+      vertex -13.2564 -9.63134 9.42597
+    endloop
+  endfacet
+  facet normal -0.587549 0.809187 -0.00171098
+    outer loop
+      vertex -12.372 -8.98878 11.4712
+      vertex -12.2542 -8.9032 11.4928
+      vertex -12.4875 -9.07272 11.4354
+    endloop
+  endfacet
+  facet normal 0.039581 0.0287571 -0.998802
+    outer loop
+      vertex -19.8254 1.51772 11.4928
+      vertex -12.1353 -8.81678 11.5
+      vertex -12.2542 -8.9032 11.4928
+    endloop
+  endfacet
+  facet normal 0.039574 0.0287519 -0.998803
+    outer loop
+      vertex -12.1353 -8.81678 11.5
+      vertex -19.8254 1.51772 11.4928
+      vertex -19.8139 1.75201 11.5
+    endloop
+  endfacet
+  facet normal 0.8003 0.581451 -0.146402
+    outer loop
+      vertex -13.3255 -9.68151 10.2926
+      vertex -19.8647 -0.717719 10.147
+      vertex -19.8667 -0.678306 10.2926
+    endloop
+  endfacet
+  facet normal 0.800305 0.581456 -0.146359
+    outer loop
+      vertex -19.8647 -0.717719 10.147
+      vertex -13.3255 -9.68151 10.2926
+      vertex -13.3429 -9.69421 10.147
+    endloop
+  endfacet
+  facet normal 0.599514 0.435573 0.671461
+    outer loop
+      vertex -19.8946 -0.109622 9.04841
+      vertex -13.0733 -9.49832 9.04841
+      vertex -19.8998 -0.00415969 8.98464
+    endloop
+  endfacet
+  facet normal 0.784763 0.570167 0.243015
+    outer loop
+      vertex -19.8667 -0.678306 9.70736
+      vertex -13.2965 -9.66049 9.56457
+      vertex -19.8699 -0.613042 9.56457
+    endloop
+  endfacet
+  facet normal 0.784708 0.570123 0.243298
+    outer loop
+      vertex -13.2965 -9.66049 9.56457
+      vertex -19.8667 -0.678306 9.70736
+      vertex -13.3255 -9.68151 9.70736
+    endloop
+  endfacet
+  facet normal 0.64961 0.47197 -0.596029
+    outer loop
+      vertex -13.0733 -9.49832 10.9516
+      vertex -19.8868 -0.269627 10.8334
+      vertex -19.8946 -0.109622 10.9516
+    endloop
+  endfacet
+  facet normal 0.649605 0.471966 -0.596039
+    outer loop
+      vertex -19.8868 -0.269627 10.8334
+      vertex -13.0733 -9.49832 10.9516
+      vertex -13.1443 -9.54987 10.8334
+    endloop
+  endfacet
+  facet normal -0.586669 0.809826 -0.000925867
+    outer loop
+      vertex -13.1443 -9.54987 10.8334
+      vertex -12.9933 -9.44022 11.0607
+      vertex -13.2055 -9.59435 10.7071
+    endloop
+  endfacet
+  facet normal -0.588095 0.808792 0.000520306
+    outer loop
+      vertex -13.0733 -9.49832 10.9516
+      vertex -12.9933 -9.44022 11.0607
+      vertex -13.1443 -9.54987 10.8334
+    endloop
+  endfacet
+  facet normal -0.58719 0.809448 -0.00138206
+    outer loop
+      vertex -12.8095 -9.30661 11.2472
+      vertex -12.5997 -9.15418 11.3858
+      vertex -12.9051 -9.37611 11.1595
+    endloop
+  endfacet
+  facet normal 0.41591 0.302176 -0.857734
+    outer loop
+      vertex -19.8792 0.424017 11.2472
+      vertex -12.7073 -9.2324 11.3229
+      vertex -12.8095 -9.30661 11.2472
+    endloop
+  endfacet
+  facet normal 0.415979 0.302227 -0.857683
+    outer loop
+      vertex -12.7073 -9.2324 11.3229
+      vertex -19.8792 0.424017 11.2472
+      vertex -19.8693 0.625218 11.3229
+    endloop
+  endfacet
+  facet normal -0.345721 -0.251182 -0.904093
+    outer loop
+      vertex -19.71 2.58553 11.3858
+      vertex -14.2092 -4.75926 11.3229
+      vertex -14.0496 -5.20533 11.3858
+    endloop
+  endfacet
+  facet normal -0.345708 -0.251171 -0.904101
+    outer loop
+      vertex -14.2092 -4.75926 11.3229
+      vertex -19.71 2.58553 11.3858
+      vertex -19.6821 2.77354 11.3229
+    endloop
+  endfacet
+  facet normal -0.649828 -0.472128 -0.595667
+    outer loop
+      vertex -14.6268 -3.26558 10.8334
+      vertex -19.582 3.44805 10.9179
+      vertex -19.5689 3.53663 10.8334
+    endloop
+  endfacet
+  facet normal -0.64962 -0.47197 -0.596018
+    outer loop
+      vertex -19.582 3.44805 10.9179
+      vertex -14.6268 -3.26558 10.8334
+      vertex -14.61 -3.33265 10.8682
+    endloop
+  endfacet
+  facet normal 0.0396836 0.0288316 0.998796
+    outer loop
+      vertex -19.8254 1.51772 8.50722
+      vertex -12.1353 -8.81678 8.5
+      vertex -19.8139 1.75201 8.5
+    endloop
+  endfacet
+  facet normal 0.0396907 0.0288368 0.998796
+    outer loop
+      vertex -12.1353 -8.81678 8.5
+      vertex -19.8254 1.51772 8.50722
+      vertex -12.2542 -8.9032 8.50722
+    endloop
+  endfacet
+  facet normal -0.587781 0.80902 0
+    outer loop
+      vertex -12.1212 -8.80658 11.4534
+      vertex -12.9051 -9.37611 8.84048
+      vertex -12.9051 -9.37611 11.1595
+    endloop
+  endfacet
+  facet normal -0.587781 0.80902 0
+    outer loop
+      vertex -12.9051 -9.37611 8.84048
+      vertex -12.1212 -8.80658 11.4534
+      vertex -12.1212 -8.80658 8.54656
+    endloop
+  endfacet
+  facet normal -0.587745 0.809046 0
+    outer loop
+      vertex -12.2542 -8.9032 8.50722
+      vertex -12.1212 -8.80658 8.54656
+      vertex -12.1212 -8.80658 8.50722
+    endloop
+  endfacet
+  facet normal -0.587761 0.809035 8.18175e-05
+    outer loop
+      vertex -12.1212 -8.80658 8.54656
+      vertex -12.2542 -8.9032 8.50722
+      vertex -12.9051 -9.37611 8.84048
+    endloop
+  endfacet
+  facet normal -0.587779 0.809022 0
+    outer loop
+      vertex -12.9051 -9.37611 11.1595
+      vertex -13.2564 -9.63134 9.42597
+      vertex -13.2564 -9.63134 10.574
+    endloop
+  endfacet
+  facet normal -0.587779 0.809022 0
+    outer loop
+      vertex -13.2564 -9.63134 9.42597
+      vertex -12.9051 -9.37611 11.1595
+      vertex -12.9051 -9.37611 8.84048
+    endloop
+  endfacet
+  facet normal -0.58719 0.809448 0.00138371
+    outer loop
+      vertex -12.5997 -9.15418 8.61418
+      vertex -12.8095 -9.30661 8.7528
+      vertex -12.9051 -9.37611 8.84048
+    endloop
+  endfacet
+  facet normal 0.482013 0.350202 0.803132
+    outer loop
+      vertex -19.8884 0.235603 8.84048
+      vertex -12.8095 -9.30661 8.7528
+      vertex -19.8847 0.311534 8.80515
+    endloop
+  endfacet
+  facet normal 0.482009 0.350199 0.803136
+    outer loop
+      vertex -12.8095 -9.30661 8.7528
+      vertex -19.8884 0.235603 8.84048
+      vertex -12.9051 -9.37611 8.84048
+    endloop
+  endfacet
+  facet normal -0.587548 0.809187 0.0017145
+    outer loop
+      vertex -12.2542 -8.9032 8.50722
+      vertex -12.372 -8.98878 8.52882
+      vertex -12.4875 -9.07272 8.56459
+    endloop
+  endfacet
+  facet normal -0.198404 -0.144189 -0.969456
+    outer loop
+      vertex -19.769 2.18797 11.4712
+      vertex -13.8834 -5.66994 11.4354
+      vertex -13.8582 -5.74025 11.4407
+    endloop
+  endfacet
+  facet normal -0.196559 -0.14281 -0.970036
+    outer loop
+      vertex -19.769 2.18797 11.4712
+      vertex -13.8582 -5.74025 11.4407
+      vertex -13.5773 -6.33404 11.4712
+    endloop
+  endfacet
+  facet normal -0.19667 -0.142887 -0.970002
+    outer loop
+      vertex -13.8834 -5.66994 11.4354
+      vertex -19.769 2.18797 11.4712
+      vertex -19.739 2.38971 11.4354
+    endloop
+  endfacet
+  facet normal -0.812526 -0.564837 -0.144084
+    outer loop
+      vertex -19.5173 3.88345 10.147
+      vertex -19.522 3.85307 10.2926
+      vertex -19.5176 3.8823 10.1532
+    endloop
+  endfacet
+  facet normal -0.800212 -0.581387 -0.14714
+    outer loop
+      vertex -14.7482 -2.68067 10.147
+      vertex -19.522 3.85307 10.2926
+      vertex -19.5173 3.88345 10.147
+    endloop
+  endfacet
+  facet normal -0.800224 -0.581398 -0.147029
+    outer loop
+      vertex -19.522 3.85307 10.2926
+      vertex -14.7482 -2.68067 10.147
+      vertex -14.7414 -2.72685 10.2926
+    endloop
+  endfacet
+  facet normal -0.761707 -0.55342 0.33694
+    outer loop
+      vertex -19.5399 3.73247 9.42597
+      vertex -14.73 -2.80331 9.56457
+      vertex -19.5295 3.80254 9.56457
+    endloop
+  endfacet
+  facet normal -0.76169 -0.553407 0.337
+    outer loop
+      vertex -14.73 -2.80331 9.56457
+      vertex -19.5399 3.73247 9.42597
+      vertex -14.7143 -2.90932 9.42597
+    endloop
+  endfacet
+  facet normal -0.649366 -0.47178 0.596445
+    outer loop
+      vertex -19.5873 3.41274 9.04841
+      vertex -14.61 -3.33265 9.13182
+      vertex -19.582 3.44805 9.08211
+    endloop
+  endfacet
+  facet normal -0.649732 -0.472058 0.595827
+    outer loop
+      vertex -14.61 -3.33265 9.13182
+      vertex -19.5873 3.41274 9.04841
+      vertex -14.5698 -3.49326 9.04841
+    endloop
+  endfacet
+  facet normal -0.693361 -0.503755 0.515248
+    outer loop
+      vertex -19.5575 3.61371 9.25767
+      vertex -14.676 -3.06908 9.2929
+      vertex -19.553 3.64355 9.2929
+    endloop
+  endfacet
+  facet normal -0.693828 -0.504101 0.51428
+    outer loop
+      vertex -14.676 -3.06908 9.2929
+      vertex -19.5575 3.61371 9.25767
+      vertex -14.6416 -3.20651 9.2046
+    endloop
+  endfacet
+  facet normal -0.118723 -0.0862585 0.989174
+    outer loop
+      vertex -19.7995 1.98225 8.50722
+      vertex -13.5773 -6.33404 8.52882
+      vertex -19.769 2.18797 8.52882
+    endloop
+  endfacet
+  facet normal -0.118647 -0.0862021 0.989188
+    outer loop
+      vertex -13.5773 -6.33404 8.52882
+      vertex -19.7995 1.98225 8.50722
+      vertex -13.2417 -7.04382 8.50722
+    endloop
+  endfacet
+  facet normal -0.272607 -0.198061 0.941519
+    outer loop
+      vertex -19.739 2.38971 8.56459
+      vertex -14.0496 -5.20533 8.61418
+      vertex -19.71 2.58553 8.61418
+    endloop
+  endfacet
+  facet normal -0.272491 -0.197973 0.941571
+    outer loop
+      vertex -14.0496 -5.20533 8.61418
+      vertex -19.739 2.38971 8.56459
+      vertex -13.8834 -5.66994 8.56459
+    endloop
+  endfacet
+  facet normal 0.69395 0.504185 0.514034
+    outer loop
+      vertex -19.88 -0.407713 9.2929
+      vertex -13.1443 -9.54987 9.16664
+      vertex -19.8868 -0.269627 9.16664
+    endloop
+  endfacet
+  facet normal 0.693967 0.504198 0.513999
+    outer loop
+      vertex -13.1443 -9.54987 9.16664
+      vertex -19.88 -0.407713 9.2929
+      vertex -13.2055 -9.59435 9.2929
+    endloop
+  endfacet
+  facet normal 0.272498 0.197981 -0.941567
+    outer loop
+      vertex -19.8589 0.837272 11.3858
+      vertex -12.4875 -9.07272 11.4354
+      vertex -12.5997 -9.15418 11.3858
+    endloop
+  endfacet
+  facet normal 0.272517 0.197995 -0.941558
+    outer loop
+      vertex -12.4875 -9.07272 11.4354
+      vertex -19.8589 0.837272 11.3858
+      vertex -19.848 1.05814 11.4354
+    endloop
+  endfacet
+  facet normal 0.761743 0.553437 0.336833
+    outer loop
+      vertex -19.8718 -0.573303 9.5037
+      vertex -13.2564 -9.63134 9.42597
+      vertex -19.8743 -0.522554 9.42597
+    endloop
+  endfacet
+  facet normal 0.481724 0.349992 -0.803397
+    outer loop
+      vertex -19.8792 0.424017 11.2472
+      vertex -12.8095 -9.30661 11.2472
+      vertex -19.8847 0.311534 11.1949
+    endloop
+  endfacet
+  facet normal 0.48208 0.350251 -0.803071
+    outer loop
+      vertex -19.8884 0.235603 11.1595
+      vertex -12.8095 -9.30661 11.2472
+      vertex -12.9051 -9.37611 11.1595
+    endloop
+  endfacet
+  facet normal 0.482616 0.350653 -0.802574
+    outer loop
+      vertex -12.8095 -9.30661 11.2472
+      vertex -19.8884 0.235603 11.1595
+      vertex -19.8847 0.311534 11.1949
+    endloop
+  endfacet
+  facet normal -0.417298 -0.303226 -0.856689
+    outer loop
+      vertex -19.6821 2.77354 11.3229
+      vertex -14.3576 -4.34013 11.2472
+      vertex -14.3541 -4.35427 11.2505
+    endloop
+  endfacet
+  facet normal -0.415846 -0.30213 -0.857782
+    outer loop
+      vertex -19.6821 2.77354 11.3229
+      vertex -14.3541 -4.35427 11.2505
+      vertex -14.2092 -4.75926 11.3229
+    endloop
+  endfacet
+  facet normal -0.415941 -0.302199 -0.857711
+    outer loop
+      vertex -14.3576 -4.34013 11.2472
+      vertex -19.6821 2.77354 11.3229
+      vertex -19.6556 2.95192 11.2472
+    endloop
+  endfacet
+  facet normal -0.599524 -0.435579 -0.671447
+    outer loop
+      vertex -19.608 3.27307 11.0607
+      vertex -14.5698 -3.49326 10.9516
+      vertex -14.5055 -3.74994 11.0607
+    endloop
+  endfacet
+  facet normal -0.599551 -0.435599 -0.67141
+    outer loop
+      vertex -14.5698 -3.49326 10.9516
+      vertex -19.608 3.27307 11.0607
+      vertex -19.5873 3.41274 10.9516
+    endloop
+  endfacet
+  facet normal -0.587329 0.809348 0.000320934
+    outer loop
+      vertex -12.9933 -9.44022 8.93934
+      vertex -13.2055 -9.59435 9.2929
+      vertex -13.2564 -9.63134 9.42597
+    endloop
+  endfacet
+  facet normal -0.586992 0.809591 0.00179063
+    outer loop
+      vertex -12.4875 -9.07272 8.56459
+      vertex -12.5997 -9.15418 8.61418
+      vertex -12.9051 -9.37611 8.84048
+    endloop
+  endfacet
+  facet normal -0.118647 -0.0862021 -0.989188
+    outer loop
+      vertex -19.7995 1.98225 11.4928
+      vertex -13.5773 -6.33404 11.4712
+      vertex -13.2417 -7.04382 11.4928
+    endloop
+  endfacet
+  facet normal -0.118723 -0.0862585 -0.989174
+    outer loop
+      vertex -13.5773 -6.33404 11.4712
+      vertex -19.7995 1.98225 11.4928
+      vertex -19.769 2.18797 11.4712
+    endloop
+  endfacet
+  facet normal -0.761707 -0.55342 -0.33694
+    outer loop
+      vertex -14.73 -2.80331 10.4354
+      vertex -19.5399 3.73247 10.574
+      vertex -19.5295 3.80254 10.4354
+    endloop
+  endfacet
+  facet normal -0.76169 -0.553407 -0.337
+    outer loop
+      vertex -19.5399 3.73247 10.574
+      vertex -14.73 -2.80331 10.4354
+      vertex -14.7143 -2.90932 10.574
+    endloop
+  endfacet
+  facet normal -0.786222 -0.599355 0.150427
+    outer loop
+      vertex -19.522 3.85307 9.70736
+      vertex -19.5173 3.88345 9.85297
+      vertex -19.5176 3.8823 9.84682
+    endloop
+  endfacet
+  facet normal -0.800213 -0.581388 0.14713
+    outer loop
+      vertex -19.522 3.85307 9.70736
+      vertex -14.7482 -2.68067 9.85297
+      vertex -19.5173 3.88345 9.85297
+    endloop
+  endfacet
+  facet normal -0.800225 -0.581399 0.147019
+    outer loop
+      vertex -14.7482 -2.68067 9.85297
+      vertex -19.522 3.85307 9.70736
+      vertex -14.7414 -2.72685 9.70736
+    endloop
+  endfacet
+  facet normal -0.599477 -0.435545 0.671512
+    outer loop
+      vertex -19.608 3.27307 8.93934
+      vertex -14.5698 -3.49326 9.04841
+      vertex -19.5873 3.41274 9.04841
+    endloop
+  endfacet
+  facet normal -0.59945 -0.435525 0.671549
+    outer loop
+      vertex -14.5698 -3.49326 9.04841
+      vertex -19.608 3.27307 8.93934
+      vertex -14.5055 -3.74994 8.93934
+    endloop
+  endfacet
+  facet normal -0.345887 -0.251302 0.903996
+    outer loop
+      vertex -19.71 2.58553 8.61418
+      vertex -14.2092 -4.75926 8.67712
+      vertex -19.6821 2.77354 8.67712
+    endloop
+  endfacet
+  facet normal -0.345901 -0.251312 0.903988
+    outer loop
+      vertex -14.2092 -4.75926 8.67712
+      vertex -19.71 2.58553 8.61418
+      vertex -14.0496 -5.20533 8.61418
+    endloop
+  endfacet
+  facet normal 0.649669 0.472013 0.595932
+    outer loop
+      vertex -19.8868 -0.269627 9.16664
+      vertex -13.0733 -9.49832 9.04841
+      vertex -19.8946 -0.109622 9.04841
+    endloop
+  endfacet
+  facet normal 0.649663 0.472008 0.595941
+    outer loop
+      vertex -13.0733 -9.49832 9.04841
+      vertex -19.8868 -0.269627 9.16664
+      vertex -13.1443 -9.54987 9.16664
+    endloop
+  endfacet
+  facet normal 0.543182 0.394644 0.741087
+    outer loop
+      vertex -19.897 0.0617943 8.93934
+      vertex -12.9051 -9.37611 8.84048
+      vertex -19.8884 0.235603 8.84048
+    endloop
+  endfacet
+  facet normal 0.543402 0.394809 0.740838
+    outer loop
+      vertex -12.9051 -9.37611 8.84048
+      vertex -19.897 0.0617943 8.93934
+      vertex -12.9933 -9.44022 8.93934
+    endloop
+  endfacet
+  facet normal 0.599606 0.435644 0.671333
+    outer loop
+      vertex -19.8998 -0.00415969 8.98464
+      vertex -12.9933 -9.44022 8.93934
+      vertex -19.897 0.0617943 8.93934
+    endloop
+  endfacet
+  facet normal 0.599396 0.435489 0.67162
+    outer loop
+      vertex -12.9933 -9.44022 8.93934
+      vertex -19.8998 -0.00415969 8.98464
+      vertex -13.0733 -9.49832 9.04841
+    endloop
+  endfacet
+  facet normal 0.60041 0.435279 0.67085
+    outer loop
+      vertex -19.8998 -0.00415969 8.98464
+      vertex -19.897 0.0617943 8.93934
+      vertex -19.9 0 8.98212
+    endloop
+  endfacet
+  facet normal -0.481926 -0.350144 -0.80321
+    outer loop
+      vertex -19.6383 3.06908 11.1857
+      vertex -14.4345 -4.03314 11.1595
+      vertex -14.3769 -4.26336 11.2253
+    endloop
+  endfacet
+  facet normal -0.48206 -0.350243 -0.803087
+    outer loop
+      vertex -14.4345 -4.03314 11.1595
+      vertex -19.6383 3.06908 11.1857
+      vertex -19.6309 3.11897 11.1595
+    endloop
+  endfacet
+  facet normal -0.693204 -0.503641 -0.51557
+    outer loop
+      vertex -14.676 -3.06908 10.7071
+      vertex -19.5575 3.61371 10.7423
+      vertex -19.553 3.64355 10.7071
+    endloop
+  endfacet
+  facet normal -0.693826 -0.504102 -0.514283
+    outer loop
+      vertex -19.5575 3.61371 10.7423
+      vertex -14.676 -3.06908 10.7071
+      vertex -14.6416 -3.20651 10.7954
+    endloop
+  endfacet
+  facet normal -0.649366 -0.471781 -0.596445
+    outer loop
+      vertex -14.61 -3.33265 10.8682
+      vertex -19.5873 3.41274 10.9516
+      vertex -19.582 3.44805 10.9179
+    endloop
+  endfacet
+  facet normal -0.649704 -0.472038 -0.595873
+    outer loop
+      vertex -19.5873 3.41274 10.9516
+      vertex -14.61 -3.33265 10.8682
+      vertex -14.5698 -3.49326 10.9516
+    endloop
+  endfacet
+  facet normal -0.784773 -0.570172 -0.242973
+    outer loop
+      vertex -14.7414 -2.72685 10.2926
+      vertex -19.5295 3.80254 10.4354
+      vertex -19.522 3.85307 10.2926
+    endloop
+  endfacet
+  facet normal -0.784832 -0.570222 -0.242662
+    outer loop
+      vertex -19.5295 3.80254 10.4354
+      vertex -14.7414 -2.72685 10.2926
+      vertex -14.73 -2.80331 10.4354
+    endloop
+  endfacet
+  facet normal -0.694024 -0.504239 0.513881
+    outer loop
+      vertex -19.5689 3.53663 9.16664
+      vertex -14.6416 -3.20651 9.2046
+      vertex -19.5575 3.61371 9.25767
+    endloop
+  endfacet
+  facet normal -0.693959 -0.504192 0.514015
+    outer loop
+      vertex -14.6416 -3.20651 9.2046
+      vertex -19.5689 3.53663 9.16664
+      vertex -14.6268 -3.26558 9.16664
+    endloop
+  endfacet
+  facet normal -0.482124 -0.350285 -0.80303
+    outer loop
+      vertex -19.6556 2.95192 11.2472
+      vertex -14.3769 -4.26336 11.2253
+      vertex -14.3576 -4.34013 11.2472
+    endloop
+  endfacet
+  facet normal -0.482163 -0.350313 -0.802994
+    outer loop
+      vertex -14.3769 -4.26336 11.2253
+      vertex -19.6556 2.95192 11.2472
+      vertex -19.6383 3.06908 11.1857
+    endloop
+  endfacet
+  facet normal -0.482115 -0.350276 0.803039
+    outer loop
+      vertex -19.6556 2.95192 8.7528
+      vertex -14.3769 -4.26336 8.77472
+      vertex -19.6383 3.06908 8.81429
+    endloop
+  endfacet
+  facet normal -0.482408 -0.350491 0.80277
+    outer loop
+      vertex -14.3769 -4.26336 8.77472
+      vertex -19.6556 2.95192 8.7528
+      vertex -14.3576 -4.34013 8.7528
+    endloop
+  endfacet
+  facet normal -0.481941 -0.350157 0.803195
+    outer loop
+      vertex -19.6383 3.06908 8.81429
+      vertex -14.4345 -4.03314 8.84048
+      vertex -19.6309 3.11897 8.84048
+    endloop
+  endfacet
+  facet normal -0.481737 -0.350007 0.803383
+    outer loop
+      vertex -14.4345 -4.03314 8.84048
+      vertex -19.6383 3.06908 8.81429
+      vertex -14.3769 -4.26336 8.77472
+    endloop
+  endfacet
+  facet normal -0.41586 -0.302141 0.857771
+    outer loop
+      vertex -19.6821 2.77354 8.67712
+      vertex -14.3576 -4.34013 8.7528
+      vertex -19.6556 2.95192 8.7528
+    endloop
+  endfacet
+  facet normal -0.414632 -0.301212 0.858692
+    outer loop
+      vertex -14.3576 -4.34013 8.7528
+      vertex -19.6821 2.77354 8.67712
+      vertex -14.3541 -4.35427 8.74953
+    endloop
+  endfacet
+  facet normal -0.415888 -0.30216 0.857751
+    outer loop
+      vertex -14.3541 -4.35427 8.74953
+      vertex -19.6821 2.77354 8.67712
+      vertex -14.2092 -4.75926 8.67712
+    endloop
+  endfacet
+  facet normal -0.308652 0.94993 -0.0486422
+    outer loop
+      vertex 5.09655 -15.6856 10.147
+      vertex -5.46456 -19.1213 10.0654
+      vertex -5.47188 -19.1195 10.147
+    endloop
+  endfacet
+  facet normal -0.305655 0.940708 -0.147118
+    outer loop
+      vertex -5.47188 -19.1195 10.147
+      vertex 5.08987 -15.665 10.2926
+      vertex 5.09655 -15.6856 10.147
+    endloop
+  endfacet
+  facet normal -0.305672 0.940747 -0.146829
+    outer loop
+      vertex 5.08987 -15.665 10.2926
+      vertex -5.47188 -19.1195 10.147
+      vertex -5.51135 -19.1096 10.2926
+    endloop
+  endfacet
+  facet normal -0.308657 0.94993 -0.0486247
+    outer loop
+      vertex -5.45869 -19.1228 10
+      vertex 5.09655 -15.6856 10.147
+      vertex 5.09878 -15.6924 10
+    endloop
+  endfacet
+  facet normal -0.308633 0.949893 -0.049488
+    outer loop
+      vertex 5.09655 -15.6856 10.147
+      vertex -5.45869 -19.1228 10
+      vertex -5.46456 -19.1213 10.0654
+    endloop
+  endfacet
+  facet normal -0.950973 -0.309273 -0.000127177
+    outer loop
+      vertex 5.08987 -15.665 9.70736
+      vertex 5.09655 -15.6856 9.85297
+      vertex 5.0635 -15.5838 9.42597
+    endloop
+  endfacet
+  facet normal -0.290932 0.895396 0.337083
+    outer loop
+      vertex 5.0635 -15.5838 9.42597
+      vertex -5.57671 -19.0932 9.56457
+      vertex 5.07882 -15.631 9.56457
+    endloop
+  endfacet
+  facet normal -0.291022 0.895639 0.33636
+    outer loop
+      vertex -5.57671 -19.0932 9.56457
+      vertex 5.0635 -15.5838 9.42597
+      vertex -5.61641 -19.0833 9.50386
+    endloop
+  endfacet
+  facet normal 0.308643 -0.949909 0.0491197
+    outer loop
+      vertex -9.70525 -17.3558 9.85297
+      vertex -1.9989 -14.8494 9.90068
+      vertex -9.71125 -17.3522 9.96029
+    endloop
+  endfacet
+  facet normal 0.308674 -0.949977 0.047581
+    outer loop
+      vertex -1.9989 -14.8494 9.90068
+      vertex -9.70525 -17.3558 9.85297
+      vertex -1.9937 -14.8501 9.85297
+    endloop
+  endfacet
+  facet normal -0.0750907 0.231105 0.970027
+    outer loop
+      vertex 4.72568 -14.5442 8.52882
+      vertex -7.14821 -18.5524 8.56459
+      vertex 4.76981 -14.68 8.56459
+    endloop
+  endfacet
+  facet normal -0.0750822 0.23108 0.970033
+    outer loop
+      vertex -7.14821 -18.5524 8.56459
+      vertex 4.72568 -14.5442 8.52882
+      vertex -7.36813 -18.4737 8.52882
+    endloop
+  endfacet
+  facet normal -0.951087 -0.308923 0
+    outer loop
+      vertex 4.72568 -14.5442 8.52882
+      vertex 4.63168 -14.2548 9.28834
+      vertex 4.63168 -14.2548 8.65483
+    endloop
+  endfacet
+  facet normal -0.951057 -0.309014 3.87119e-05
+    outer loop
+      vertex 4.63168 -14.2548 9.28834
+      vertex 4.72568 -14.5442 8.52882
+      vertex 5.0635 -15.5838 9.42597
+    endloop
+  endfacet
+  facet normal 0.305676 -0.940754 -0.14678
+    outer loop
+      vertex -9.68068 -17.3705 10.2926
+      vertex -1.9612 -14.8549 10.2456
+      vertex -1.94571 -14.8572 10.2926
+    endloop
+  endfacet
+  facet normal 0.305653 -0.94069 -0.147239
+    outer loop
+      vertex -1.9612 -14.8549 10.2456
+      vertex -9.68068 -17.3705 10.2926
+      vertex -9.6986 -17.3597 10.1864
+    endloop
+  endfacet
+  facet normal -0.248353 0.764345 -0.59506
+    outer loop
+      vertex 4.99356 -15.3686 10.9516
+      vertex -5.9552 -18.9792 10.8834
+      vertex -6.03305 -18.9514 10.9516
+    endloop
+  endfacet
+  facet normal -0.0151494 0.0466257 0.998798
+    outer loop
+      vertex 4.63525 -14.2658 8.5
+      vertex -7.59238 -18.3934 8.50722
+      vertex 4.68069 -14.4057 8.50722
+    endloop
+  endfacet
+  facet normal -0.0151627 0.0466651 0.998796
+    outer loop
+      vertex -7.78945 -18.3029 8.5
+      vertex -7.59238 -18.3934 8.50722
+      vertex 4.63525 -14.2658 8.5
+    endloop
+  endfacet
+  facet normal -0.0146628 0.0477502 0.998752
+    outer loop
+      vertex -7.59238 -18.3934 8.50722
+      vertex -7.78945 -18.3029 8.5
+      vertex -7.6154 -18.3852 8.50649
+    endloop
+  endfacet
+  facet normal -0.207489 0.638586 -0.741051
+    outer loop
+      vertex -6.1853 -18.8969 11.0607
+      vertex 4.92931 -15.1709 11.1595
+      vertex 4.96302 -15.2746 11.0607
+    endloop
+  endfacet
+  facet normal -0.207464 0.638515 -0.741119
+    outer loop
+      vertex 4.92931 -15.1709 11.1595
+      vertex -6.1853 -18.8969 11.0607
+      vertex -6.35327 -18.8368 11.1595
+    endloop
+  endfacet
+  facet normal -0.299764 0.92258 0.242875
+    outer loop
+      vertex 5.07882 -15.631 9.56457
+      vertex -5.54789 -19.1004 9.62755
+      vertex 5.08987 -15.665 9.70736
+    endloop
+  endfacet
+  facet normal -0.299782 0.922631 0.242659
+    outer loop
+      vertex -5.54789 -19.1004 9.62755
+      vertex 5.07882 -15.631 9.56457
+      vertex -5.57671 -19.0932 9.56457
+    endloop
+  endfacet
+  facet normal -0.95113 -0.30879 0
+    outer loop
+      vertex 5.09655 -15.6856 9.85297
+      vertex 5.0635 -15.5838 10.574
+      vertex 5.0635 -15.5838 9.42597
+    endloop
+  endfacet
+  facet normal -0.95113 -0.30879 0
+    outer loop
+      vertex 5.0635 -15.5838 10.574
+      vertex 5.09655 -15.6856 9.85297
+      vertex 5.09655 -15.6856 10.147
+    endloop
+  endfacet
+  facet normal -0.228988 0.704745 0.67149
+    outer loop
+      vertex 4.96302 -15.2746 8.93934
+      vertex -6.03305 -18.9514 9.04841
+      vertex 4.99356 -15.3686 9.04841
+    endloop
+  endfacet
+  facet normal -0.22894 0.704606 0.671652
+    outer loop
+      vertex -6.03305 -18.9514 9.04841
+      vertex 4.96302 -15.2746 8.93934
+      vertex -6.1853 -18.8969 8.93934
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309018 0
+    outer loop
+      vertex 5.0635 -15.5838 9.42597
+      vertex 4.63168 -14.2548 10.7117
+      vertex 4.63168 -14.2548 9.28834
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309018 0
+    outer loop
+      vertex 4.63168 -14.2548 10.7117
+      vertex 5.0635 -15.5838 9.42597
+      vertex 5.0635 -15.5838 10.574
+    endloop
+  endfacet
+  facet normal -0.950973 -0.309273 0.000127199
+    outer loop
+      vertex 5.09655 -15.6856 10.147
+      vertex 5.08987 -15.665 10.2926
+      vertex 5.0635 -15.5838 10.574
+    endloop
+  endfacet
+  facet normal -0.951103 -0.308874 0.000133891
+    outer loop
+      vertex 4.99356 -15.3686 9.04841
+      vertex 5.0635 -15.5838 9.42597
+      vertex 4.89278 -15.0584 8.7528
+    endloop
+  endfacet
+  facet normal 0.299648 -0.922249 -0.244271
+    outer loop
+      vertex -1.92021 -14.861 10.3385
+      vertex -9.63999 -17.3949 10.4354
+      vertex -9.65108 -17.3882 10.3965
+    endloop
+  endfacet
+  facet normal 0.299752 -0.922521 -0.243114
+    outer loop
+      vertex -9.63999 -17.3949 10.4354
+      vertex -1.92021 -14.861 10.3385
+      vertex -1.86624 -14.869 10.4354
+    endloop
+  endfacet
+  facet normal -0.951161 -0.308695 0
+    outer loop
+      vertex 4.63168 -14.2548 11.3452
+      vertex 4.63525 -14.2658 11.5
+      vertex 4.63168 -14.2548 11.4938
+    endloop
+  endfacet
+  facet normal -0.951085 -0.30893 -1.84463e-05
+    outer loop
+      vertex 4.63525 -14.2658 11.5
+      vertex 4.63168 -14.2548 11.3452
+      vertex 4.72568 -14.5442 11.4712
+    endloop
+  endfacet
+  facet normal 0.299791 -0.922641 0.242608
+    outer loop
+      vertex -9.65108 -17.3882 9.60347
+      vertex -1.94571 -14.8572 9.70736
+      vertex -9.68068 -17.3705 9.70736
+    endloop
+  endfacet
+  facet normal 0.299728 -0.922477 0.24331
+    outer loop
+      vertex -1.94571 -14.8572 9.70736
+      vertex -9.65108 -17.3882 9.60347
+      vertex -1.92021 -14.861 9.66154
+    endloop
+  endfacet
+  facet normal -0.951051 -0.309035 -6.69248e-05
+    outer loop
+      vertex 4.89278 -15.0584 11.2472
+      vertex 4.81264 -14.8118 11.3858
+      vertex 4.72568 -14.5442 11.4712
+    endloop
+  endfacet
+  facet normal -0.951295 -0.308282 0.000506849
+    outer loop
+      vertex 5.04405 -15.524 9.2929
+      vertex 5.0635 -15.5838 9.42597
+      vertex 4.99356 -15.3686 9.04841
+    endloop
+  endfacet
+  facet normal 0.158948 -0.48918 0.857577
+    outer loop
+      vertex 0 -15 8.69333
+      vertex -8.72127 -17.8622 8.67712
+      vertex 0.103154 -14.9949 8.67712
+    endloop
+  endfacet
+  facet normal 0.158879 -0.48897 0.85771
+    outer loop
+      vertex -0.193397 -14.9905 8.73457
+      vertex -8.72127 -17.8622 8.67712
+      vertex 0 -15 8.69333
+    endloop
+  endfacet
+  facet normal 0.158799 -0.488735 0.857858
+    outer loop
+      vertex -8.72127 -17.8622 8.67712
+      vertex -0.193397 -14.9905 8.73457
+      vertex -8.77239 -17.838 8.70037
+    endloop
+  endfacet
+  facet normal -0.951051 -0.309035 6.68613e-05
+    outer loop
+      vertex 4.81264 -14.8118 8.61418
+      vertex 4.89278 -15.0584 8.7528
+      vertex 4.72568 -14.5442 8.52882
+    endloop
+  endfacet
+  facet normal -0.10411 0.320423 0.941536
+    outer loop
+      vertex 4.76981 -14.68 8.56459
+      vertex -6.93476 -18.6287 8.61418
+      vertex 4.81264 -14.8118 8.61418
+    endloop
+  endfacet
+  facet normal -0.104151 0.320544 0.94149
+    outer loop
+      vertex -6.93476 -18.6287 8.61418
+      vertex 4.76981 -14.68 8.56459
+      vertex -7.14821 -18.5524 8.56459
+    endloop
+  endfacet
+  facet normal -0.950958 -0.309321 -0.000223419
+    outer loop
+      vertex 5.02066 -15.452 9.16664
+      vertex 5.04405 -15.524 9.2929
+      vertex 4.99356 -15.3686 9.04841
+    endloop
+  endfacet
+  facet normal -0.951087 -0.308923 0
+    outer loop
+      vertex 4.63168 -14.2548 10.7117
+      vertex 4.72568 -14.5442 11.4712
+      vertex 4.63168 -14.2548 11.3452
+    endloop
+  endfacet
+  facet normal -0.951057 -0.309014 -3.87121e-05
+    outer loop
+      vertex 4.72568 -14.5442 11.4712
+      vertex 4.63168 -14.2548 10.7117
+      vertex 5.0635 -15.5838 10.574
+    endloop
+  endfacet
+  facet normal -0.299787 0.922648 -0.242586
+    outer loop
+      vertex 5.07882 -15.631 10.4354
+      vertex -5.54789 -19.1004 10.3724
+      vertex -5.57671 -19.0932 10.4354
+    endloop
+  endfacet
+  facet normal -0.299765 0.922584 -0.242859
+    outer loop
+      vertex -5.54789 -19.1004 10.3724
+      vertex 5.07882 -15.631 10.4354
+      vertex 5.08987 -15.665 10.2926
+    endloop
+  endfacet
+  facet normal 0.30862 -0.949831 0.0507404
+    outer loop
+      vertex -9.71125 -17.3522 9.96029
+      vertex -2.00974 -14.8477 10
+      vertex -9.71347 -17.3508 10
+    endloop
+  endfacet
+  facet normal 0.308636 -0.949868 0.0499435
+    outer loop
+      vertex -2.00974 -14.8477 10
+      vertex -9.71125 -17.3522 9.96029
+      vertex -1.9989 -14.8494 9.90068
+    endloop
+  endfacet
+  facet normal -0.279395 0.859878 0.427256
+    outer loop
+      vertex 5.04405 -15.524 9.2929
+      vertex -5.66733 -19.0705 9.42597
+      vertex 5.0635 -15.5838 9.42597
+    endloop
+  endfacet
+  facet normal -0.279344 0.859737 0.427573
+    outer loop
+      vertex -5.78145 -19.0414 9.2929
+      vertex -5.66733 -19.0705 9.42597
+      vertex 5.04405 -15.524 9.2929
+    endloop
+  endfacet
+  facet normal -0.269993 0.865986 0.420919
+    outer loop
+      vertex -5.66733 -19.0705 9.42597
+      vertex -5.78145 -19.0414 9.2929
+      vertex -5.77666 -19.0431 9.29947
+    endloop
+  endfacet
+  facet normal -0.951295 -0.308282 -0.000506509
+    outer loop
+      vertex 5.0635 -15.5838 10.574
+      vertex 5.04405 -15.524 10.7071
+      vertex 4.99356 -15.3686 10.9516
+    endloop
+  endfacet
+  facet normal -0.950958 -0.30932 0.000222812
+    outer loop
+      vertex 5.04405 -15.524 10.7071
+      vertex 5.02066 -15.452 10.8334
+      vertex 4.99356 -15.3686 10.9516
+    endloop
+  endfacet
+  facet normal -0.308657 0.94993 0.0486148
+    outer loop
+      vertex 5.09655 -15.6856 9.85297
+      vertex -5.45869 -19.1228 10
+      vertex 5.09878 -15.6924 10
+    endloop
+  endfacet
+  facet normal -0.308633 0.949892 0.0495031
+    outer loop
+      vertex -5.45869 -19.1228 10
+      vertex 5.09655 -15.6856 9.85297
+      vertex -5.46456 -19.1213 9.93462
+    endloop
+  endfacet
+  facet normal -0.950209 -0.311613 0
+    outer loop
+      vertex 5.09878 -15.6924 10
+      vertex 5.09655 -15.6856 10.147
+      vertex 5.09655 -15.6856 9.85297
+    endloop
+  endfacet
+  facet normal -0.305656 0.940709 0.147108
+    outer loop
+      vertex 5.08987 -15.665 9.70736
+      vertex -5.47188 -19.1195 9.85297
+      vertex 5.09655 -15.6856 9.85297
+    endloop
+  endfacet
+  facet normal -0.305673 0.940749 0.146819
+    outer loop
+      vertex -5.47188 -19.1195 9.85297
+      vertex 5.08987 -15.665 9.70736
+      vertex -5.51135 -19.1096 9.70736
+    endloop
+  endfacet
+  facet normal 0.279332 -0.85969 -0.427677
+    outer loop
+      vertex -9.51198 -17.4716 10.7071
+      vertex -1.65946 -14.8997 10.666
+      vertex -1.61623 -14.9061 10.7071
+    endloop
+  endfacet
+  facet normal 0.279339 -0.859711 -0.42763
+    outer loop
+      vertex -1.65946 -14.8997 10.666
+      vertex -9.51198 -17.4716 10.7071
+      vertex -9.56384 -17.4405 10.6107
+    endloop
+  endfacet
+  facet normal 0.0751607 -0.231319 0.96997
+    outer loop
+      vertex 1.47026 -14.9278 8.54282
+      vertex -8.17509 -18.1205 8.52882
+      vertex 1.80297 -14.8784 8.52882
+    endloop
+  endfacet
+  facet normal 0.0750193 -0.230892 0.970083
+    outer loop
+      vertex 1.13889 -14.944 8.56459
+      vertex -8.17509 -18.1205 8.52882
+      vertex 1.47026 -14.9278 8.54282
+    endloop
+  endfacet
+  facet normal 0.0750894 -0.231097 0.970029
+    outer loop
+      vertex -8.17509 -18.1205 8.52882
+      vertex 1.13889 -14.944 8.56459
+      vertex -8.36327 -18.0315 8.56459
+    endloop
+  endfacet
+  facet normal 0.207491 -0.638591 0.741046
+    outer loop
+      vertex -0.917831 -14.9549 8.93934
+      vertex -9.04347 -17.7098 8.84048
+      vertex -0.611229 -14.97 8.84048
+    endloop
+  endfacet
+  facet normal 0.207509 -0.638642 0.740997
+    outer loop
+      vertex -9.04347 -17.7098 8.84048
+      vertex -0.917831 -14.9549 8.93934
+      vertex -9.18721 -17.6418 8.93934
+    endloop
+  endfacet
+  facet normal -0.132173 0.406778 0.903915
+    outer loop
+      vertex 4.81264 -14.8118 8.61418
+      vertex -6.72982 -18.7021 8.67712
+      vertex 4.85376 -14.9383 8.67712
+    endloop
+  endfacet
+  facet normal -0.13207 0.406477 0.904065
+    outer loop
+      vertex -6.72982 -18.7021 8.67712
+      vertex 4.81264 -14.8118 8.61418
+      vertex -6.93476 -18.6287 8.61418
+    endloop
+  endfacet
+  facet normal -0.951037 -0.309078 -4.21101e-05
+    outer loop
+      vertex 4.89278 -15.0584 8.7528
+      vertex 5.0635 -15.5838 9.42597
+      vertex 4.72568 -14.5442 8.52882
+    endloop
+  endfacet
+  facet normal -0.0453394 0.139541 0.989178
+    outer loop
+      vertex 4.68069 -14.4057 8.50722
+      vertex -7.36813 -18.4737 8.52882
+      vertex 4.72568 -14.5442 8.52882
+    endloop
+  endfacet
+  facet normal -0.0453261 0.139502 0.989184
+    outer loop
+      vertex -7.36813 -18.4737 8.52882
+      vertex 4.68069 -14.4057 8.50722
+      vertex -7.59238 -18.3934 8.50722
+    endloop
+  endfacet
+  facet normal -0.248198 0.763873 0.595731
+    outer loop
+      vertex 4.99356 -15.3686 9.04841
+      vertex -5.898 -18.9997 9.16664
+      vertex 5.02066 -15.452 9.16664
+    endloop
+  endfacet
+  facet normal -0.248129 0.763675 0.596013
+    outer loop
+      vertex -5.898 -18.9997 9.16664
+      vertex 4.99356 -15.3686 9.04841
+      vertex -5.9552 -18.9792 9.11656
+    endloop
+  endfacet
+  facet normal -0.264973 0.815509 0.514524
+    outer loop
+      vertex -5.78145 -19.0414 9.2929
+      vertex 5.04405 -15.524 9.2929
+      vertex -5.84811 -19.0175 9.22069
+    endloop
+  endfacet
+  facet normal -0.951161 -0.308695 0
+    outer loop
+      vertex 4.63168 -14.2548 11.4989
+      vertex 4.63525 -14.2658 11.5
+      vertex 4.63168 -14.2548 11.4994
+    endloop
+  endfacet
+  facet normal -0.951161 -0.308695 0
+    outer loop
+      vertex 4.63168 -14.2548 11.4938
+      vertex 4.63525 -14.2658 11.5
+      vertex 4.63168 -14.2548 11.4989
+    endloop
+  endfacet
+  facet normal -0.951044 -0.309057 9.42916e-06
+    outer loop
+      vertex 4.81264 -14.8118 11.3858
+      vertex 4.76981 -14.68 11.4354
+      vertex 4.72568 -14.5442 11.4712
+    endloop
+  endfacet
+  facet normal -0.132104 0.406567 -0.90402
+    outer loop
+      vertex -6.72982 -18.7021 11.3229
+      vertex 4.81264 -14.8118 11.3858
+      vertex 4.85376 -14.9383 11.3229
+    endloop
+  endfacet
+  facet normal -0.132002 0.406266 -0.90417
+    outer loop
+      vertex 4.81264 -14.8118 11.3858
+      vertex -6.72982 -18.7021 11.3229
+      vertex -6.93476 -18.6287 11.3858
+    endloop
+  endfacet
+  facet normal -0.279356 0.859773 -0.427494
+    outer loop
+      vertex -5.66733 -19.0705 10.574
+      vertex -5.78145 -19.0414 10.7071
+      vertex 5.04405 -15.524 10.7071
+    endloop
+  endfacet
+  facet normal -0.279406 0.859914 -0.427177
+    outer loop
+      vertex -5.66733 -19.0705 10.574
+      vertex 5.04405 -15.524 10.7071
+      vertex 5.0635 -15.5838 10.574
+    endloop
+  endfacet
+  facet normal -0.258408 0.87352 -0.412539
+    outer loop
+      vertex -5.78145 -19.0414 10.7071
+      vertex -5.66733 -19.0705 10.574
+      vertex -5.77666 -19.0431 10.7005
+    endloop
+  endfacet
+  facet normal -0.299714 0.92241 -0.24358
+    outer loop
+      vertex 5.08987 -15.665 10.2926
+      vertex -5.51135 -19.1096 10.2926
+      vertex -5.54789 -19.1004 10.3724
+    endloop
+  endfacet
+  facet normal 0.264899 -0.815307 0.514881
+    outer loop
+      vertex -9.42589 -17.5232 9.16664
+      vertex -1.56497 -14.9137 9.25441
+      vertex -9.45001 -17.5087 9.20201
+    endloop
+  endfacet
+  facet normal 0.264968 -0.815503 0.514535
+    outer loop
+      vertex -1.56497 -14.9137 9.25441
+      vertex -9.42589 -17.5232 9.16664
+      vertex -1.47026 -14.9278 9.18329
+    endloop
+  endfacet
+  facet normal 0.265584 -0.81737 0.511244
+    outer loop
+      vertex -1.47026 -14.9278 9.18329
+      vertex -9.42589 -17.5232 9.16664
+      vertex -1.44221 -14.9291 9.16664
+    endloop
+  endfacet
+  facet normal -0.951161 -0.308695 0
+    outer loop
+      vertex 4.63525 -14.2658 8.5
+      vertex 4.63168 -14.2548 8.50114
+      vertex 4.63168 -14.2548 8.50057
+    endloop
+  endfacet
+  facet normal 0.229009 -0.704822 -0.671402
+    outer loop
+      vertex -1.19572 -14.9413 10.9516
+      vertex -9.18721 -17.6418 11.0607
+      vertex -9.31748 -17.5802 10.9516
+    endloop
+  endfacet
+  facet normal 0.229046 -0.704928 -0.671278
+    outer loop
+      vertex -9.18721 -17.6418 11.0607
+      vertex -1.19572 -14.9413 10.9516
+      vertex -0.917831 -14.9549 11.0607
+    endloop
+  endfacet
+  facet normal 0.0453409 -0.139546 -0.989177
+    outer loop
+      vertex -7.98321 -18.2112 11.4928
+      vertex 1.80297 -14.8784 11.4712
+      vertex 2.67 -14.7498 11.4928
+    endloop
+  endfacet
+  facet normal 0.0453609 -0.139605 -0.989168
+    outer loop
+      vertex 1.80297 -14.8784 11.4712
+      vertex -7.98321 -18.2112 11.4928
+      vertex -8.17509 -18.1205 11.4712
+    endloop
+  endfacet
+  facet normal -0.158851 0.488898 0.857756
+    outer loop
+      vertex 4.85376 -14.9383 8.67712
+      vertex -6.53537 -18.7716 8.7528
+      vertex 4.89278 -15.0584 8.7528
+    endloop
+  endfacet
+  facet normal -0.15894 0.489159 0.857591
+    outer loop
+      vertex -6.53537 -18.7716 8.7528
+      vertex 4.85376 -14.9383 8.67712
+      vertex -6.72982 -18.7021 8.67712
+    endloop
+  endfacet
+  facet normal -0.207558 0.638799 0.740848
+    outer loop
+      vertex 4.92931 -15.1709 8.84048
+      vertex -6.1853 -18.8969 8.93934
+      vertex 4.96302 -15.2746 8.93934
+    endloop
+  endfacet
+  facet normal -0.207533 0.638728 0.740916
+    outer loop
+      vertex -6.1853 -18.8969 8.93934
+      vertex 4.92931 -15.1709 8.84048
+      vertex -6.35327 -18.8368 8.84048
+    endloop
+  endfacet
+  facet normal -0.951037 -0.309078 4.21092e-05
+    outer loop
+      vertex 5.0635 -15.5838 10.574
+      vertex 4.89278 -15.0584 11.2472
+      vertex 4.72568 -14.5442 11.4712
+    endloop
+  endfacet
+  facet normal -0.950846 -0.309662 0.0011673
+    outer loop
+      vertex 4.89278 -15.0584 11.2472
+      vertex 4.85376 -14.9383 11.3229
+      vertex 4.81264 -14.8118 11.3858
+    endloop
+  endfacet
+  facet normal -0.299716 0.922417 0.243552
+    outer loop
+      vertex -5.51135 -19.1096 9.70736
+      vertex 5.08987 -15.665 9.70736
+      vertex -5.54789 -19.1004 9.62755
+    endloop
+  endfacet
+  facet normal -0.951427 -0.307874 0.000319131
+    outer loop
+      vertex 5.07882 -15.631 9.56457
+      vertex 5.08987 -15.665 9.70736
+      vertex 5.0635 -15.5838 9.42597
+    endloop
+  endfacet
+  facet normal -0.308652 0.949932 0.0486125
+    outer loop
+      vertex -5.46456 -19.1213 9.93462
+      vertex 5.09655 -15.6856 9.85297
+      vertex -5.47188 -19.1195 9.85297
+    endloop
+  endfacet
+  facet normal 0.305653 -0.940692 0.147225
+    outer loop
+      vertex -9.68068 -17.3705 9.70736
+      vertex -1.9612 -14.8549 9.75436
+      vertex -9.6986 -17.3597 9.81357
+    endloop
+  endfacet
+  facet normal 0.305676 -0.940754 0.14678
+    outer loop
+      vertex -1.9612 -14.8549 9.75436
+      vertex -9.68068 -17.3705 9.70736
+      vertex -1.94571 -14.8572 9.70736
+    endloop
+  endfacet
+  facet normal 0.305769 -0.941037 0.144757
+    outer loop
+      vertex -9.6986 -17.3597 9.81357
+      vertex -1.9937 -14.8501 9.85297
+      vertex -9.70525 -17.3558 9.85297
+    endloop
+  endfacet
+  facet normal 0.30568 -0.94079 0.146541
+    outer loop
+      vertex -1.9937 -14.8501 9.85297
+      vertex -9.6986 -17.3597 9.81357
+      vertex -1.9612 -14.8549 9.75436
+    endloop
+  endfacet
+  facet normal 0.0453409 -0.139546 0.989177
+    outer loop
+      vertex 1.80297 -14.8784 8.52882
+      vertex -7.98321 -18.2112 8.50722
+      vertex 2.67 -14.7498 8.50722
+    endloop
+  endfacet
+  facet normal 0.0453609 -0.139605 0.989168
+    outer loop
+      vertex -7.98321 -18.2112 8.50722
+      vertex 1.80297 -14.8784 8.52882
+      vertex -8.17509 -18.1205 8.52882
+    endloop
+  endfacet
+  facet normal -0.950845 -0.309664 -0.00117155
+    outer loop
+      vertex 4.85376 -14.9383 8.67712
+      vertex 4.89278 -15.0584 8.7528
+      vertex 4.81264 -14.8118 8.61418
+    endloop
+  endfacet
+  facet normal 0.0158565 -0.049326 -0.998657
+    outer loop
+      vertex 4.63525 -14.2658 11.5
+      vertex 4.35427 -14.3541 11.4999
+      vertex 4.63168 -14.2548 11.4994
+    endloop
+  endfacet
+  facet normal 0.0108331 -0.0333404 -0.999385
+    outer loop
+      vertex -7.78945 -18.3029 11.5
+      vertex 4.35427 -14.3541 11.4999
+      vertex 4.63525 -14.2658 11.5
+    endloop
+  endfacet
+  facet normal 0.0152581 -0.0469485 -0.998781
+    outer loop
+      vertex -7.78945 -18.3029 11.5
+      vertex 2.92635 -14.7118 11.4949
+      vertex 4.35427 -14.3541 11.4999
+    endloop
+  endfacet
+  facet normal 0.0150492 -0.0463251 -0.998813
+    outer loop
+      vertex -7.78945 -18.3029 11.5
+      vertex 2.67 -14.7498 11.4928
+      vertex 2.92635 -14.7118 11.4949
+    endloop
+  endfacet
+  facet normal 0.0151084 -0.0464993 -0.998804
+    outer loop
+      vertex 2.67 -14.7498 11.4928
+      vertex -7.78945 -18.3029 11.5
+      vertex -7.98321 -18.2112 11.4928
+    endloop
+  endfacet
+  facet normal 0.0751607 -0.231319 -0.96997
+    outer loop
+      vertex -8.17509 -18.1205 11.4712
+      vertex 1.47026 -14.9278 11.4572
+      vertex 1.80297 -14.8784 11.4712
+    endloop
+  endfacet
+  facet normal 0.0751164 -0.231185 -0.970006
+    outer loop
+      vertex -8.17509 -18.1205 11.4712
+      vertex 1.13889 -14.944 11.4354
+      vertex 1.47026 -14.9278 11.4572
+    endloop
+  endfacet
+  facet normal 0.0751486 -0.231279 -0.969981
+    outer loop
+      vertex 1.13889 -14.944 11.4354
+      vertex -8.17509 -18.1205 11.4712
+      vertex -8.36327 -18.0315 11.4354
+    endloop
+  endfacet
+  facet normal -0.951566 -0.307437 -0.0019846
+    outer loop
+      vertex 4.96302 -15.2746 11.0607
+      vertex 4.92931 -15.1709 11.1595
+      vertex 4.89278 -15.0584 11.2472
+    endloop
+  endfacet
+  facet normal -0.951074 -0.308964 -2.95227e-05
+    outer loop
+      vertex 4.99356 -15.3686 10.9516
+      vertex 4.96302 -15.2746 11.0607
+      vertex 4.89278 -15.0584 11.2472
+    endloop
+  endfacet
+  facet normal -0.264964 0.815479 -0.514576
+    outer loop
+      vertex 5.04405 -15.524 10.7071
+      vertex -5.78145 -19.0414 10.7071
+      vertex -5.84811 -19.0175 10.7793
+    endloop
+  endfacet
+  facet normal -0.951427 -0.307874 -0.000319057
+    outer loop
+      vertex 5.08987 -15.665 10.2926
+      vertex 5.07882 -15.631 10.4354
+      vertex 5.0635 -15.5838 10.574
+    endloop
+  endfacet
+  facet normal -0.290932 0.895396 -0.337083
+    outer loop
+      vertex -5.57671 -19.0932 10.4354
+      vertex 5.0635 -15.5838 10.574
+      vertex 5.07882 -15.631 10.4354
+    endloop
+  endfacet
+  facet normal -0.291016 0.895622 -0.336408
+    outer loop
+      vertex 5.0635 -15.5838 10.574
+      vertex -5.57671 -19.0932 10.4354
+      vertex -5.61641 -19.0833 10.4961
+    endloop
+  endfacet
+  facet normal -0.290914 0.89533 -0.337273
+    outer loop
+      vertex 5.0635 -15.5838 10.574
+      vertex -5.61641 -19.0833 10.4961
+      vertex -5.66733 -19.0705 10.574
+    endloop
+  endfacet
+  facet normal 0.279326 -0.859679 0.427702
+    outer loop
+      vertex -9.51198 -17.4716 9.2929
+      vertex -1.65946 -14.8997 9.33404
+      vertex -9.56384 -17.4405 9.38928
+    endloop
+  endfacet
+  facet normal 0.279381 -0.859842 0.427337
+    outer loop
+      vertex -1.65946 -14.8997 9.33404
+      vertex -9.51198 -17.4716 9.2929
+      vertex -1.61623 -14.9061 9.2929
+    endloop
+  endfacet
+  facet normal 0.279451 -0.860066 -0.426843
+    outer loop
+      vertex -1.75606 -14.8854 10.574
+      vertex -9.56384 -17.4405 10.6107
+      vertex -9.58358 -17.4287 10.574
+    endloop
+  endfacet
+  facet normal 0.279418 -0.859969 -0.427058
+    outer loop
+      vertex -9.56384 -17.4405 10.6107
+      vertex -1.75606 -14.8854 10.574
+      vertex -1.65946 -14.8997 10.666
+    endloop
+  endfacet
+  facet normal 0.158876 -0.488958 -0.857717
+    outer loop
+      vertex -8.72127 -17.8622 11.3229
+      vertex 0 -15 11.3067
+      vertex 0.103154 -14.9949 11.3229
+    endloop
+  endfacet
+  facet normal 0.15905 -0.489486 -0.857383
+    outer loop
+      vertex -8.72127 -17.8622 11.3229
+      vertex -0.193397 -14.9905 11.2654
+      vertex 0 -15 11.3067
+    endloop
+  endfacet
+  facet normal 0.159055 -0.489501 -0.857374
+    outer loop
+      vertex -0.193397 -14.9905 11.2654
+      vertex -8.72127 -17.8622 11.3229
+      vertex -8.77239 -17.838 11.2996
+    endloop
+  endfacet
+  facet normal -0.18402 0.56636 0.803351
+    outer loop
+      vertex 4.89278 -15.0584 8.7528
+      vertex -6.35327 -18.8368 8.84048
+      vertex 4.92931 -15.1709 8.84048
+    endloop
+  endfacet
+  facet normal -0.184022 0.566366 0.803347
+    outer loop
+      vertex -6.35327 -18.8368 8.84048
+      vertex 4.89278 -15.0584 8.7528
+      vertex -6.53537 -18.7716 8.7528
+    endloop
+  endfacet
+  facet normal -0.265024 0.815674 0.514236
+    outer loop
+      vertex 5.02066 -15.452 9.16664
+      vertex -5.84811 -19.0175 9.22069
+      vertex 5.04405 -15.524 9.2929
+    endloop
+  endfacet
+  facet normal -0.265163 0.816085 0.513511
+    outer loop
+      vertex -5.84811 -19.0175 9.22069
+      vertex 5.02066 -15.452 9.16664
+      vertex -5.898 -18.9997 9.16664
+    endloop
+  endfacet
+  facet normal -0.951564 -0.307443 0.00197596
+    outer loop
+      vertex 4.92931 -15.1709 8.84048
+      vertex 4.96302 -15.2746 8.93934
+      vertex 4.89278 -15.0584 8.7528
+    endloop
+  endfacet
+  facet normal -0.951074 -0.308964 2.95727e-05
+    outer loop
+      vertex 4.96302 -15.2746 8.93934
+      vertex 4.99356 -15.3686 9.04841
+      vertex 4.89278 -15.0584 8.7528
+    endloop
+  endfacet
+  facet normal -0.951103 -0.308874 -0.000133855
+    outer loop
+      vertex 5.0635 -15.5838 10.574
+      vertex 4.99356 -15.3686 10.9516
+      vertex 4.89278 -15.0584 11.2472
+    endloop
+  endfacet
+  facet normal -0.158882 0.488993 -0.857696
+    outer loop
+      vertex -6.53537 -18.7716 11.2472
+      vertex 4.85376 -14.9383 11.3229
+      vertex 4.89278 -15.0584 11.2472
+    endloop
+  endfacet
+  facet normal -0.158971 0.489254 -0.857531
+    outer loop
+      vertex 4.85376 -14.9383 11.3229
+      vertex -6.53537 -18.7716 11.2472
+      vertex -6.72982 -18.7021 11.3229
+    endloop
+  endfacet
+  facet normal 0.246411 -0.765066 -0.594942
+    outer loop
+      vertex -9.42589 -17.5232 10.8334
+      vertex -9.31748 -17.5802 10.9516
+      vertex -9.38079 -17.5502 10.8868
+    endloop
+  endfacet
+  facet normal 0.24816 -0.763746 -0.59591
+    outer loop
+      vertex -9.31748 -17.5802 10.9516
+      vertex -9.42589 -17.5232 10.8334
+      vertex -1.44221 -14.9291 10.8334
+    endloop
+  endfacet
+  facet normal 0.248094 -0.76356 -0.596176
+    outer loop
+      vertex -9.31748 -17.5802 10.9516
+      vertex -1.44221 -14.9291 10.8334
+      vertex -1.19572 -14.9413 10.9516
+    endloop
+  endfacet
+  facet normal -0.29091 0.895317 0.337311
+    outer loop
+      vertex -5.61641 -19.0833 9.50386
+      vertex 5.0635 -15.5838 9.42597
+      vertex -5.66733 -19.0705 9.42597
+    endloop
+  endfacet
+  facet normal 0.241947 -0.768494 0.59235
+    outer loop
+      vertex -9.31748 -17.5802 9.04841
+      vertex -9.42589 -17.5232 9.16664
+      vertex -9.38079 -17.5502 9.11319
+    endloop
+  endfacet
+  facet normal 0.248183 -0.763815 0.595813
+    outer loop
+      vertex -9.42589 -17.5232 9.16664
+      vertex -9.31748 -17.5802 9.04841
+      vertex -1.44221 -14.9291 9.16664
+    endloop
+  endfacet
+  facet normal 0.248116 -0.763628 0.596079
+    outer loop
+      vertex -1.44221 -14.9291 9.16664
+      vertex -9.31748 -17.5802 9.04841
+      vertex -1.19572 -14.9413 9.04841
+    endloop
+  endfacet
+  facet normal 0.0152108 -0.0468188 0.998788
+    outer loop
+      vertex 4.35427 -14.3541 8.50014
+      vertex 4.63525 -14.2658 8.5
+      vertex 4.63168 -14.2548 8.50057
+    endloop
+  endfacet
+  facet normal 0.0151574 -0.046649 0.998796
+    outer loop
+      vertex 4.35427 -14.3541 8.50014
+      vertex -7.78945 -18.3029 8.5
+      vertex 4.63525 -14.2658 8.5
+    endloop
+  endfacet
+  facet normal 0.015178 -0.0467122 0.998793
+    outer loop
+      vertex 2.92635 -14.7118 8.50511
+      vertex -7.78945 -18.3029 8.5
+      vertex 4.35427 -14.3541 8.50014
+    endloop
+  endfacet
+  facet normal 0.0151196 -0.0465381 0.998802
+    outer loop
+      vertex 2.67 -14.7498 8.50722
+      vertex -7.78945 -18.3029 8.5
+      vertex 2.92635 -14.7118 8.50511
+    endloop
+  endfacet
+  facet normal 0.0151503 -0.0466282 0.998797
+    outer loop
+      vertex -7.78945 -18.3029 8.5
+      vertex 2.67 -14.7498 8.50722
+      vertex -7.98321 -18.2112 8.50722
+    endloop
+  endfacet
+  facet normal 0.183895 -0.565964 0.803659
+    outer loop
+      vertex -0.361519 -14.9822 8.7746
+      vertex -8.88766 -17.7835 8.7528
+      vertex -0.278867 -14.9863 8.7528
+    endloop
+  endfacet
+  facet normal 0.183952 -0.566135 0.803525
+    outer loop
+      vertex -8.88766 -17.7835 8.7528
+      vertex -0.361519 -14.9822 8.7746
+      vertex -8.99701 -17.7317 8.81433
+    endloop
+  endfacet
+  facet normal -0.951044 -0.309057 -9.41704e-06
+    outer loop
+      vertex 4.76981 -14.68 8.56459
+      vertex 4.81264 -14.8118 8.61418
+      vertex 4.72568 -14.5442 8.52882
+    endloop
+  endfacet
+  facet normal -0.0751499 0.231288 -0.969979
+    outer loop
+      vertex -7.14821 -18.5524 11.4354
+      vertex 4.72568 -14.5442 11.4712
+      vertex 4.76981 -14.68 11.4354
+    endloop
+  endfacet
+  facet normal -0.0751414 0.231263 -0.969985
+    outer loop
+      vertex 4.72568 -14.5442 11.4712
+      vertex -7.14821 -18.5524 11.4354
+      vertex -7.36813 -18.4737 11.4712
+    endloop
+  endfacet
+  facet normal -0.0453394 0.139541 -0.989178
+    outer loop
+      vertex -7.36813 -18.4737 11.4712
+      vertex 4.68069 -14.4057 11.4928
+      vertex 4.72568 -14.5442 11.4712
+    endloop
+  endfacet
+  facet normal -0.0453261 0.139502 -0.989184
+    outer loop
+      vertex 4.68069 -14.4057 11.4928
+      vertex -7.36813 -18.4737 11.4712
+      vertex -7.59238 -18.3934 11.4928
+    endloop
+  endfacet
+  facet normal -0.951094 -0.308903 -0.000310511
+    outer loop
+      vertex 4.72568 -14.5442 11.4712
+      vertex 4.68069 -14.4057 11.4928
+      vertex 4.63525 -14.2658 11.5
+    endloop
+  endfacet
+  facet normal -0.0151075 0.0464968 -0.998804
+    outer loop
+      vertex -7.59238 -18.3934 11.4928
+      vertex 4.63525 -14.2658 11.5
+      vertex 4.68069 -14.4057 11.4928
+    endloop
+  endfacet
+  facet normal -0.00920583 0.059368 -0.998194
+    outer loop
+      vertex -7.78945 -18.3029 11.5
+      vertex -7.59238 -18.3934 11.4928
+      vertex -7.6154 -18.3852 11.4935
+    endloop
+  endfacet
+  facet normal -0.0151208 0.0465362 -0.998802
+    outer loop
+      vertex -7.59238 -18.3934 11.4928
+      vertex -7.78945 -18.3029 11.5
+      vertex 4.63525 -14.2658 11.5
+    endloop
+  endfacet
+  facet normal -0.229016 0.704833 -0.671388
+    outer loop
+      vertex -6.03305 -18.9514 10.9516
+      vertex 4.96302 -15.2746 11.0607
+      vertex 4.99356 -15.3686 10.9516
+    endloop
+  endfacet
+  facet normal -0.228968 0.704693 -0.671551
+    outer loop
+      vertex 4.96302 -15.2746 11.0607
+      vertex -6.03305 -18.9514 10.9516
+      vertex -6.1853 -18.8969 11.0607
+    endloop
+  endfacet
+  facet normal -0.184047 0.566444 -0.803286
+    outer loop
+      vertex -6.35327 -18.8368 11.1595
+      vertex 4.89278 -15.0584 11.2472
+      vertex 4.92931 -15.1709 11.1595
+    endloop
+  endfacet
+  facet normal -0.184049 0.566449 -0.803282
+    outer loop
+      vertex 4.89278 -15.0584 11.2472
+      vertex -6.35327 -18.8368 11.1595
+      vertex -6.53537 -18.7716 11.2472
+    endloop
+  endfacet
+  facet normal -0.248176 0.763805 -0.595828
+    outer loop
+      vertex -5.898 -18.9997 10.8334
+      vertex 4.99356 -15.3686 10.9516
+      vertex 5.02066 -15.452 10.8334
+    endloop
+  endfacet
+  facet normal -0.247982 0.763247 -0.596622
+    outer loop
+      vertex 4.99356 -15.3686 10.9516
+      vertex -5.898 -18.9997 10.8334
+      vertex -5.9552 -18.9792 10.8834
+    endloop
+  endfacet
+  facet normal -0.265228 0.816284 -0.513162
+    outer loop
+      vertex 5.02066 -15.452 10.8334
+      vertex -5.84811 -19.0175 10.7793
+      vertex -5.898 -18.9997 10.8334
+    endloop
+  endfacet
+  facet normal -0.265045 0.815742 -0.514116
+    outer loop
+      vertex -5.84811 -19.0175 10.7793
+      vertex 5.02066 -15.452 10.8334
+      vertex 5.04405 -15.524 10.7071
+    endloop
+  endfacet
+  facet normal 0.26511 -0.815919 0.513802
+    outer loop
+      vertex -9.45001 -17.5087 9.20201
+      vertex -1.61623 -14.9061 9.2929
+      vertex -9.51198 -17.4716 9.2929
+    endloop
+  endfacet
+  facet normal 0.265056 -0.815767 0.514071
+    outer loop
+      vertex -1.61623 -14.9061 9.2929
+      vertex -9.45001 -17.5087 9.20201
+      vertex -1.56497 -14.9137 9.25441
+    endloop
+  endfacet
+  facet normal 0.279437 -0.860023 0.426938
+    outer loop
+      vertex -9.56384 -17.4405 9.38928
+      vertex -1.75606 -14.8854 9.42597
+      vertex -9.58358 -17.4287 9.42597
+    endloop
+  endfacet
+  facet normal 0.279378 -0.85985 0.427323
+    outer loop
+      vertex -1.75606 -14.8854 9.42597
+      vertex -9.56384 -17.4405 9.38928
+      vertex -1.65946 -14.8997 9.33404
+    endloop
+  endfacet
+  facet normal 0.290968 -0.895489 0.336804
+    outer loop
+      vertex -9.58358 -17.4287 9.42597
+      vertex -1.86624 -14.869 9.56457
+      vertex -9.63999 -17.3949 9.56457
+    endloop
+  endfacet
+  facet normal 0.290916 -0.895354 0.337208
+    outer loop
+      vertex -1.86624 -14.869 9.56457
+      vertex -9.58358 -17.4287 9.42597
+      vertex -1.75606 -14.8854 9.42597
+    endloop
+  endfacet
+  facet normal 0.299646 -0.922249 0.244271
+    outer loop
+      vertex -9.63999 -17.3949 9.56457
+      vertex -1.92021 -14.861 9.66154
+      vertex -9.65108 -17.3882 9.60347
+    endloop
+  endfacet
+  facet normal 0.299765 -0.92256 0.242949
+    outer loop
+      vertex -1.92021 -14.861 9.66154
+      vertex -9.63999 -17.3949 9.56457
+      vertex -1.86624 -14.869 9.56457
+    endloop
+  endfacet
+  facet normal 0.299793 -0.922646 -0.242586
+    outer loop
+      vertex -1.94571 -14.8572 10.2926
+      vertex -9.65108 -17.3882 10.3965
+      vertex -9.68068 -17.3705 10.2926
+    endloop
+  endfacet
+  facet normal 0.299763 -0.92257 -0.242913
+    outer loop
+      vertex -9.65108 -17.3882 10.3965
+      vertex -1.94571 -14.8572 10.2926
+      vertex -1.92021 -14.861 10.3385
+    endloop
+  endfacet
+  facet normal 0.207422 -0.638378 -0.741249
+    outer loop
+      vertex -9.04347 -17.7098 11.1595
+      vertex -0.917831 -14.9549 11.0607
+      vertex -0.611229 -14.97 11.1595
+    endloop
+  endfacet
+  facet normal 0.207439 -0.638429 -0.7412
+    outer loop
+      vertex -0.917831 -14.9549 11.0607
+      vertex -9.04347 -17.7098 11.1595
+      vertex -9.18721 -17.6418 11.0607
+    endloop
+  endfacet
+  facet normal -0.248289 0.764147 0.595342
+    outer loop
+      vertex -5.9552 -18.9792 9.11656
+      vertex 4.99356 -15.3686 9.04841
+      vertex -6.03305 -18.9514 9.04841
+    endloop
+  endfacet
+  facet normal -0.104129 0.32048 -0.941515
+    outer loop
+      vertex -6.93476 -18.6287 11.3858
+      vertex 4.76981 -14.68 11.4354
+      vertex 4.81264 -14.8118 11.3858
+    endloop
+  endfacet
+  facet normal -0.10417 0.320601 -0.941469
+    outer loop
+      vertex 4.76981 -14.68 11.4354
+      vertex -6.93476 -18.6287 11.3858
+      vertex -7.14821 -18.5524 11.4354
+    endloop
+  endfacet
+  facet normal 0.22898 -0.704734 0.671504
+    outer loop
+      vertex -9.18721 -17.6418 8.93934
+      vertex -1.19572 -14.9413 9.04841
+      vertex -9.31748 -17.5802 9.04841
+    endloop
+  endfacet
+  facet normal 0.229018 -0.70484 0.67138
+    outer loop
+      vertex -1.19572 -14.9413 9.04841
+      vertex -9.18721 -17.6418 8.93934
+      vertex -0.917831 -14.9549 8.93934
+    endloop
+  endfacet
+  facet normal -0.951161 -0.308695 0
+    outer loop
+      vertex 4.63525 -14.2658 8.5
+      vertex 4.63168 -14.2548 8.65483
+      vertex 4.63168 -14.2548 8.50618
+    endloop
+  endfacet
+  facet normal -0.951085 -0.30893 1.84427e-05
+    outer loop
+      vertex 4.63168 -14.2548 8.65483
+      vertex 4.63525 -14.2658 8.5
+      vertex 4.72568 -14.5442 8.52882
+    endloop
+  endfacet
+  facet normal -0.951094 -0.308902 0.000310936
+    outer loop
+      vertex 4.68069 -14.4057 8.50722
+      vertex 4.72568 -14.5442 8.52882
+      vertex 4.63525 -14.2658 8.5
+    endloop
+  endfacet
+  facet normal 0.132074 -0.40648 0.904063
+    outer loop
+      vertex 0.103154 -14.9949 8.67712
+      vertex -8.66665 -17.888 8.65751
+      vertex 0.505289 -14.9752 8.62723
+    endloop
+  endfacet
+  facet normal 0.132244 -0.406995 0.903807
+    outer loop
+      vertex -8.66665 -17.888 8.65751
+      vertex 0.103154 -14.9949 8.67712
+      vertex -8.72127 -17.8622 8.67712
+    endloop
+  endfacet
+  facet normal -0.951161 -0.308695 0
+    outer loop
+      vertex 4.63525 -14.2658 8.5
+      vertex 4.63168 -14.2548 8.50618
+      vertex 4.63168 -14.2548 8.50114
+    endloop
+  endfacet
+  facet normal 0.184196 -0.566921 -0.802915
+    outer loop
+      vertex -8.99701 -17.7317 11.1857
+      vertex -0.611229 -14.97 11.1595
+      vertex -0.361519 -14.9822 11.2254
+    endloop
+  endfacet
+  facet normal 0.184558 -0.568011 -0.802061
+    outer loop
+      vertex -0.611229 -14.97 11.1595
+      vertex -8.99701 -17.7317 11.1857
+      vertex -9.04347 -17.7098 11.1595
+    endloop
+  endfacet
+  facet normal 0.158707 -0.488459 -0.858032
+    outer loop
+      vertex -8.77239 -17.838 11.2996
+      vertex -0.278867 -14.9863 11.2472
+      vertex -0.193397 -14.9905 11.2654
+    endloop
+  endfacet
+  facet normal 0.158829 -0.48882 -0.857804
+    outer loop
+      vertex -0.278867 -14.9863 11.2472
+      vertex -8.77239 -17.838 11.2996
+      vertex -8.88766 -17.7835 11.2472
+    endloop
+  endfacet
+  facet normal 0.104129 -0.320471 -0.941518
+    outer loop
+      vertex -8.36327 -18.0315 11.4354
+      vertex 0.714704 -14.9649 11.3956
+      vertex 1.13889 -14.944 11.4354
+    endloop
+  endfacet
+  facet normal 0.103811 -0.319534 -0.941871
+    outer loop
+      vertex 0.714704 -14.9649 11.3956
+      vertex -8.36327 -18.0315 11.4354
+      vertex -8.42196 -18.0037 11.4195
+    endloop
+  endfacet
+  facet normal 0.290968 -0.895489 -0.336804
+    outer loop
+      vertex -1.86624 -14.869 10.4354
+      vertex -9.58358 -17.4287 10.574
+      vertex -9.63999 -17.3949 10.4354
+    endloop
+  endfacet
+  facet normal 0.290916 -0.895354 -0.337208
+    outer loop
+      vertex -9.58358 -17.4287 10.574
+      vertex -1.86624 -14.869 10.4354
+      vertex -1.75606 -14.8854 10.574
+    endloop
+  endfacet
+  facet normal 0.265118 -0.815943 -0.51376
+    outer loop
+      vertex -1.61623 -14.9061 10.7071
+      vertex -9.45001 -17.5087 10.798
+      vertex -9.51198 -17.4716 10.7071
+    endloop
+  endfacet
+  facet normal 0.265075 -0.815822 -0.513974
+    outer loop
+      vertex -9.45001 -17.5087 10.798
+      vertex -1.61623 -14.9061 10.7071
+      vertex -1.56497 -14.9137 10.7456
+    endloop
+  endfacet
+  facet normal 0.265792 -0.81801 -0.510113
+    outer loop
+      vertex -9.42589 -17.5232 10.8334
+      vertex -1.47026 -14.9278 10.8167
+      vertex -1.44221 -14.9291 10.8334
+    endloop
+  endfacet
+  facet normal 0.264961 -0.815489 -0.514561
+    outer loop
+      vertex -1.56497 -14.9137 10.7456
+      vertex -9.42589 -17.5232 10.8334
+      vertex -9.45001 -17.5087 10.798
+    endloop
+  endfacet
+  facet normal 0.264946 -0.815445 -0.514639
+    outer loop
+      vertex -9.42589 -17.5232 10.8334
+      vertex -1.56497 -14.9137 10.7456
+      vertex -1.47026 -14.9278 10.8167
+    endloop
+  endfacet
+  facet normal 0.308619 -0.949831 -0.0507531
+    outer loop
+      vertex -2.00974 -14.8477 10
+      vertex -9.71125 -17.3522 10.0397
+      vertex -9.71347 -17.3508 10
+    endloop
+  endfacet
+  facet normal 0.308636 -0.949868 -0.0499535
+    outer loop
+      vertex -9.71125 -17.3522 10.0397
+      vertex -2.00974 -14.8477 10
+      vertex -1.9989 -14.8494 10.0993
+    endloop
+  endfacet
+  facet normal 0.305769 -0.941037 -0.144757
+    outer loop
+      vertex -1.9937 -14.8501 10.147
+      vertex -9.6986 -17.3597 10.1864
+      vertex -9.70525 -17.3558 10.147
+    endloop
+  endfacet
+  facet normal 0.305679 -0.940788 -0.146555
+    outer loop
+      vertex -9.6986 -17.3597 10.1864
+      vertex -1.9937 -14.8501 10.147
+      vertex -1.9612 -14.8549 10.2456
+    endloop
+  endfacet
+  facet normal 0.184162 -0.566803 0.803006
+    outer loop
+      vertex -0.611229 -14.97 8.84048
+      vertex -8.99701 -17.7317 8.81433
+      vertex -0.361519 -14.9822 8.7746
+    endloop
+  endfacet
+  facet normal 0.184331 -0.567313 0.802607
+    outer loop
+      vertex -8.99701 -17.7317 8.81433
+      vertex -0.611229 -14.97 8.84048
+      vertex -9.04347 -17.7098 8.84048
+    endloop
+  endfacet
+  facet normal 0.104153 -0.320542 0.941491
+    outer loop
+      vertex 0.714704 -14.9649 8.6044
+      vertex -8.36327 -18.0315 8.56459
+      vertex 1.13889 -14.944 8.56459
+    endloop
+  endfacet
+  facet normal 0.103989 -0.320061 0.941672
+    outer loop
+      vertex -8.36327 -18.0315 8.56459
+      vertex 0.714704 -14.9649 8.6044
+      vertex -8.42196 -18.0037 8.58052
+    endloop
+  endfacet
+  facet normal 0.183895 -0.565964 -0.803659
+    outer loop
+      vertex -8.88766 -17.7835 11.2472
+      vertex -0.361519 -14.9822 11.2254
+      vertex -0.278867 -14.9863 11.2472
+    endloop
+  endfacet
+  facet normal 0.183893 -0.565958 -0.803664
+    outer loop
+      vertex -0.361519 -14.9822 11.2254
+      vertex -8.88766 -17.7835 11.2472
+      vertex -8.99701 -17.7317 11.1857
+    endloop
+  endfacet
+  facet normal 0.132095 -0.406542 -0.904032
+    outer loop
+      vertex -8.66665 -17.888 11.3425
+      vertex 0.103154 -14.9949 11.3229
+      vertex 0.505289 -14.9752 11.3728
+    endloop
+  endfacet
+  facet normal 0.132189 -0.406826 -0.903891
+    outer loop
+      vertex 0.103154 -14.9949 11.3229
+      vertex -8.66665 -17.888 11.3425
+      vertex -8.72127 -17.8622 11.3229
+    endloop
+  endfacet
+  facet normal 0.308674 -0.949977 -0.047591
+    outer loop
+      vertex -9.70525 -17.3558 10.147
+      vertex -1.9989 -14.8494 10.0993
+      vertex -1.9937 -14.8501 10.147
+    endloop
+  endfacet
+  facet normal 0.308643 -0.949908 -0.0491289
+    outer loop
+      vertex -1.9989 -14.8494 10.0993
+      vertex -9.70525 -17.3558 10.147
+      vertex -9.71125 -17.3522 10.0397
+    endloop
+  endfacet
+  facet normal 0.158901 -0.48904 0.857665
+    outer loop
+      vertex -0.278867 -14.9863 8.7528
+      vertex -8.77239 -17.838 8.70037
+      vertex -0.193397 -14.9905 8.73457
+    endloop
+  endfacet
+  facet normal 0.158896 -0.489026 0.857674
+    outer loop
+      vertex -8.77239 -17.838 8.70037
+      vertex -0.278867 -14.9863 8.7528
+      vertex -8.88766 -17.7835 8.7528
+    endloop
+  endfacet
+  facet normal 0.132239 -0.40699 0.90381
+    outer loop
+      vertex 0.505289 -14.9752 8.62723
+      vertex -8.54591 -17.9451 8.61418
+      vertex 0.610485 -14.97 8.61418
+    endloop
+  endfacet
+  facet normal 0.132118 -0.406621 0.903993
+    outer loop
+      vertex -8.54591 -17.9451 8.61418
+      vertex 0.505289 -14.9752 8.62723
+      vertex -8.66665 -17.888 8.65751
+    endloop
+  endfacet
+  facet normal 0.104031 -0.320188 0.941625
+    outer loop
+      vertex 0.610485 -14.97 8.61418
+      vertex -8.42196 -18.0037 8.58052
+      vertex 0.714704 -14.9649 8.6044
+    endloop
+  endfacet
+  facet normal 0.104143 -0.320518 0.9415
+    outer loop
+      vertex -8.42196 -18.0037 8.58052
+      vertex 0.610485 -14.97 8.61418
+      vertex -8.54591 -17.9451 8.61418
+    endloop
+  endfacet
+  facet normal 0.10422 -0.320759 -0.94141
+    outer loop
+      vertex -8.42196 -18.0037 11.4195
+      vertex 0.610485 -14.97 11.3858
+      vertex 0.714704 -14.9649 11.3956
+    endloop
+  endfacet
+  facet normal 0.104253 -0.320856 -0.941373
+    outer loop
+      vertex 0.610485 -14.97 11.3858
+      vertex -8.42196 -18.0037 11.4195
+      vertex -8.54591 -17.9451 11.3858
+    endloop
+  endfacet
+  facet normal 0.131825 -0.405715 -0.904443
+    outer loop
+      vertex -8.54591 -17.9451 11.3858
+      vertex 0.505289 -14.9752 11.3728
+      vertex 0.610485 -14.97 11.3858
+    endloop
+  endfacet
+  facet normal 0.132046 -0.406387 -0.904109
+    outer loop
+      vertex 0.505289 -14.9752 11.3728
+      vertex -8.54591 -17.9451 11.3858
+      vertex -8.66665 -17.888 11.3425
+    endloop
+  endfacet
+  facet normal -0.989176 -0.146737 0
+    outer loop
+      vertex 14.9278 1.47026 0
+      vertex 14.7118 2.92635 41
+      vertex 14.7118 2.92635 0
+    endloop
+  endfacet
+  facet normal -0.989176 -0.146737 0
+    outer loop
+      vertex 14.7118 2.92635 41
+      vertex 14.9278 1.47026 0
+      vertex 14.9278 1.47026 41
+    endloop
+  endfacet
+  facet normal -0.998796 -0.0490479 -0
+    outer loop
+      vertex 15 0 8.5
+      vertex 14.9278 1.47026 0
+      vertex 15 0 0
+    endloop
+  endfacet
+  facet normal -0.998796 -0.0490479 -0
+    outer loop
+      vertex 15 0 11.5
+      vertex 14.9278 1.47026 0
+      vertex 15 0 8.5
+    endloop
+  endfacet
+  facet normal -0.998796 -0.0490479 0
+    outer loop
+      vertex 14.9278 1.47026 0
+      vertex 15 0 11.5
+      vertex 14.9278 1.47026 41
+    endloop
+  endfacet
+  facet normal -0.998796 -0.0490479 0
+    outer loop
+      vertex 14.9278 1.47026 41
+      vertex 15 0 11.5
+      vertex 15 0 41
+    endloop
+  endfacet
+  facet normal -0.970027 -0.242996 0
+    outer loop
+      vertex 14.7118 2.92635 0
+      vertex 14.3541 4.35427 41
+      vertex 14.3541 4.35427 0
+    endloop
+  endfacet
+  facet normal -0.970027 -0.242996 0
+    outer loop
+      vertex 14.3541 4.35427 41
+      vertex 14.7118 2.92635 0
+      vertex 14.7118 2.92635 41
+    endloop
+  endfacet
+  facet normal -0.336883 0.941547 1.38616e-06
+    outer loop
+      vertex 4.63168 -14.2548 11.4994
+      vertex 4.35427 -14.3541 41
+      vertex 5.74025 -13.8582 41
+    endloop
+  endfacet
+  facet normal -0.337014 0.9415 0
+    outer loop
+      vertex 4.35427 -14.3541 41
+      vertex 4.63168 -14.2548 11.4994
+      vertex 4.35427 -14.3541 11.4999
+    endloop
+  endfacet
+  facet normal -0.33685 0.941558 0
+    outer loop
+      vertex 5.74025 -13.8582 0
+      vertex 4.63168 -14.2548 11.4994
+      vertex 5.74025 -13.8582 41
+    endloop
+  endfacet
+  facet normal -0.33685 0.941558 0
+    outer loop
+      vertex 4.63168 -14.2548 11.4994
+      vertex 5.74025 -13.8582 0
+      vertex 4.63168 -14.2548 11.4989
+    endloop
+  endfacet
+  facet normal -0.33685 0.941558 0
+    outer loop
+      vertex 4.63168 -14.2548 11.4989
+      vertex 5.74025 -13.8582 0
+      vertex 4.63168 -14.2548 11.4938
+    endloop
+  endfacet
+  facet normal -0.33685 0.941558 0
+    outer loop
+      vertex 4.63168 -14.2548 11.4938
+      vertex 5.74025 -13.8582 0
+      vertex 4.63168 -14.2548 11.3452
+    endloop
+  endfacet
+  facet normal -0.33685 0.941558 0
+    outer loop
+      vertex 4.63168 -14.2548 11.3452
+      vertex 5.74025 -13.8582 0
+      vertex 4.63168 -14.2548 10.7117
+    endloop
+  endfacet
+  facet normal -0.33685 0.941558 0
+    outer loop
+      vertex 4.63168 -14.2548 10.7117
+      vertex 5.74025 -13.8582 0
+      vertex 4.63168 -14.2548 9.28834
+    endloop
+  endfacet
+  facet normal -0.33685 0.941558 0
+    outer loop
+      vertex 4.63168 -14.2548 9.28834
+      vertex 5.74025 -13.8582 0
+      vertex 4.63168 -14.2548 8.65483
+    endloop
+  endfacet
+  facet normal -0.33685 0.941558 0
+    outer loop
+      vertex 4.63168 -14.2548 8.65483
+      vertex 5.74025 -13.8582 0
+      vertex 4.63168 -14.2548 8.50618
+    endloop
+  endfacet
+  facet normal -0.33685 0.941558 0
+    outer loop
+      vertex 4.63168 -14.2548 8.50618
+      vertex 5.74025 -13.8582 0
+      vertex 4.63168 -14.2548 8.50114
+    endloop
+  endfacet
+  facet normal -0.33685 0.941558 0
+    outer loop
+      vertex 4.63168 -14.2548 8.50114
+      vertex 5.74025 -13.8582 0
+      vertex 4.63168 -14.2548 8.50057
+    endloop
+  endfacet
+  facet normal -0.336883 0.941547 -4.81058e-06
+    outer loop
+      vertex 4.35427 -14.3541 0
+      vertex 4.63168 -14.2548 8.50057
+      vertex 5.74025 -13.8582 0
+    endloop
+  endfacet
+  facet normal -0.337014 0.9415 0
+    outer loop
+      vertex 4.63168 -14.2548 8.50057
+      vertex 4.35427 -14.3541 0
+      vertex 4.35427 -14.3541 8.50014
+    endloop
+  endfacet
+  facet normal -0.857721 -0.514116 0
+    outer loop
+      vertex 13.2288 7.07095 0
+      vertex 12.472 8.33355 41
+      vertex 12.472 8.33355 0
+    endloop
+  endfacet
+  facet normal -0.857721 -0.514116 0
+    outer loop
+      vertex 12.472 8.33355 41
+      vertex 13.2288 7.07095 0
+      vertex 13.2288 7.07095 41
+    endloop
+  endfacet
+  facet normal -0.242996 -0.970027 0
+    outer loop
+      vertex 2.92635 14.7118 0
+      vertex 4.35427 14.3541 41
+      vertex 2.92635 14.7118 41
+    endloop
+  endfacet
+  facet normal -0.242996 -0.970027 -0
+    outer loop
+      vertex 4.35427 14.3541 41
+      vertex 2.92635 14.7118 0
+      vertex 4.35427 14.3541 0
+    endloop
+  endfacet
+  facet normal 0.740898 -0.671618 0
+    outer loop
+      vertex -10.6066 10.6066 41
+      vertex -10.8412 10.3478 11.4928
+      vertex -10.6066 10.6066 11.4872
+    endloop
+  endfacet
+  facet normal 0.741109 -0.671385 -3.71674e-06
+    outer loop
+      vertex -10.6066 10.6066 41
+      vertex -10.9269 10.2532 11.4935
+      vertex -10.8412 10.3478 11.4928
+    endloop
+  endfacet
+  facet normal 0.740935 -0.671577 4.61146e-07
+    outer loop
+      vertex -11.5952 9.5159 41
+      vertex -10.9269 10.2532 11.4935
+      vertex -10.6066 10.6066 41
+    endloop
+  endfacet
+  facet normal 0.740926 -0.671587 0
+    outer loop
+      vertex -10.9269 10.2532 11.4935
+      vertex -11.5952 9.5159 41
+      vertex -11.5952 9.5159 11.4987
+    endloop
+  endfacet
+  facet normal 0.740898 -0.671618 0
+    outer loop
+      vertex -10.8412 10.3478 8.50722
+      vertex -10.6066 10.6066 0
+      vertex -10.6066 10.6066 8.51281
+    endloop
+  endfacet
+  facet normal 0.741109 -0.671385 1.28895e-05
+    outer loop
+      vertex -10.9269 10.2532 8.50655
+      vertex -10.6066 10.6066 0
+      vertex -10.8412 10.3478 8.50722
+    endloop
+  endfacet
+  facet normal 0.740926 -0.671587 0
+    outer loop
+      vertex -11.5952 9.5159 0
+      vertex -10.9269 10.2532 8.50655
+      vertex -11.5952 9.5159 8.50128
+    endloop
+  endfacet
+  facet normal 0.740935 -0.671577 -1.59957e-06
+    outer loop
+      vertex -10.9269 10.2532 8.50655
+      vertex -11.5952 9.5159 0
+      vertex -10.6066 10.6066 0
+    endloop
+  endfacet
+  facet normal -0.0490479 0.998796 0
+    outer loop
+      vertex 1.47026 -14.9278 11.4572
+      vertex 0 -15 41
+      vertex 1.47026 -14.9278 41
+    endloop
+  endfacet
+  facet normal -0.0488303 0.998807 1.0851e-05
+    outer loop
+      vertex 1.13889 -14.944 11.4354
+      vertex 0 -15 41
+      vertex 1.47026 -14.9278 11.4572
+    endloop
+  endfacet
+  facet normal -0.0492108 0.998788 -3.83963e-06
+    outer loop
+      vertex 0.714704 -14.9649 11.3956
+      vertex 0 -15 41
+      vertex 1.13889 -14.944 11.4354
+    endloop
+  endfacet
+  facet normal -0.0488773 0.998805 4.23007e-06
+    outer loop
+      vertex 0.610485 -14.97 11.3858
+      vertex 0 -15 41
+      vertex 0.714704 -14.9649 11.3956
+    endloop
+  endfacet
+  facet normal -0.0493705 0.998781 -5.96154e-06
+    outer loop
+      vertex 0.505289 -14.9752 11.3728
+      vertex 0 -15 41
+      vertex 0.610485 -14.97 11.3858
+    endloop
+  endfacet
+  facet normal -0.04893 0.998802 1.56895e-06
+    outer loop
+      vertex 0.103154 -14.9949 11.3229
+      vertex 0 -15 41
+      vertex 0.505289 -14.9752 11.3728
+    endloop
+  endfacet
+  facet normal -0.0493803 0.99878 0
+    outer loop
+      vertex 0 -15 41
+      vertex 0.103154 -14.9949 11.3229
+      vertex 0 -15 11.3067
+    endloop
+  endfacet
+  facet normal -0.0493687 0.998781 2.0368e-05
+    outer loop
+      vertex 0 -15 0
+      vertex 0.505289 -14.9752 8.62723
+      vertex 0.610485 -14.97 8.61418
+    endloop
+  endfacet
+  facet normal -0.0492099 0.998788 1.31382e-05
+    outer loop
+      vertex 0 -15 0
+      vertex 0.714704 -14.9649 8.6044
+      vertex 1.13889 -14.944 8.56459
+    endloop
+  endfacet
+  facet normal -0.0488296 0.998807 0
+    outer loop
+      vertex 1.47026 -14.9278 0
+      vertex 1.13889 -14.944 8.56459
+      vertex 1.47026 -14.9278 8.54282
+    endloop
+  endfacet
+  facet normal -0.0490479 0.998796 -8.46348e-06
+    outer loop
+      vertex 0 -15 0
+      vertex 1.13889 -14.944 8.56459
+      vertex 1.47026 -14.9278 0
+    endloop
+  endfacet
+  facet normal -0.0488783 0.998805 -1.44743e-05
+    outer loop
+      vertex 0.714704 -14.9649 8.6044
+      vertex 0 -15 0
+      vertex 0.610485 -14.97 8.61418
+    endloop
+  endfacet
+  facet normal -0.0489305 0.998802 -5.36046e-06
+    outer loop
+      vertex 0.505289 -14.9752 8.62723
+      vertex 0 -15 0
+      vertex 0.103154 -14.9949 8.67712
+    endloop
+  endfacet
+  facet normal -0.0493803 0.99878 0
+    outer loop
+      vertex 0.103154 -14.9949 8.67712
+      vertex 0 -15 0
+      vertex 0 -15 8.69333
+    endloop
+  endfacet
+  facet normal -0.427528 -0.904002 0
+    outer loop
+      vertex 6.35916 13.5655 11.4934
+      vertex 5.74025 13.8582 41
+      vertex 5.74025 13.8582 11.4977
+    endloop
+  endfacet
+  facet normal -0.427569 -0.903983 -1.06053e-06
+    outer loop
+      vertex 5.74025 13.8582 41
+      vertex 6.35916 13.5655 11.4934
+      vertex 7.07095 13.2288 41
+    endloop
+  endfacet
+  facet normal -0.428086 -0.903738 1.41998e-05
+    outer loop
+      vertex 6.45606 13.5196 11.4928
+      vertex 7.07095 13.2288 41
+      vertex 6.35916 13.5655 11.4934
+    endloop
+  endfacet
+  facet normal -0.427028 -0.904239 -1.2798e-05
+    outer loop
+      vertex 6.56363 13.4688 11.4905
+      vertex 7.07095 13.2288 41
+      vertex 6.45606 13.5196 11.4928
+    endloop
+  endfacet
+  facet normal -0.427636 -0.903951 -0
+    outer loop
+      vertex 7.07095 13.2288 41
+      vertex 6.56363 13.4688 11.4905
+      vertex 7.07095 13.2288 11.4799
+    endloop
+  endfacet
+  facet normal -0.427028 -0.904238 4.43425e-05
+    outer loop
+      vertex 7.07095 13.2288 0
+      vertex 6.56363 13.4688 8.50947
+      vertex 6.45606 13.5196 8.50722
+    endloop
+  endfacet
+  facet normal -0.427528 -0.904002 0
+    outer loop
+      vertex 5.74025 13.8582 0
+      vertex 6.35916 13.5655 8.50655
+      vertex 5.74025 13.8582 8.50227
+    endloop
+  endfacet
+  facet normal -0.428087 -0.903738 4.97343e-05
+    outer loop
+      vertex 5.74025 13.8582 0
+      vertex 6.45606 13.5196 8.50722
+      vertex 6.35916 13.5655 8.50655
+    endloop
+  endfacet
+  facet normal -0.427569 -0.903983 -3.52999e-06
+    outer loop
+      vertex 7.07095 13.2288 0
+      vertex 6.45606 13.5196 8.50722
+      vertex 5.74025 13.8582 0
+    endloop
+  endfacet
+  facet normal -0.427636 -0.903951 0
+    outer loop
+      vertex 6.56363 13.4688 8.50947
+      vertex 7.07095 13.2288 0
+      vertex 7.07095 13.2288 8.52006
+    endloop
+  endfacet
+  facet normal -0.671577 -0.740935 0
+    outer loop
+      vertex 9.5159 11.5952 11.0868
+      vertex 10.6066 10.6066 41
+      vertex 9.5159 11.5952 41
+    endloop
+  endfacet
+  facet normal -0.672029 -0.740525 3.00719e-05
+    outer loop
+      vertex 9.56813 11.5478 11.0607
+      vertex 10.6066 10.6066 41
+      vertex 9.5159 11.5952 11.0868
+    endloop
+  endfacet
+  facet normal -0.671477 -0.741025 -4.82589e-06
+    outer loop
+      vertex 9.74691 11.3858 10.9516
+      vertex 10.6066 10.6066 41
+      vertex 9.56813 11.5478 11.0607
+    endloop
+  endfacet
+  facet normal -0.672101 -0.740459 2.77077e-05
+    outer loop
+      vertex 9.79296 11.344 10.9173
+      vertex 10.6066 10.6066 41
+      vertex 9.74691 11.3858 10.9516
+    endloop
+  endfacet
+  facet normal -0.671267 -0.741215 -1.33794e-05
+    outer loop
+      vertex 9.90548 11.2421 10.8334
+      vertex 10.6066 10.6066 41
+      vertex 9.79296 11.344 10.9173
+    endloop
+  endfacet
+  facet normal -0.672006 -0.740546 1.79061e-05
+    outer loop
+      vertex 10.0008 11.1556 10.7454
+      vertex 10.6066 10.6066 41
+      vertex 9.90548 11.2421 10.8334
+    endloop
+  endfacet
+  facet normal -0.671429 -0.741069 -3.14099e-06
+    outer loop
+      vertex 10.0423 11.118 10.7071
+      vertex 10.6066 10.6066 41
+      vertex 10.0008 11.1556 10.7454
+    endloop
+  endfacet
+  facet normal -0.670276 -0.742112 -4.2235e-05
+    outer loop
+      vertex 10.0774 11.0863 10.6661
+      vertex 10.6066 10.6066 41
+      vertex 10.0423 11.118 10.7071
+    endloop
+  endfacet
+  facet normal -0.671458 -0.741043 -4.7032e-06
+    outer loop
+      vertex 10.1562 11.0149 10.574
+      vertex 10.6066 10.6066 41
+      vertex 10.0774 11.0863 10.6661
+    endloop
+  endfacet
+  facet normal -0.671965 -0.740582 8.98707e-06
+    outer loop
+      vertex 10.2458 10.9336 10.4354
+      vertex 10.6066 10.6066 41
+      vertex 10.1562 11.0149 10.574
+    endloop
+  endfacet
+  facet normal -0.670843 -0.741599 -1.51351e-05
+    outer loop
+      vertex 10.2898 10.8938 10.3385
+      vertex 10.6066 10.6066 41
+      vertex 10.2458 10.9336 10.4354
+    endloop
+  endfacet
+  facet normal -0.672302 -0.740277 1.23145e-05
+    outer loop
+      vertex 10.3105 10.875 10.2926
+      vertex 10.6066 10.6066 41
+      vertex 10.2898 10.8938 10.3385
+    endloop
+  endfacet
+  facet normal -0.671177 -0.741297 -7.4501e-06
+    outer loop
+      vertex 10.3496 10.8396 10.147
+      vertex 10.6066 10.6066 41
+      vertex 10.3105 10.875 10.2926
+    endloop
+  endfacet
+  facet normal -0.679703 -0.733487 0.000122557
+    outer loop
+      vertex 10.3538 10.8357 10.0993
+      vertex 10.6066 10.6066 41
+      vertex 10.3496 10.8396 10.147
+    endloop
+  endfacet
+  facet normal -0.672576 -0.740029 1.57459e-05
+    outer loop
+      vertex 10.3626 10.8277 10
+      vertex 10.6066 10.6066 41
+      vertex 10.3538 10.8357 10.0993
+    endloop
+  endfacet
+  facet normal -0.670333 -0.74206 0.000131351
+    outer loop
+      vertex 10.6066 10.6066 0
+      vertex 10.0774 11.0863 9.33388
+      vertex 10.0423 11.118 9.2929
+    endloop
+  endfacet
+  facet normal -0.671987 -0.740563 -5.62241e-05
+    outer loop
+      vertex 10.6066 10.6066 0
+      vertex 10.0008 11.1556 9.25462
+      vertex 9.90548 11.2421 9.16664
+    endloop
+  endfacet
+  facet normal -0.672076 -0.740482 -8.7759e-05
+    outer loop
+      vertex 10.6066 10.6066 0
+      vertex 9.79296 11.344 9.08275
+      vertex 9.74691 11.3858 9.04841
+    endloop
+  endfacet
+  facet normal -0.671577 -0.740935 0
+    outer loop
+      vertex 10.6066 10.6066 0
+      vertex 9.5159 11.5952 8.91316
+      vertex 9.5159 11.5952 0
+    endloop
+  endfacet
+  facet normal -0.672011 -0.740541 -9.68256e-05
+    outer loop
+      vertex 9.5159 11.5952 8.91316
+      vertex 10.6066 10.6066 0
+      vertex 9.56813 11.5478 8.93934
+    endloop
+  endfacet
+  facet normal -0.67148 -0.741022 1.54124e-05
+    outer loop
+      vertex 9.56813 11.5478 8.93934
+      vertex 10.6066 10.6066 0
+      vertex 9.74691 11.3858 9.04841
+    endloop
+  endfacet
+  facet normal -0.671279 -0.741205 4.23764e-05
+    outer loop
+      vertex 9.79296 11.344 9.08275
+      vertex 10.6066 10.6066 0
+      vertex 9.90548 11.2421 9.16664
+    endloop
+  endfacet
+  facet normal -0.671432 -0.741066 9.86252e-06
+    outer loop
+      vertex 10.0008 11.1556 9.25462
+      vertex 10.6066 10.6066 0
+      vertex 10.0423 11.118 9.2929
+    endloop
+  endfacet
+  facet normal -0.671464 -0.741037 1.46272e-05
+    outer loop
+      vertex 10.0774 11.0863 9.33388
+      vertex 10.6066 10.6066 0
+      vertex 10.1562 11.0149 9.42597
+    endloop
+  endfacet
+  facet normal -0.67195 -0.740597 -2.76318e-05
+    outer loop
+      vertex 10.1562 11.0149 9.42597
+      vertex 10.6066 10.6066 0
+      vertex 10.2458 10.9336 9.56457
+    endloop
+  endfacet
+  facet normal -0.670881 -0.741565 4.58126e-05
+    outer loop
+      vertex 10.2458 10.9336 9.56457
+      vertex 10.6066 10.6066 0
+      vertex 10.2898 10.8938 9.66153
+    endloop
+  endfacet
+  facet normal -0.672271 -0.740305 -3.72719e-05
+    outer loop
+      vertex 10.2898 10.8938 9.66153
+      vertex 10.6066 10.6066 0
+      vertex 10.3105 10.875 9.70736
+    endloop
+  endfacet
+  facet normal -0.671206 -0.741271 2.19221e-05
+    outer loop
+      vertex 10.3105 10.875 9.70736
+      vertex 10.6066 10.6066 0
+      vertex 10.3496 10.8396 9.85297
+    endloop
+  endfacet
+  facet normal -0.678467 -0.734631 -0.000324453
+    outer loop
+      vertex 10.3496 10.8396 9.85297
+      vertex 10.6066 10.6066 0
+      vertex 10.3538 10.8357 9.90075
+    endloop
+  endfacet
+  facet normal -0.671478 -0.741025 0
+    outer loop
+      vertex 10.3626 10.8277 10
+      vertex 10.6066 10.6066 0
+      vertex 10.6066 10.6066 41
+    endloop
+  endfacet
+  facet normal -0.672415 -0.740174 -4.16862e-05
+    outer loop
+      vertex 10.3538 10.8357 9.90075
+      vertex 10.6066 10.6066 0
+      vertex 10.3626 10.8277 10
+    endloop
+  endfacet
+  facet normal 0.59566 0.803237 -0
+    outer loop
+      vertex -8.33355 -12.472 0
+      vertex -9.5159 -11.5952 41
+      vertex -8.33355 -12.472 41
+    endloop
+  endfacet
+  facet normal 0.59566 0.803237 0
+    outer loop
+      vertex -9.5159 -11.5952 41
+      vertex -8.33355 -12.472 0
+      vertex -9.5159 -11.5952 0
+    endloop
+  endfacet
+  facet normal -0.242996 0.970027 0
+    outer loop
+      vertex 4.35427 -14.3541 11.4999
+      vertex 2.92635 -14.7118 41
+      vertex 4.35427 -14.3541 41
+    endloop
+  endfacet
+  facet normal -0.242996 0.970027 0
+    outer loop
+      vertex 2.92635 -14.7118 41
+      vertex 4.35427 -14.3541 11.4999
+      vertex 2.92635 -14.7118 11.4949
+    endloop
+  endfacet
+  facet normal -0.242996 0.970027 0
+    outer loop
+      vertex 4.35427 -14.3541 0
+      vertex 2.92635 -14.7118 8.50511
+      vertex 4.35427 -14.3541 8.50014
+    endloop
+  endfacet
+  facet normal -0.242996 0.970027 0
+    outer loop
+      vertex 2.92635 -14.7118 8.50511
+      vertex 4.35427 -14.3541 0
+      vertex 2.92635 -14.7118 0
+    endloop
+  endfacet
+  facet normal -0.989175 0.146739 0
+    outer loop
+      vertex 14.853 -1.97449 11.4928
+      vertex 14.9278 -1.47026 41
+      vertex 14.9278 -1.47026 11.4965
+    endloop
+  endfacet
+  facet normal -0.989176 0.146735 0
+    outer loop
+      vertex 14.7118 -2.92635 41
+      vertex 14.853 -1.97449 11.4928
+      vertex 14.7118 -2.92635 11.4718
+    endloop
+  endfacet
+  facet normal -0.989176 0.146737 4.26381e-08
+    outer loop
+      vertex 14.853 -1.97449 11.4928
+      vertex 14.7118 -2.92635 41
+      vertex 14.9278 -1.47026 41
+    endloop
+  endfacet
+  facet normal -0.989175 0.146739 0
+    outer loop
+      vertex 14.9278 -1.47026 0
+      vertex 14.853 -1.97449 8.50722
+      vertex 14.9278 -1.47026 8.50355
+    endloop
+  endfacet
+  facet normal -0.989176 0.146737 -1.4789e-07
+    outer loop
+      vertex 14.7118 -2.92635 0
+      vertex 14.853 -1.97449 8.50722
+      vertex 14.9278 -1.47026 0
+    endloop
+  endfacet
+  facet normal -0.989176 0.146735 0
+    outer loop
+      vertex 14.853 -1.97449 8.50722
+      vertex 14.7118 -2.92635 0
+      vertex 14.7118 -2.92635 8.52817
+    endloop
+  endfacet
+  facet normal 0.242996 0.970027 -0
+    outer loop
+      vertex -2.92635 -14.7118 0
+      vertex -4.35427 -14.3541 41
+      vertex -2.92635 -14.7118 41
+    endloop
+  endfacet
+  facet normal 0.242996 0.970027 0
+    outer loop
+      vertex -4.35427 -14.3541 41
+      vertex -2.92635 -14.7118 0
+      vertex -4.35427 -14.3541 0
+    endloop
+  endfacet
+  facet normal 0.59566 -0.803237 0
+    outer loop
+      vertex -9.5159 11.5952 11.4173
+      vertex -8.33355 12.472 41
+      vertex -9.5159 11.5952 41
+    endloop
+  endfacet
+  facet normal 0.595595 -0.803285 3.97345e-06
+    outer loop
+      vertex -9.35392 11.7153 11.3957
+      vertex -8.33355 12.472 41
+      vertex -9.5159 11.5952 11.4173
+    endloop
+  endfacet
+  facet normal 0.59554 -0.803326 6.93831e-06
+    outer loop
+      vertex -9.28 11.7701 11.3858
+      vertex -8.33355 12.472 41
+      vertex -9.35392 11.7153 11.3957
+    endloop
+  endfacet
+  facet normal 0.595951 -0.803021 -1.34404e-05
+    outer loop
+      vertex -9.20589 11.8251 11.3727
+      vertex -8.33355 12.472 41
+      vertex -9.28 11.7701 11.3858
+    endloop
+  endfacet
+  facet normal 0.595575 -0.8033 3.75178e-06
+    outer loop
+      vertex -8.92332 12.0346 11.3229
+      vertex -8.33355 12.472 41
+      vertex -9.20589 11.8251 11.3727
+    endloop
+  endfacet
+  facet normal 0.59572 -0.803192 -7.29628e-07
+    outer loop
+      vertex -8.66607 12.2254 11.2654
+      vertex -8.33355 12.472 41
+      vertex -8.92332 12.0346 11.3229
+    endloop
+  endfacet
+  facet normal 0.595701 -0.803207 -3.92373e-07
+    outer loop
+      vertex -8.5849 12.2856 11.2472
+      vertex -8.33355 12.472 41
+      vertex -8.66607 12.2254 11.2654
+    endloop
+  endfacet
+  facet normal 0.595671 -0.803229 0
+    outer loop
+      vertex -8.33355 12.472 41
+      vertex -8.5849 12.2856 11.2472
+      vertex -8.33355 12.472 11.1777
+    endloop
+  endfacet
+  facet normal 0.59572 -0.803192 2.469e-06
+    outer loop
+      vertex -8.33355 12.472 0
+      vertex -8.66607 12.2254 8.73464
+      vertex -8.92332 12.0346 8.67712
+    endloop
+  endfacet
+  facet normal 0.59566 -0.803237 0
+    outer loop
+      vertex -8.33355 12.472 0
+      vertex -9.5159 11.5952 8.58269
+      vertex -9.5159 11.5952 0
+    endloop
+  endfacet
+  facet normal 0.595596 -0.803284 -1.352e-05
+    outer loop
+      vertex -9.5159 11.5952 8.58269
+      vertex -8.33355 12.472 0
+      vertex -9.35392 11.7153 8.60431
+    endloop
+  endfacet
+  facet normal 0.595541 -0.803325 -2.36086e-05
+    outer loop
+      vertex -9.35392 11.7153 8.60431
+      vertex -8.33355 12.472 0
+      vertex -9.28 11.7701 8.61418
+    endloop
+  endfacet
+  facet normal 0.595948 -0.803023 4.55832e-05
+    outer loop
+      vertex -9.28 11.7701 8.61418
+      vertex -8.33355 12.472 0
+      vertex -9.20589 11.8251 8.62726
+    endloop
+  endfacet
+  facet normal 0.595576 -0.803299 -1.2724e-05
+    outer loop
+      vertex -9.20589 11.8251 8.62726
+      vertex -8.33355 12.472 0
+      vertex -8.92332 12.0346 8.67712
+    endloop
+  endfacet
+  facet normal 0.595701 -0.803207 1.32776e-06
+    outer loop
+      vertex -8.66607 12.2254 8.73464
+      vertex -8.33355 12.472 0
+      vertex -8.5849 12.2856 8.7528
+    endloop
+  endfacet
+  facet normal 0.595671 -0.803229 0
+    outer loop
+      vertex -8.5849 12.2856 8.7528
+      vertex -8.33355 12.472 0
+      vertex -8.33355 12.472 8.82234
+    endloop
+  endfacet
+  facet normal 0.998796 0.0490479 0
+    outer loop
+      vertex -14.9278 -1.47026 41
+      vertex -15 0 0
+      vertex -15 0 41
+    endloop
+  endfacet
+  facet normal 0.998796 0.0490479 0
+    outer loop
+      vertex -15 0 0
+      vertex -14.9278 -1.47026 41
+      vertex -14.9278 -1.47026 0
+    endloop
+  endfacet
+  facet normal 0.969954 0.243287 0
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.676 -3.06908 10.7071
+      vertex -14.7118 -2.92635 10.5909
+    endloop
+  endfacet
+  facet normal 0.970072 0.242819 2.34215e-06
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.6416 -3.20651 10.7954
+      vertex -14.676 -3.06908 10.7071
+    endloop
+  endfacet
+  facet normal 0.970017 0.243038 1.86996e-07
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.6268 -3.26558 10.8334
+      vertex -14.6416 -3.20651 10.7954
+    endloop
+  endfacet
+  facet normal 0.970032 0.242978 8.98972e-07
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.61 -3.33265 10.8682
+      vertex -14.6268 -3.26558 10.8334
+    endloop
+  endfacet
+  facet normal 0.970075 0.242807 3.35172e-06
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.5698 -3.49326 10.9516
+      vertex -14.61 -3.33265 10.8682
+    endloop
+  endfacet
+  facet normal 0.970027 0.242998 -4.68253e-07
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.5055 -3.74994 11.0607
+      vertex -14.5698 -3.49326 10.9516
+    endloop
+  endfacet
+  facet normal 0.97009 0.242746 6.8895e-06
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.4863 -3.82667 11.0874
+      vertex -14.5055 -3.74994 11.0607
+    endloop
+  endfacet
+  facet normal 0.969941 0.243338 -1.20588e-05
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.4345 -4.03314 11.1595
+      vertex -14.4863 -3.82667 11.0874
+    endloop
+  endfacet
+  facet normal 0.970097 0.242717 1.24222e-05
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.3769 -4.26336 11.2253
+      vertex -14.4345 -4.03314 11.1595
+    endloop
+  endfacet
+  facet normal 0.969825 0.243803 -3.93864e-05
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.3576 -4.34013 11.2472
+      vertex -14.3769 -4.26336 11.2253
+    endloop
+  endfacet
+  facet normal 0.970027 0.242996 -0
+    outer loop
+      vertex -14.3541 -4.35427 11.2505
+      vertex -14.7118 -2.92635 41
+      vertex -14.3541 -4.35427 41
+    endloop
+  endfacet
+  facet normal 0.970698 0.240304 0.000137281
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.3541 -4.35427 11.2505
+      vertex -14.3576 -4.34013 11.2472
+    endloop
+  endfacet
+  facet normal 0.969954 0.243287 0
+    outer loop
+      vertex -14.676 -3.06908 9.2929
+      vertex -14.7118 -2.92635 0
+      vertex -14.7118 -2.92635 9.40913
+    endloop
+  endfacet
+  facet normal 0.970071 0.242823 -7.5832e-06
+    outer loop
+      vertex -14.6416 -3.20651 9.2046
+      vertex -14.7118 -2.92635 0
+      vertex -14.676 -3.06908 9.2929
+    endloop
+  endfacet
+  facet normal 0.970017 0.243038 -6.0544e-07
+    outer loop
+      vertex -14.6268 -3.26558 9.16664
+      vertex -14.7118 -2.92635 0
+      vertex -14.6416 -3.20651 9.2046
+    endloop
+  endfacet
+  facet normal 0.970031 0.242979 -2.91961e-06
+    outer loop
+      vertex -14.61 -3.33265 9.13182
+      vertex -14.7118 -2.92635 0
+      vertex -14.6268 -3.26558 9.16664
+    endloop
+  endfacet
+  facet normal 0.970074 0.242811 -1.08854e-05
+    outer loop
+      vertex -14.5698 -3.49326 9.04841
+      vertex -14.7118 -2.92635 0
+      vertex -14.61 -3.33265 9.13182
+    endloop
+  endfacet
+  facet normal 0.970027 0.242997 1.52682e-06
+    outer loop
+      vertex -14.5055 -3.74994 8.93934
+      vertex -14.7118 -2.92635 0
+      vertex -14.5698 -3.49326 9.04841
+    endloop
+  endfacet
+  facet normal 0.970089 0.242751 -2.25689e-05
+    outer loop
+      vertex -14.4863 -3.82667 8.91255
+      vertex -14.7118 -2.92635 0
+      vertex -14.5055 -3.74994 8.93934
+    endloop
+  endfacet
+  facet normal 0.969944 0.243329 3.95047e-05
+    outer loop
+      vertex -14.4345 -4.03314 8.84048
+      vertex -14.7118 -2.92635 0
+      vertex -14.4863 -3.82667 8.91255
+    endloop
+  endfacet
+  facet normal 0.970095 0.242725 -4.09117e-05
+    outer loop
+      vertex -14.3769 -4.26336 8.77472
+      vertex -14.7118 -2.92635 0
+      vertex -14.4345 -4.03314 8.84048
+    endloop
+  endfacet
+  facet normal 0.969831 0.243779 0.000129717
+    outer loop
+      vertex -14.3576 -4.34013 8.7528
+      vertex -14.7118 -2.92635 0
+      vertex -14.3769 -4.26336 8.77472
+    endloop
+  endfacet
+  facet normal 0.970681 0.240373 -0.000454827
+    outer loop
+      vertex -14.3541 -4.35427 8.74953
+      vertex -14.7118 -2.92635 0
+      vertex -14.3576 -4.34013 8.7528
+    endloop
+  endfacet
+  facet normal 0.970027 0.242996 0
+    outer loop
+      vertex -14.7118 -2.92635 0
+      vertex -14.3541 -4.35427 8.74953
+      vertex -14.3541 -4.35427 0
+    endloop
+  endfacet
+  facet normal -0.97024 0.242147 0
+    outer loop
+      vertex 14.7074 -2.94398 11.4712
+      vertex 14.7118 -2.92635 41
+      vertex 14.7118 -2.92635 11.4718
+    endloop
+  endfacet
+  facet normal -0.970028 0.242992 -7.34602e-07
+    outer loop
+      vertex 14.3541 -4.35427 41
+      vertex 14.7074 -2.94398 11.4712
+      vertex 14.5646 -3.51404 11.4354
+    endloop
+  endfacet
+  facet normal -0.97003 0.242985 -9.39092e-07
+    outer loop
+      vertex 14.3541 -4.35427 41
+      vertex 14.5646 -3.51404 11.4354
+      vertex 14.426 -4.06735 11.3858
+    endloop
+  endfacet
+  facet normal -0.970007 0.243077 0
+    outer loop
+      vertex 14.3541 -4.35427 41
+      vertex 14.426 -4.06735 11.3858
+      vertex 14.3541 -4.35427 11.3518
+    endloop
+  endfacet
+  facet normal -0.970027 0.242996 -5.38401e-07
+    outer loop
+      vertex 14.7074 -2.94398 11.4712
+      vertex 14.3541 -4.35427 41
+      vertex 14.7118 -2.92635 41
+    endloop
+  endfacet
+  facet normal -0.97024 0.242147 0
+    outer loop
+      vertex 14.7118 -2.92635 0
+      vertex 14.7074 -2.94398 8.52882
+      vertex 14.7118 -2.92635 8.52817
+    endloop
+  endfacet
+  facet normal -0.970028 0.242992 1.85573e-06
+    outer loop
+      vertex 14.7118 -2.92635 0
+      vertex 14.5646 -3.51404 8.56459
+      vertex 14.7074 -2.94398 8.52882
+    endloop
+  endfacet
+  facet normal -0.970027 0.242996 2.13279e-06
+    outer loop
+      vertex 14.3541 -4.35427 0
+      vertex 14.5646 -3.51404 8.56459
+      vertex 14.7118 -2.92635 0
+    endloop
+  endfacet
+  facet normal -0.97003 0.242985 3.22164e-06
+    outer loop
+      vertex 14.5646 -3.51404 8.56459
+      vertex 14.3541 -4.35427 0
+      vertex 14.426 -4.06735 8.61418
+    endloop
+  endfacet
+  facet normal -0.970007 0.243077 0
+    outer loop
+      vertex 14.426 -4.06735 8.61418
+      vertex 14.3541 -4.35427 0
+      vertex 14.3541 -4.35427 8.64817
+    endloop
+  endfacet
+  facet normal 0.514116 -0.857721 0
+    outer loop
+      vertex -8.33355 12.472 11.1777
+      vertex -7.07095 13.2288 41
+      vertex -8.33355 12.472 41
+    endloop
+  endfacet
+  facet normal 0.514142 -0.857705 -1.49308e-06
+    outer loop
+      vertex -8.28 12.5041 11.1595
+      vertex -7.07095 13.2288 41
+      vertex -8.33355 12.472 11.1777
+    endloop
+  endfacet
+  facet normal 0.514325 -0.857595 -1.15944e-05
+    outer loop
+      vertex -8.10609 12.6084 11.0875
+      vertex -7.07095 13.2288 41
+      vertex -8.28 12.5041 11.1595
+    endloop
+  endfacet
+  facet normal 0.514049 -0.857761 1.40161e-06
+    outer loop
+      vertex -8.04118 12.6473 11.0607
+      vertex -7.07095 13.2288 41
+      vertex -8.10609 12.6084 11.0875
+    endloop
+  endfacet
+  facet normal 0.513789 -0.857917 1.28704e-05
+    outer loop
+      vertex -7.9809 12.6834 11.0303
+      vertex -7.07095 13.2288 41
+      vertex -8.04118 12.6473 11.0607
+    endloop
+  endfacet
+  facet normal 0.514084 -0.85774 6.85545e-07
+    outer loop
+      vertex -7.82473 12.777 10.9516
+      vertex -7.07095 13.2288 41
+      vertex -7.9809 12.6834 11.0303
+    endloop
+  endfacet
+  facet normal 0.514166 -0.857691 -2.11963e-06
+    outer loop
+      vertex -7.63273 12.8921 10.8334
+      vertex -7.07095 13.2288 41
+      vertex -7.82473 12.777 10.9516
+    endloop
+  endfacet
+  facet normal 0.51404 -0.857766 1.08897e-06
+    outer loop
+      vertex -7.46703 12.9914 10.7071
+      vertex -7.07095 13.2288 41
+      vertex -7.63273 12.8921 10.8334
+    endloop
+  endfacet
+  facet normal 0.514102 -0.857729 -2.31304e-08
+    outer loop
+      vertex -7.32922 13.074 10.574
+      vertex -7.07095 13.2288 41
+      vertex -7.46703 12.9914 10.7071
+    endloop
+  endfacet
+  facet normal 0.514216 -0.857661 -1.3337e-06
+    outer loop
+      vertex -7.22064 13.1391 10.4354
+      vertex -7.07095 13.2288 41
+      vertex -7.32922 13.074 10.574
+    endloop
+  endfacet
+  facet normal 0.513805 -0.857907 1.40185e-06
+    outer loop
+      vertex -7.14233 13.186 10.2926
+      vertex -7.07095 13.2288 41
+      vertex -7.22064 13.1391 10.4354
+    endloop
+  endfacet
+  facet normal 0.514759 -0.857335 -1.61287e-06
+    outer loop
+      vertex -7.09503 13.2144 10.147
+      vertex -7.07095 13.2288 41
+      vertex -7.14233 13.186 10.2926
+    endloop
+  endfacet
+  facet normal 0.515041 -0.857166 -1.91208e-06
+    outer loop
+      vertex -7.07922 13.2239 10
+      vertex -7.07095 13.2288 41
+      vertex -7.09503 13.2144 10.147
+    endloop
+  endfacet
+  facet normal 0.514116 -0.857721 0
+    outer loop
+      vertex -7.07095 13.2288 0
+      vertex -8.33355 12.472 8.82234
+      vertex -8.33355 12.472 0
+    endloop
+  endfacet
+  facet normal 0.514141 -0.857706 4.88297e-06
+    outer loop
+      vertex -8.33355 12.472 8.82234
+      vertex -7.07095 13.2288 0
+      vertex -8.28 12.5041 8.84048
+    endloop
+  endfacet
+  facet normal 0.514317 -0.8576 3.76608e-05
+    outer loop
+      vertex -8.28 12.5041 8.84048
+      vertex -7.07095 13.2288 0
+      vertex -8.10609 12.6084 8.91247
+    endloop
+  endfacet
+  facet normal 0.51405 -0.85776 -4.55248e-06
+    outer loop
+      vertex -8.10609 12.6084 8.91247
+      vertex -7.07095 13.2288 0
+      vertex -8.04118 12.6473 8.93934
+    endloop
+  endfacet
+  facet normal 0.513799 -0.85791 -4.1537e-05
+    outer loop
+      vertex -8.04118 12.6473 8.93934
+      vertex -7.07095 13.2288 0
+      vertex -7.9809 12.6834 8.96972
+    endloop
+  endfacet
+  facet normal 0.514085 -0.857739 -2.2125e-06
+    outer loop
+      vertex -7.9809 12.6834 8.96972
+      vertex -7.07095 13.2288 0
+      vertex -7.82473 12.777 9.04841
+    endloop
+  endfacet
+  facet normal 0.514164 -0.857692 6.79893e-06
+    outer loop
+      vertex -7.82473 12.777 9.04841
+      vertex -7.07095 13.2288 0
+      vertex -7.63273 12.8921 9.16664
+    endloop
+  endfacet
+  facet normal 0.514041 -0.857766 -3.47241e-06
+    outer loop
+      vertex -7.63273 12.8921 9.16664
+      vertex -7.07095 13.2288 0
+      vertex -7.46703 12.9914 9.2929
+    endloop
+  endfacet
+  facet normal 0.514102 -0.857729 7.33343e-08
+    outer loop
+      vertex -7.46703 12.9914 9.2929
+      vertex -7.07095 13.2288 0
+      vertex -7.32922 13.074 9.42597
+    endloop
+  endfacet
+  facet normal 0.514213 -0.857663 4.20464e-06
+    outer loop
+      vertex -7.32922 13.074 9.42597
+      vertex -7.07095 13.2288 0
+      vertex -7.22064 13.1391 9.56457
+    endloop
+  endfacet
+  facet normal 0.513809 -0.857905 -4.39434e-06
+    outer loop
+      vertex -7.22064 13.1391 9.56457
+      vertex -7.07095 13.2288 0
+      vertex -7.14233 13.186 9.70736
+    endloop
+  endfacet
+  facet normal 0.509745 -0.860325 0
+    outer loop
+      vertex -7.07922 13.2239 10
+      vertex -7.07095 13.2288 0
+      vertex -7.07095 13.2288 41
+    endloop
+  endfacet
+  facet normal 0.515013 -0.857182 5.89691e-06
+    outer loop
+      vertex -7.09503 13.2144 9.85297
+      vertex -7.07095 13.2288 0
+      vertex -7.07922 13.2239 10
+    endloop
+  endfacet
+  facet normal 0.514751 -0.85734 5.02479e-06
+    outer loop
+      vertex -7.14233 13.186 9.70736
+      vertex -7.07095 13.2288 0
+      vertex -7.09503 13.2144 9.85297
+    endloop
+  endfacet
+  facet normal -0.59566 -0.803237 0
+    outer loop
+      vertex 8.33355 12.472 11.3897
+      vertex 9.5159 11.5952 41
+      vertex 8.33355 12.472 41
+    endloop
+  endfacet
+  facet normal -0.595439 -0.8034 -1.36393e-05
+    outer loop
+      vertex 8.36094 12.4517 11.3858
+      vertex 9.5159 11.5952 41
+      vertex 8.33355 12.472 11.3897
+    endloop
+  endfacet
+  facet normal -0.595685 -0.803218 1.21618e-06
+    outer loop
+      vertex 8.69669 12.2027 11.3229
+      vertex 9.5159 11.5952 41
+      vertex 8.36094 12.4517 11.3858
+    endloop
+  endfacet
+  facet normal -0.59559 -0.803289 -2.8593e-06
+    outer loop
+      vertex 9.01526 11.9665 11.2472
+      vertex 9.5159 11.5952 41
+      vertex 8.69669 12.2027 11.3229
+    endloop
+  endfacet
+  facet normal -0.595787 -0.803142 2.28848e-06
+    outer loop
+      vertex 9.31358 11.7452 11.1595
+      vertex 9.5159 11.5952 41
+      vertex 9.01526 11.9665 11.2472
+    endloop
+  endfacet
+  facet normal -0.595569 -0.803304 -0
+    outer loop
+      vertex 9.5159 11.5952 41
+      vertex 9.31358 11.7452 11.1595
+      vertex 9.5159 11.5952 11.0868
+    endloop
+  endfacet
+  facet normal -0.595438 -0.803401 0
+    outer loop
+      vertex 8.33355 12.472 0
+      vertex 8.36094 12.4517 8.61418
+      vertex 8.33355 12.472 8.6103
+    endloop
+  endfacet
+  facet normal -0.59566 -0.803237 1.09204e-06
+    outer loop
+      vertex 9.5159 11.5952 0
+      vertex 8.36094 12.4517 8.61418
+      vertex 8.33355 12.472 0
+    endloop
+  endfacet
+  facet normal -0.595685 -0.803218 -4.10833e-06
+    outer loop
+      vertex 8.36094 12.4517 8.61418
+      vertex 9.5159 11.5952 0
+      vertex 8.69669 12.2027 8.67712
+    endloop
+  endfacet
+  facet normal -0.595591 -0.803288 9.62746e-06
+    outer loop
+      vertex 8.69669 12.2027 8.67712
+      vertex 9.5159 11.5952 0
+      vertex 9.01526 11.9665 8.7528
+    endloop
+  endfacet
+  facet normal -0.595786 -0.803143 -7.6883e-06
+    outer loop
+      vertex 9.01526 11.9665 8.7528
+      vertex 9.5159 11.5952 0
+      vertex 9.31358 11.7452 8.84048
+    endloop
+  endfacet
+  facet normal -0.595569 -0.803304 0
+    outer loop
+      vertex 9.31358 11.7452 8.84048
+      vertex 9.5159 11.5952 0
+      vertex 9.5159 11.5952 8.91316
+    endloop
+  endfacet
+  facet normal 0.903955 0.427628 0
+    outer loop
+      vertex -13.8582 -5.74025 41
+      vertex -13.5773 -6.33404 11.4712
+      vertex -13.8582 -5.74025 11.4407
+    endloop
+  endfacet
+  facet normal 0.904039 0.42745 4.36583e-06
+    outer loop
+      vertex -13.8582 -5.74025 41
+      vertex -13.2417 -7.04382 11.4928
+      vertex -13.5773 -6.33404 11.4712
+    endloop
+  endfacet
+  facet normal 0.903983 0.427569 -2.08142e-06
+    outer loop
+      vertex -13.2288 -7.07095 41
+      vertex -13.2417 -7.04382 11.4928
+      vertex -13.8582 -5.74025 41
+    endloop
+  endfacet
+  facet normal 0.903106 0.429417 0
+    outer loop
+      vertex -13.2417 -7.04382 11.4928
+      vertex -13.2288 -7.07095 41
+      vertex -13.2288 -7.07095 11.4931
+    endloop
+  endfacet
+  facet normal 0.903955 0.427628 0
+    outer loop
+      vertex -13.5773 -6.33404 8.52882
+      vertex -13.8582 -5.74025 0
+      vertex -13.8582 -5.74025 8.55933
+    endloop
+  endfacet
+  facet normal 0.904039 0.42745 7.6864e-06
+    outer loop
+      vertex -13.2288 -7.07095 0
+      vertex -13.5773 -6.33404 8.52882
+      vertex -13.2417 -7.04382 8.50722
+    endloop
+  endfacet
+  facet normal 0.903106 0.429417 -0
+    outer loop
+      vertex -13.2288 -7.07095 0
+      vertex -13.2417 -7.04382 8.50722
+      vertex -13.2288 -7.07095 8.50695
+    endloop
+  endfacet
+  facet normal 0.903983 0.427569 -4.95461e-06
+    outer loop
+      vertex -13.5773 -6.33404 8.52882
+      vertex -13.2288 -7.07095 0
+      vertex -13.8582 -5.74025 0
+    endloop
+  endfacet
+  facet normal -0.941543 0.336894 5.96859e-07
+    outer loop
+      vertex 13.8582 -5.74025 41
+      vertex 14.3541 -4.35427 11.3518
+      vertex 14.2929 -4.52531 11.3229
+    endloop
+  endfacet
+  facet normal -0.941513 0.336978 4.4548e-06
+    outer loop
+      vertex 13.8582 -5.74025 41
+      vertex 14.2929 -4.52531 11.3229
+      vertex 14.1666 -4.87819 11.2472
+    endloop
+  endfacet
+  facet normal -0.941574 0.336806 -1.15987e-06
+    outer loop
+      vertex 13.8582 -5.74025 41
+      vertex 14.1666 -4.87819 11.2472
+      vertex 14.0484 -5.20863 11.1595
+    endloop
+  endfacet
+  facet normal -0.941515 0.336972 2.16896e-06
+    outer loop
+      vertex 13.8582 -5.74025 41
+      vertex 14.0484 -5.20863 11.1595
+      vertex 13.9393 -5.51346 11.0607
+    endloop
+  endfacet
+  facet normal -0.941606 0.336718 0
+    outer loop
+      vertex 13.8582 -5.74025 41
+      vertex 13.9393 -5.51346 11.0607
+      vertex 13.8582 -5.74025 10.9711
+    endloop
+  endfacet
+  facet normal -0.941547 0.336883 0
+    outer loop
+      vertex 14.3541 -4.35427 11.3518
+      vertex 13.8582 -5.74025 41
+      vertex 14.3541 -4.35427 41
+    endloop
+  endfacet
+  facet normal -0.941547 0.336883 0
+    outer loop
+      vertex 13.8582 -5.74025 0
+      vertex 14.3541 -4.35427 8.64817
+      vertex 14.3541 -4.35427 0
+    endloop
+  endfacet
+  facet normal -0.941543 0.336894 -2.00789e-06
+    outer loop
+      vertex 14.3541 -4.35427 8.64817
+      vertex 13.8582 -5.74025 0
+      vertex 14.2929 -4.52531 8.67712
+    endloop
+  endfacet
+  facet normal -0.941513 0.336976 -1.49219e-05
+    outer loop
+      vertex 14.2929 -4.52531 8.67712
+      vertex 13.8582 -5.74025 0
+      vertex 14.1666 -4.87819 8.7528
+    endloop
+  endfacet
+  facet normal -0.941574 0.336807 3.8718e-06
+    outer loop
+      vertex 14.1666 -4.87819 8.7528
+      vertex 13.8582 -5.74025 0
+      vertex 14.0484 -5.20863 8.84048
+    endloop
+  endfacet
+  facet normal -0.941515 0.33697 -7.2226e-06
+    outer loop
+      vertex 14.0484 -5.20863 8.84048
+      vertex 13.8582 -5.74025 0
+      vertex 13.9393 -5.51346 8.93934
+    endloop
+  endfacet
+  facet normal -0.941606 0.336718 0
+    outer loop
+      vertex 13.9393 -5.51346 8.93934
+      vertex 13.8582 -5.74025 0
+      vertex 13.8582 -5.74025 9.02887
+    endloop
+  endfacet
+  facet normal -0.146737 -0.989176 0
+    outer loop
+      vertex 1.47026 14.9278 0
+      vertex 2.92635 14.7118 41
+      vertex 1.47026 14.9278 41
+    endloop
+  endfacet
+  facet normal -0.146737 -0.989176 -0
+    outer loop
+      vertex 2.92635 14.7118 41
+      vertex 1.47026 14.9278 0
+      vertex 2.92635 14.7118 0
+    endloop
+  endfacet
+  facet normal 0.427569 -0.903983 0
+    outer loop
+      vertex -7.07095 13.2288 0
+      vertex -5.74025 13.8582 41
+      vertex -7.07095 13.2288 41
+    endloop
+  endfacet
+  facet normal 0.427569 -0.903983 0
+    outer loop
+      vertex -5.74025 13.8582 41
+      vertex -7.07095 13.2288 0
+      vertex -5.74025 13.8582 0
+    endloop
+  endfacet
+  facet normal -0.514116 -0.857721 0
+    outer loop
+      vertex 7.07095 13.2288 11.4799
+      vertex 8.33355 12.472 41
+      vertex 7.07095 13.2288 41
+    endloop
+  endfacet
+  facet normal -0.513949 -0.857821 -9.6962e-06
+    outer loop
+      vertex 7.29711 13.0933 11.4712
+      vertex 8.33355 12.472 41
+      vertex 7.07095 13.2288 11.4799
+    endloop
+  endfacet
+  facet normal -0.514115 -0.857721 -1.79116e-06
+    outer loop
+      vertex 7.7509 12.8213 11.4415
+      vertex 8.33355 12.472 41
+      vertex 7.29711 13.0933 11.4712
+    endloop
+  endfacet
+  facet normal -0.514117 -0.85772 -1.73491e-06
+    outer loop
+      vertex 7.84416 12.7654 11.4354
+      vertex 8.33355 12.472 41
+      vertex 7.7509 12.8213 11.4415
+    endloop
+  endfacet
+  facet normal -0.514194 -0.857674 -0
+    outer loop
+      vertex 8.33355 12.472 41
+      vertex 7.84416 12.7654 11.4354
+      vertex 8.33355 12.472 11.3897
+    endloop
+  endfacet
+  facet normal -0.513949 -0.857821 0
+    outer loop
+      vertex 7.07095 13.2288 0
+      vertex 7.29711 13.0933 8.52882
+      vertex 7.07095 13.2288 8.52006
+    endloop
+  endfacet
+  facet normal -0.514116 -0.857721 6.02066e-06
+    outer loop
+      vertex 8.33355 12.472 0
+      vertex 7.29711 13.0933 8.52882
+      vertex 7.07095 13.2288 0
+    endloop
+  endfacet
+  facet normal -0.514115 -0.857721 6.16668e-06
+    outer loop
+      vertex 7.29711 13.0933 8.52882
+      vertex 8.33355 12.472 0
+      vertex 7.7509 12.8213 8.55849
+    endloop
+  endfacet
+  facet normal -0.514117 -0.85772 5.97298e-06
+    outer loop
+      vertex 7.7509 12.8213 8.55849
+      vertex 8.33355 12.472 0
+      vertex 7.84416 12.7654 8.56459
+    endloop
+  endfacet
+  facet normal -0.514194 -0.857674 0
+    outer loop
+      vertex 7.84416 12.7654 8.56459
+      vertex 8.33355 12.472 0
+      vertex 8.33355 12.472 8.6103
+    endloop
+  endfacet
+  facet normal -0.427569 0.903983 0
+    outer loop
+      vertex 7.07095 -13.2288 0
+      vertex 5.74025 -13.8582 41
+      vertex 7.07095 -13.2288 41
+    endloop
+  endfacet
+  facet normal -0.427569 0.903983 0
+    outer loop
+      vertex 5.74025 -13.8582 41
+      vertex 7.07095 -13.2288 0
+      vertex 5.74025 -13.8582 0
+    endloop
+  endfacet
+  facet normal 0.94155 0.336874 0
+    outer loop
+      vertex -14.3541 -4.35427 41
+      vertex -14.2092 -4.75926 11.3229
+      vertex -14.3541 -4.35427 11.2505
+    endloop
+  endfacet
+  facet normal 0.941548 0.336878 -6.11204e-08
+    outer loop
+      vertex -14.3541 -4.35427 41
+      vertex -14.0496 -5.20533 11.3858
+      vertex -14.2092 -4.75926 11.3229
+    endloop
+  endfacet
+  facet normal 0.94157 0.336818 1.88112e-06
+    outer loop
+      vertex -14.3541 -4.35427 41
+      vertex -13.8834 -5.66994 11.4354
+      vertex -14.0496 -5.20533 11.3858
+    endloop
+  endfacet
+  facet normal 0.941547 0.336883 -0
+    outer loop
+      vertex -13.8582 -5.74025 11.4407
+      vertex -14.3541 -4.35427 41
+      vertex -13.8582 -5.74025 41
+    endloop
+  endfacet
+  facet normal 0.941363 0.337395 -2.70661e-05
+    outer loop
+      vertex -14.3541 -4.35427 41
+      vertex -13.8582 -5.74025 11.4407
+      vertex -13.8834 -5.66994 11.4354
+    endloop
+  endfacet
+  facet normal 0.94155 0.336874 0
+    outer loop
+      vertex -14.2092 -4.75926 8.67712
+      vertex -14.3541 -4.35427 0
+      vertex -14.3541 -4.35427 8.74953
+    endloop
+  endfacet
+  facet normal 0.941548 0.336878 2.08073e-07
+    outer loop
+      vertex -14.0496 -5.20533 8.61418
+      vertex -14.3541 -4.35427 0
+      vertex -14.2092 -4.75926 8.67712
+    endloop
+  endfacet
+  facet normal 0.94157 0.336818 -6.41916e-06
+    outer loop
+      vertex -13.8834 -5.66994 8.56459
+      vertex -14.3541 -4.35427 0
+      vertex -14.0496 -5.20533 8.61418
+    endloop
+  endfacet
+  facet normal 0.941363 0.337396 -0
+    outer loop
+      vertex -13.8582 -5.74025 0
+      vertex -13.8834 -5.66994 8.56459
+      vertex -13.8582 -5.74025 8.55933
+    endloop
+  endfacet
+  facet normal 0.941547 0.336883 4.75653e-06
+    outer loop
+      vertex -13.8834 -5.66994 8.56459
+      vertex -13.8582 -5.74025 0
+      vertex -14.3541 -4.35427 0
+    endloop
+  endfacet
+  facet normal -0.857721 0.514116 0
+    outer loop
+      vertex 12.472 -8.33355 0
+      vertex 13.2288 -7.07095 41
+      vertex 13.2288 -7.07095 0
+    endloop
+  endfacet
+  facet normal -0.857721 0.514116 0
+    outer loop
+      vertex 13.2288 -7.07095 41
+      vertex 12.472 -8.33355 0
+      vertex 12.472 -8.33355 41
+    endloop
+  endfacet
+  facet normal -0.903983 0.427569 0
+    outer loop
+      vertex 13.2288 -7.07095 0
+      vertex 13.8582 -5.74025 9.02887
+      vertex 13.8582 -5.74025 0
+    endloop
+  endfacet
+  facet normal -0.904056 0.427413 2.81764e-05
+    outer loop
+      vertex 13.8582 -5.74025 9.02887
+      vertex 13.2288 -7.07095 0
+      vertex 13.8405 -5.77769 9.04841
+    endloop
+  endfacet
+  facet normal -0.903967 0.427602 -4.80114e-06
+    outer loop
+      vertex 13.8405 -5.77769 9.04841
+      vertex 13.2288 -7.07095 0
+      vertex 13.7528 -5.96309 9.16664
+    endloop
+  endfacet
+  facet normal -0.903947 0.427644 -1.11188e-05
+    outer loop
+      vertex 13.7528 -5.96309 9.16664
+      vertex 13.2288 -7.07095 0
+      vertex 13.6771 -6.1231 9.2929
+    endloop
+  endfacet
+  facet normal -0.904078 0.427367 2.35623e-05
+    outer loop
+      vertex 13.6771 -6.1231 9.2929
+      vertex 13.2288 -7.07095 0
+      vertex 13.6142 -6.25617 9.42597
+    endloop
+  endfacet
+  facet normal -0.903959 0.42762 -3.19969e-06
+    outer loop
+      vertex 13.6142 -6.25617 9.42597
+      vertex 13.2288 -7.07095 0
+      vertex 13.5646 -6.36102 9.56457
+    endloop
+  endfacet
+  facet normal -0.903867 0.427813 -2.07572e-05
+    outer loop
+      vertex 13.5646 -6.36102 9.56457
+      vertex 13.2288 -7.07095 0
+      vertex 13.5288 -6.43665 9.70736
+    endloop
+  endfacet
+  facet normal -0.903991 0.427551 2.02501e-07
+    outer loop
+      vertex 13.5288 -6.43665 9.70736
+      vertex 13.2288 -7.07095 0
+      vertex 13.5072 -6.48232 9.85297
+    endloop
+  endfacet
+  facet normal -0.904311 0.426873 4.97254e-05
+    outer loop
+      vertex 13.5072 -6.48232 9.85297
+      vertex 13.2288 -7.07095 0
+      vertex 13.5 -6.49759 10
+    endloop
+  endfacet
+  facet normal -0.90406 0.427405 -8.91775e-06
+    outer loop
+      vertex 13.2288 -7.07095 41
+      vertex 13.8582 -5.74025 10.9711
+      vertex 13.8405 -5.77769 10.9516
+    endloop
+  endfacet
+  facet normal -0.903966 0.427603 1.5354e-06
+    outer loop
+      vertex 13.2288 -7.07095 41
+      vertex 13.8405 -5.77769 10.9516
+      vertex 13.7528 -5.96309 10.8334
+    endloop
+  endfacet
+  facet normal -0.903945 0.427649 3.59657e-06
+    outer loop
+      vertex 13.2288 -7.07095 41
+      vertex 13.7528 -5.96309 10.8334
+      vertex 13.6771 -6.1231 10.7071
+    endloop
+  endfacet
+  facet normal -0.904085 0.427354 -7.72376e-06
+    outer loop
+      vertex 13.2288 -7.07095 41
+      vertex 13.6771 -6.1231 10.7071
+      vertex 13.6142 -6.25617 10.574
+    endloop
+  endfacet
+  facet normal -0.903958 0.427622 1.06677e-06
+    outer loop
+      vertex 13.2288 -7.07095 41
+      vertex 13.6142 -6.25617 10.574
+      vertex 13.5646 -6.36102 10.4354
+    endloop
+  endfacet
+  facet normal -0.903857 0.427834 7.09458e-06
+    outer loop
+      vertex 13.2288 -7.07095 41
+      vertex 13.5646 -6.36102 10.4354
+      vertex 13.5288 -6.43665 10.2926
+    endloop
+  endfacet
+  facet normal -0.903992 0.42755 -7.25728e-08
+    outer loop
+      vertex 13.2288 -7.07095 41
+      vertex 13.5288 -6.43665 10.2926
+      vertex 13.5072 -6.48232 10.147
+    endloop
+  endfacet
+  facet normal -0.904418 0.426648 -2.11356e-05
+    outer loop
+      vertex 13.2288 -7.07095 41
+      vertex 13.5072 -6.48232 10.147
+      vertex 13.5 -6.49759 10
+    endloop
+  endfacet
+  facet normal -0.903977 0.427582 0
+    outer loop
+      vertex 13.2288 -7.07095 41
+      vertex 13.5 -6.49759 10
+      vertex 13.2288 -7.07095 0
+    endloop
+  endfacet
+  facet normal -0.903983 0.427569 0
+    outer loop
+      vertex 13.8582 -5.74025 10.9711
+      vertex 13.2288 -7.07095 41
+      vertex 13.8582 -5.74025 41
+    endloop
+  endfacet
+  facet normal -0.998796 0.0490479 0
+    outer loop
+      vertex 14.9278 -1.47026 11.4965
+      vertex 15 0 41
+      vertex 15 0 11.5
+    endloop
+  endfacet
+  facet normal -0.998796 0.0490479 0
+    outer loop
+      vertex 15 0 41
+      vertex 14.9278 -1.47026 11.4965
+      vertex 14.9278 -1.47026 41
+    endloop
+  endfacet
+  facet normal -0.998796 0.0490479 0
+    outer loop
+      vertex 14.9278 -1.47026 0
+      vertex 15 0 8.5
+      vertex 15 0 0
+    endloop
+  endfacet
+  facet normal -0.998796 0.0490479 0
+    outer loop
+      vertex 15 0 8.5
+      vertex 14.9278 -1.47026 0
+      vertex 14.9278 -1.47026 8.50355
+    endloop
+  endfacet
+  facet normal 0.146737 -0.989176 0
+    outer loop
+      vertex -2.92635 14.7118 0
+      vertex -1.47026 14.9278 41
+      vertex -2.92635 14.7118 41
+    endloop
+  endfacet
+  facet normal 0.146737 -0.989176 0
+    outer loop
+      vertex -1.47026 14.9278 41
+      vertex -2.92635 14.7118 0
+      vertex -1.47026 14.9278 0
+    endloop
+  endfacet
+  facet normal -0.146633 0.989191 0
+    outer loop
+      vertex 2.67 -14.7498 11.4928
+      vertex 2.92635 -14.7118 41
+      vertex 2.92635 -14.7118 11.4949
+    endloop
+  endfacet
+  facet normal -0.146737 0.989176 9.25054e-07
+    outer loop
+      vertex 2.92635 -14.7118 41
+      vertex 2.67 -14.7498 11.4928
+      vertex 1.47026 -14.9278 41
+    endloop
+  endfacet
+  facet normal -0.146717 0.989178 1.72949e-06
+    outer loop
+      vertex 1.80297 -14.8784 11.4712
+      vertex 1.47026 -14.9278 41
+      vertex 2.67 -14.7498 11.4928
+    endloop
+  endfacet
+  facet normal -0.146868 0.989156 0
+    outer loop
+      vertex 1.47026 -14.9278 41
+      vertex 1.80297 -14.8784 11.4712
+      vertex 1.47026 -14.9278 11.4572
+    endloop
+  endfacet
+  facet normal -0.146633 0.989191 0
+    outer loop
+      vertex 2.92635 -14.7118 0
+      vertex 2.67 -14.7498 8.50722
+      vertex 2.92635 -14.7118 8.50511
+    endloop
+  endfacet
+  facet normal -0.146737 0.989176 -3.20854e-06
+    outer loop
+      vertex 1.47026 -14.9278 0
+      vertex 2.67 -14.7498 8.50722
+      vertex 2.92635 -14.7118 0
+    endloop
+  endfacet
+  facet normal -0.146718 0.989178 -5.98377e-06
+    outer loop
+      vertex 2.67 -14.7498 8.50722
+      vertex 1.47026 -14.9278 0
+      vertex 1.80297 -14.8784 8.52882
+    endloop
+  endfacet
+  facet normal -0.146868 0.989156 0
+    outer loop
+      vertex 1.80297 -14.8784 8.52882
+      vertex 1.47026 -14.9278 0
+      vertex 1.47026 -14.9278 8.54282
+    endloop
+  endfacet
+  facet normal -0.941547 -0.336883 0
+    outer loop
+      vertex 14.3541 4.35427 0
+      vertex 13.8582 5.74025 41
+      vertex 13.8582 5.74025 0
+    endloop
+  endfacet
+  facet normal -0.941547 -0.336883 0
+    outer loop
+      vertex 13.8582 5.74025 41
+      vertex 14.3541 4.35427 0
+      vertex 14.3541 4.35427 41
+    endloop
+  endfacet
+  facet normal -0.740935 0.671577 0
+    outer loop
+      vertex 10.6066 -10.6066 0
+      vertex 11.5952 -9.5159 41
+      vertex 11.5952 -9.5159 0
+    endloop
+  endfacet
+  facet normal -0.740935 0.671577 0
+    outer loop
+      vertex 11.5952 -9.5159 41
+      vertex 10.6066 -10.6066 0
+      vertex 10.6066 -10.6066 41
+    endloop
+  endfacet
+  facet normal -0.803237 0.59566 0
+    outer loop
+      vertex 11.5952 -9.5159 0
+      vertex 12.472 -8.33355 41
+      vertex 12.472 -8.33355 0
+    endloop
+  endfacet
+  facet normal -0.803237 0.59566 0
+    outer loop
+      vertex 12.472 -8.33355 41
+      vertex 11.5952 -9.5159 0
+      vertex 11.5952 -9.5159 41
+    endloop
+  endfacet
+  facet normal 0.242996 -0.970027 0
+    outer loop
+      vertex -4.35427 14.3541 0
+      vertex -2.92635 14.7118 41
+      vertex -4.35427 14.3541 41
+    endloop
+  endfacet
+  facet normal 0.242996 -0.970027 0
+    outer loop
+      vertex -2.92635 14.7118 41
+      vertex -4.35427 14.3541 0
+      vertex -2.92635 14.7118 0
+    endloop
+  endfacet
+  facet normal -0.803237 -0.59566 0
+    outer loop
+      vertex 12.472 8.33355 0
+      vertex 11.5952 9.5159 41
+      vertex 11.5952 9.5159 0
+    endloop
+  endfacet
+  facet normal -0.803237 -0.59566 0
+    outer loop
+      vertex 11.5952 9.5159 41
+      vertex 12.472 8.33355 0
+      vertex 12.472 8.33355 41
+    endloop
+  endfacet
+  facet normal -0.0490479 -0.998796 0
+    outer loop
+      vertex 0 15 0
+      vertex 1.47026 14.9278 41
+      vertex 0 15 41
+    endloop
+  endfacet
+  facet normal -0.0490479 -0.998796 -0
+    outer loop
+      vertex 1.47026 14.9278 41
+      vertex 0 15 0
+      vertex 1.47026 14.9278 0
+    endloop
+  endfacet
+  facet normal -0.903983 -0.427569 0
+    outer loop
+      vertex 13.8582 5.74025 0
+      vertex 13.2288 7.07095 41
+      vertex 13.2288 7.07095 0
+    endloop
+  endfacet
+  facet normal -0.903983 -0.427569 0
+    outer loop
+      vertex 13.2288 7.07095 41
+      vertex 13.8582 5.74025 0
+      vertex 13.8582 5.74025 41
+    endloop
+  endfacet
+  facet normal 0.857721 -0.514116 0
+    outer loop
+      vertex -13.2288 7.07095 41
+      vertex -12.472 8.33355 0
+      vertex -12.472 8.33355 41
+    endloop
+  endfacet
+  facet normal 0.857721 -0.514116 0
+    outer loop
+      vertex -12.472 8.33355 0
+      vertex -13.2288 7.07095 41
+      vertex -13.2288 7.07095 0
+    endloop
+  endfacet
+  facet normal 0.671577 -0.740935 0
+    outer loop
+      vertex -10.6066 10.6066 11.4872
+      vertex -9.5159 11.5952 41
+      vertex -10.6066 10.6066 41
+    endloop
+  endfacet
+  facet normal 0.671558 -0.740952 1.21492e-06
+    outer loop
+      vertex -10.2158 10.9608 11.4712
+      vertex -9.5159 11.5952 41
+      vertex -10.6066 10.6066 11.4872
+    endloop
+  endfacet
+  facet normal 0.671559 -0.740951 1.20022e-06
+    outer loop
+      vertex -9.699 11.4292 11.4354
+      vertex -9.5159 11.5952 41
+      vertex -10.2158 10.9608 11.4712
+    endloop
+  endfacet
+  facet normal 0.671665 -0.740855 0
+    outer loop
+      vertex -9.5159 11.5952 41
+      vertex -9.699 11.4292 11.4354
+      vertex -9.5159 11.5952 11.4173
+    endloop
+  endfacet
+  facet normal 0.671558 -0.740952 0
+    outer loop
+      vertex -10.6066 10.6066 0
+      vertex -10.2158 10.9608 8.52882
+      vertex -10.6066 10.6066 8.51281
+    endloop
+  endfacet
+  facet normal 0.671577 -0.740935 -1.50857e-06
+    outer loop
+      vertex -9.5159 11.5952 0
+      vertex -10.2158 10.9608 8.52882
+      vertex -10.6066 10.6066 0
+    endloop
+  endfacet
+  facet normal 0.671559 -0.740951 -4.13875e-06
+    outer loop
+      vertex -10.2158 10.9608 8.52882
+      vertex -9.5159 11.5952 0
+      vertex -9.699 11.4292 8.56459
+    endloop
+  endfacet
+  facet normal 0.671665 -0.740855 0
+    outer loop
+      vertex -9.699 11.4292 8.56459
+      vertex -9.5159 11.5952 0
+      vertex -9.5159 11.5952 8.58269
+    endloop
+  endfacet
+  facet normal 0.857721 0.514116 0
+    outer loop
+      vertex -12.472 -8.33355 41
+      vertex -13.2288 -7.07095 11.4931
+      vertex -13.2288 -7.07095 41
+    endloop
+  endfacet
+  facet normal 0.857721 0.514116 0
+    outer loop
+      vertex -13.2288 -7.07095 11.4931
+      vertex -12.472 -8.33355 41
+      vertex -12.472 -8.33355 11.4994
+    endloop
+  endfacet
+  facet normal 0.857721 0.514116 0
+    outer loop
+      vertex -12.472 -8.33355 8.50057
+      vertex -13.2288 -7.07095 0
+      vertex -13.2288 -7.07095 8.50695
+    endloop
+  endfacet
+  facet normal 0.857721 0.514116 0
+    outer loop
+      vertex -13.2288 -7.07095 0
+      vertex -12.472 -8.33355 8.50057
+      vertex -12.472 -8.33355 0
+    endloop
+  endfacet
+  facet normal 0.427569 0.903983 -0
+    outer loop
+      vertex -5.74025 -13.8582 0
+      vertex -7.07095 -13.2288 41
+      vertex -5.74025 -13.8582 41
+    endloop
+  endfacet
+  facet normal 0.427569 0.903983 0
+    outer loop
+      vertex -7.07095 -13.2288 41
+      vertex -5.74025 -13.8582 0
+      vertex -7.07095 -13.2288 0
+    endloop
+  endfacet
+  facet normal 0.740935 0.671577 0
+    outer loop
+      vertex -10.6066 -10.6066 41
+      vertex -11.5952 -9.5159 0
+      vertex -11.5952 -9.5159 41
+    endloop
+  endfacet
+  facet normal 0.740935 0.671577 0
+    outer loop
+      vertex -11.5952 -9.5159 0
+      vertex -10.6066 -10.6066 41
+      vertex -10.6066 -10.6066 0
+    endloop
+  endfacet
+  facet normal 0.336883 -0.941547 0
+    outer loop
+      vertex -5.74025 13.8582 0
+      vertex -4.35427 14.3541 41
+      vertex -5.74025 13.8582 41
+    endloop
+  endfacet
+  facet normal 0.336883 -0.941547 0
+    outer loop
+      vertex -4.35427 14.3541 41
+      vertex -5.74025 13.8582 0
+      vertex -4.35427 14.3541 0
+    endloop
+  endfacet
+  facet normal 0.514116 0.857721 -0
+    outer loop
+      vertex -7.07095 -13.2288 0
+      vertex -8.33355 -12.472 41
+      vertex -7.07095 -13.2288 41
+    endloop
+  endfacet
+  facet normal 0.514116 0.857721 0
+    outer loop
+      vertex -8.33355 -12.472 41
+      vertex -7.07095 -13.2288 0
+      vertex -8.33355 -12.472 0
+    endloop
+  endfacet
+  facet normal -0.740935 -0.671577 0
+    outer loop
+      vertex 11.5952 9.5159 0
+      vertex 10.6066 10.6066 41
+      vertex 10.6066 10.6066 0
+    endloop
+  endfacet
+  facet normal -0.740935 -0.671577 0
+    outer loop
+      vertex 10.6066 10.6066 41
+      vertex 11.5952 9.5159 0
+      vertex 11.5952 9.5159 41
+    endloop
+  endfacet
+  facet normal -0.59566 0.803237 0
+    outer loop
+      vertex 9.5159 -11.5952 0
+      vertex 8.33355 -12.472 41
+      vertex 9.5159 -11.5952 41
+    endloop
+  endfacet
+  facet normal -0.59566 0.803237 0
+    outer loop
+      vertex 8.33355 -12.472 41
+      vertex 9.5159 -11.5952 0
+      vertex 8.33355 -12.472 0
+    endloop
+  endfacet
+  facet normal 0.0490479 -0.998796 0
+    outer loop
+      vertex -1.47026 14.9278 0
+      vertex 0 15 41
+      vertex -1.47026 14.9278 41
+    endloop
+  endfacet
+  facet normal 0.0490479 -0.998796 0
+    outer loop
+      vertex 0 15 41
+      vertex -1.47026 14.9278 0
+      vertex 0 15 0
+    endloop
+  endfacet
+  facet normal 0.970027 -0.242996 0
+    outer loop
+      vertex -14.7118 2.92635 41
+      vertex -14.3541 4.35427 0
+      vertex -14.3541 4.35427 41
+    endloop
+  endfacet
+  facet normal 0.970027 -0.242996 0
+    outer loop
+      vertex -14.3541 4.35427 0
+      vertex -14.7118 2.92635 41
+      vertex -14.7118 2.92635 0
+    endloop
+  endfacet
+  facet normal 0.941547 -0.336883 0
+    outer loop
+      vertex -14.3541 4.35427 41
+      vertex -13.8582 5.74025 0
+      vertex -13.8582 5.74025 41
+    endloop
+  endfacet
+  facet normal 0.941547 -0.336883 0
+    outer loop
+      vertex -13.8582 5.74025 0
+      vertex -14.3541 4.35427 41
+      vertex -14.3541 4.35427 0
+    endloop
+  endfacet
+  facet normal 0.989171 0.146765 0
+    outer loop
+      vertex -14.9278 -1.47026 41
+      vertex -14.7505 -2.66523 10
+      vertex -14.9278 -1.47026 0
+    endloop
+  endfacet
+  facet normal 0.989109 0.147184 -1.65063e-05
+    outer loop
+      vertex -14.9278 -1.47026 41
+      vertex -14.7482 -2.68067 10.147
+      vertex -14.7505 -2.66523 10
+    endloop
+  endfacet
+  facet normal 0.989314 0.145799 3.90158e-05
+    outer loop
+      vertex -14.9278 -1.47026 41
+      vertex -14.7414 -2.72685 10.2926
+      vertex -14.7482 -2.68067 10.147
+    endloop
+  endfacet
+  facet normal 0.989075 0.147415 -2.85616e-05
+    outer loop
+      vertex -14.9278 -1.47026 41
+      vertex -14.73 -2.80331 10.4354
+      vertex -14.7414 -2.72685 10.2926
+    endloop
+  endfacet
+  facet normal 0.989208 0.146516 1.15222e-05
+    outer loop
+      vertex -14.9278 -1.47026 41
+      vertex -14.7143 -2.90932 10.574
+      vertex -14.73 -2.80331 10.4354
+    endloop
+  endfacet
+  facet normal 0.989176 0.146737 -0
+    outer loop
+      vertex -14.7118 -2.92635 10.5909
+      vertex -14.9278 -1.47026 41
+      vertex -14.7118 -2.92635 41
+    endloop
+  endfacet
+  facet normal 0.989386 0.145311 6.97709e-05
+    outer loop
+      vertex -14.9278 -1.47026 41
+      vertex -14.7118 -2.92635 10.5909
+      vertex -14.7143 -2.90932 10.574
+    endloop
+  endfacet
+  facet normal 0.989132 0.147033 3.27187e-05
+    outer loop
+      vertex -14.7482 -2.68067 9.85297
+      vertex -14.9278 -1.47026 0
+      vertex -14.7505 -2.66523 10
+    endloop
+  endfacet
+  facet normal 0.989287 0.145984 -9.89509e-05
+    outer loop
+      vertex -14.7414 -2.72685 9.70736
+      vertex -14.9278 -1.47026 0
+      vertex -14.7482 -2.68067 9.85297
+    endloop
+  endfacet
+  facet normal 0.989088 0.147324 7.83219e-05
+    outer loop
+      vertex -14.73 -2.80331 9.56457
+      vertex -14.9278 -1.47026 0
+      vertex -14.7414 -2.72685 9.70736
+    endloop
+  endfacet
+  facet normal 0.989204 0.146543 -3.29209e-05
+    outer loop
+      vertex -14.7143 -2.90932 9.42597
+      vertex -14.9278 -1.47026 0
+      vertex -14.73 -2.80331 9.56457
+    endloop
+  endfacet
+  facet normal 0.989367 0.145441 -0.000204853
+    outer loop
+      vertex -14.7118 -2.92635 9.40913
+      vertex -14.9278 -1.47026 0
+      vertex -14.7143 -2.90932 9.42597
+    endloop
+  endfacet
+  facet normal 0.989176 0.146737 0
+    outer loop
+      vertex -14.9278 -1.47026 0
+      vertex -14.7118 -2.92635 9.40913
+      vertex -14.7118 -2.92635 0
+    endloop
+  endfacet
+  facet normal -0.336883 -0.941547 1.38616e-06
+    outer loop
+      vertex 4.35427 14.3541 41
+      vertex 4.63168 14.2548 11.4994
+      vertex 5.74025 13.8582 41
+    endloop
+  endfacet
+  facet normal -0.337014 -0.9415 0
+    outer loop
+      vertex 4.35427 14.3541 0
+      vertex 4.63168 14.2548 11.4994
+      vertex 4.35427 14.3541 41
+    endloop
+  endfacet
+  facet normal -0.337014 -0.9415 -0
+    outer loop
+      vertex 4.63168 14.2548 11.4994
+      vertex 4.35427 14.3541 0
+      vertex 4.63168 14.2548 11.4928
+    endloop
+  endfacet
+  facet normal -0.337014 -0.9415 -0
+    outer loop
+      vertex 4.63168 14.2548 11.4928
+      vertex 4.35427 14.3541 0
+      vertex 4.63168 14.2548 11.4794
+    endloop
+  endfacet
+  facet normal -0.337014 -0.9415 -0
+    outer loop
+      vertex 4.63168 14.2548 11.4794
+      vertex 4.35427 14.3541 0
+      vertex 4.63168 14.2548 11.4135
+    endloop
+  endfacet
+  facet normal -0.337014 -0.9415 -0
+    outer loop
+      vertex 4.63168 14.2548 11.4135
+      vertex 4.35427 14.3541 0
+      vertex 4.63168 14.2548 11.2152
+    endloop
+  endfacet
+  facet normal -0.337014 -0.9415 -0
+    outer loop
+      vertex 4.63168 14.2548 11.2152
+      vertex 4.35427 14.3541 0
+      vertex 4.63168 14.2548 8.7848
+    endloop
+  endfacet
+  facet normal -0.337014 -0.9415 -0
+    outer loop
+      vertex 4.63168 14.2548 8.7848
+      vertex 4.35427 14.3541 0
+      vertex 4.63168 14.2548 8.58655
+    endloop
+  endfacet
+  facet normal -0.337014 -0.9415 -0
+    outer loop
+      vertex 4.63168 14.2548 8.58655
+      vertex 4.35427 14.3541 0
+      vertex 4.63168 14.2548 8.52056
+    endloop
+  endfacet
+  facet normal -0.337014 -0.9415 -0
+    outer loop
+      vertex 4.63168 14.2548 8.52056
+      vertex 4.35427 14.3541 0
+      vertex 4.63168 14.2548 8.50722
+    endloop
+  endfacet
+  facet normal -0.337014 -0.9415 -0
+    outer loop
+      vertex 4.63168 14.2548 8.50722
+      vertex 4.35427 14.3541 0
+      vertex 4.63168 14.2548 8.50057
+    endloop
+  endfacet
+  facet normal -0.33685 -0.941558 -0
+    outer loop
+      vertex 5.74025 13.8582 41
+      vertex 4.63168 14.2548 11.4994
+      vertex 5.74025 13.8582 11.4977
+    endloop
+  endfacet
+  facet normal -0.336883 -0.941547 -4.81058e-06
+    outer loop
+      vertex 5.74025 13.8582 0
+      vertex 4.63168 14.2548 8.50057
+      vertex 4.35427 14.3541 0
+    endloop
+  endfacet
+  facet normal -0.33685 -0.941558 0
+    outer loop
+      vertex 4.63168 14.2548 8.50057
+      vertex 5.74025 13.8582 0
+      vertex 5.74025 13.8582 8.50227
+    endloop
+  endfacet
+  facet normal 0.803226 0.595674 0
+    outer loop
+      vertex -12.472 -8.33355 41
+      vertex -12.1212 -8.80658 11.4991
+      vertex -12.472 -8.33355 11.4994
+    endloop
+  endfacet
+  facet normal 0.803244 0.59565 0
+    outer loop
+      vertex -11.5952 -9.5159 0
+      vertex -12.1212 -8.80658 11.4534
+      vertex -12.1212 -8.80658 11.4928
+    endloop
+  endfacet
+  facet normal 0.803244 0.59565 0
+    outer loop
+      vertex -12.1212 -8.80658 11.4534
+      vertex -11.5952 -9.5159 0
+      vertex -12.1212 -8.80658 8.54656
+    endloop
+  endfacet
+  facet normal 0.803244 0.59565 0
+    outer loop
+      vertex -12.1212 -8.80658 11.4991
+      vertex -11.5952 -9.5159 0
+      vertex -12.1212 -8.80658 11.4928
+    endloop
+  endfacet
+  facet normal 0.803244 0.59565 -0
+    outer loop
+      vertex -11.5952 -9.5159 0
+      vertex -12.1212 -8.80658 11.4991
+      vertex -11.5952 -9.5159 41
+    endloop
+  endfacet
+  facet normal 0.803237 0.59566 3.60992e-07
+    outer loop
+      vertex -11.5952 -9.5159 41
+      vertex -12.1212 -8.80658 11.4991
+      vertex -12.472 -8.33355 41
+    endloop
+  endfacet
+  facet normal 0.803226 0.595674 0
+    outer loop
+      vertex -12.1212 -8.80658 8.50085
+      vertex -12.472 -8.33355 0
+      vertex -12.472 -8.33355 8.50057
+    endloop
+  endfacet
+  facet normal 0.803244 0.59565 0
+    outer loop
+      vertex -12.1212 -8.80658 8.54656
+      vertex -11.5952 -9.5159 0
+      vertex -12.1212 -8.80658 8.50722
+    endloop
+  endfacet
+  facet normal 0.803237 0.59566 -1.25277e-06
+    outer loop
+      vertex -12.1212 -8.80658 8.50085
+      vertex -11.5952 -9.5159 0
+      vertex -12.472 -8.33355 0
+    endloop
+  endfacet
+  facet normal 0.803244 0.59565 0
+    outer loop
+      vertex -12.1212 -8.80658 8.50722
+      vertex -11.5952 -9.5159 0
+      vertex -12.1212 -8.80658 8.50085
+    endloop
+  endfacet
+  facet normal 0.903983 -0.427569 0
+    outer loop
+      vertex -13.8582 5.74025 41
+      vertex -13.2288 7.07095 0
+      vertex -13.2288 7.07095 41
+    endloop
+  endfacet
+  facet normal 0.903983 -0.427569 0
+    outer loop
+      vertex -13.2288 7.07095 0
+      vertex -13.8582 5.74025 41
+      vertex -13.8582 5.74025 0
+    endloop
+  endfacet
+  facet normal -0.514116 0.857721 0
+    outer loop
+      vertex 8.33355 -12.472 0
+      vertex 7.07095 -13.2288 41
+      vertex 8.33355 -12.472 41
+    endloop
+  endfacet
+  facet normal -0.514116 0.857721 0
+    outer loop
+      vertex 7.07095 -13.2288 41
+      vertex 8.33355 -12.472 0
+      vertex 7.07095 -13.2288 0
+    endloop
+  endfacet
+  facet normal 0.671577 0.740935 -0
+    outer loop
+      vertex -9.5159 -11.5952 0
+      vertex -10.6066 -10.6066 41
+      vertex -9.5159 -11.5952 41
+    endloop
+  endfacet
+  facet normal 0.671577 0.740935 0
+    outer loop
+      vertex -10.6066 -10.6066 41
+      vertex -9.5159 -11.5952 0
+      vertex -10.6066 -10.6066 0
+    endloop
+  endfacet
+  facet normal 0.803244 -0.59565 0
+    outer loop
+      vertex -11.5952 9.5159 41
+      vertex -12.1212 8.80658 11.4991
+      vertex -11.5952 9.5159 11.4987
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -12.1212 8.80658 11.4991
+      vertex -12.1212 8.80658 11.4974
+      vertex -12.1212 8.80658 11.4983
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -12.1212 8.80658 11.4991
+      vertex -12.1212 8.80658 11.4928
+      vertex -12.1212 8.80658 11.4974
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -12.1212 8.80658 11.4991
+      vertex -12.1212 8.80658 11.2154
+      vertex -12.1212 8.80658 11.4928
+    endloop
+  endfacet
+  facet normal 0.803226 -0.595674 0
+    outer loop
+      vertex -12.472 8.33355 0
+      vertex -12.1212 8.80658 11.2154
+      vertex -12.1212 8.80658 11.4991
+    endloop
+  endfacet
+  facet normal 0.803226 -0.595674 0
+    outer loop
+      vertex -12.1212 8.80658 11.2154
+      vertex -12.472 8.33355 0
+      vertex -12.1212 8.80658 8.78458
+    endloop
+  endfacet
+  facet normal 0.803226 -0.595674 0
+    outer loop
+      vertex -12.1212 8.80658 8.78458
+      vertex -12.472 8.33355 0
+      vertex -12.1212 8.80658 8.50718
+    endloop
+  endfacet
+  facet normal 0.803226 -0.595674 0
+    outer loop
+      vertex -12.1212 8.80658 8.50718
+      vertex -12.472 8.33355 0
+      vertex -12.1212 8.80658 8.50257
+    endloop
+  endfacet
+  facet normal 0.803226 -0.595674 0
+    outer loop
+      vertex -12.1212 8.80658 8.50257
+      vertex -12.472 8.33355 0
+      vertex -12.1212 8.80658 8.50171
+    endloop
+  endfacet
+  facet normal 0.803226 -0.595674 0
+    outer loop
+      vertex -12.472 8.33355 0
+      vertex -12.1212 8.80658 11.4991
+      vertex -12.472 8.33355 41
+    endloop
+  endfacet
+  facet normal 0.803237 -0.59566 3.60992e-07
+    outer loop
+      vertex -12.472 8.33355 41
+      vertex -12.1212 8.80658 11.4991
+      vertex -11.5952 9.5159 41
+    endloop
+  endfacet
+  facet normal 0.803244 -0.59565 0
+    outer loop
+      vertex -12.1212 8.80658 8.50085
+      vertex -11.5952 9.5159 0
+      vertex -11.5952 9.5159 8.50128
+    endloop
+  endfacet
+  facet normal 0.803237 -0.59566 -1.25277e-06
+    outer loop
+      vertex -12.1212 8.80658 8.50085
+      vertex -12.472 8.33355 0
+      vertex -11.5952 9.5159 0
+    endloop
+  endfacet
+  facet normal 0.803226 -0.595674 0
+    outer loop
+      vertex -12.1212 8.80658 8.50171
+      vertex -12.472 8.33355 0
+      vertex -12.1212 8.80658 8.50085
+    endloop
+  endfacet
+  facet normal 0.0490479 0.998796 -0
+    outer loop
+      vertex 0 -15 11.3067
+      vertex -1.47026 -14.9278 41
+      vertex 0 -15 41
+    endloop
+  endfacet
+  facet normal 0.0490624 0.998796 7.23988e-07
+    outer loop
+      vertex -0.193397 -14.9905 11.2654
+      vertex -1.47026 -14.9278 41
+      vertex 0 -15 11.3067
+    endloop
+  endfacet
+  facet normal 0.0490805 0.998795 1.50155e-06
+    outer loop
+      vertex -0.278867 -14.9863 11.2472
+      vertex -1.47026 -14.9278 41
+      vertex -0.193397 -14.9905 11.2654
+    endloop
+  endfacet
+  facet normal 0.0495394 0.998772 1.99221e-05
+    outer loop
+      vertex -0.361519 -14.9822 11.2254
+      vertex -1.47026 -14.9278 41
+      vertex -0.278867 -14.9863 11.2472
+    endloop
+  endfacet
+  facet normal 0.0488005 0.998809 -7.66044e-06
+    outer loop
+      vertex -0.611229 -14.97 11.1595
+      vertex -1.47026 -14.9278 41
+      vertex -0.361519 -14.9822 11.2254
+    endloop
+  endfacet
+  facet normal 0.0491888 0.99879 3.54385e-06
+    outer loop
+      vertex -0.917831 -14.9549 11.0607
+      vertex -1.47026 -14.9278 41
+      vertex -0.611229 -14.97 11.1595
+    endloop
+  endfacet
+  facet normal 0.0488827 0.998805 -2.11648e-06
+    outer loop
+      vertex -1.19572 -14.9413 10.9516
+      vertex -1.47026 -14.9278 41
+      vertex -0.917831 -14.9549 11.0607
+    endloop
+  endfacet
+  facet normal 0.049433 0.998777 2.92326e-06
+    outer loop
+      vertex -1.44221 -14.9291 10.8334
+      vertex -1.47026 -14.9278 41
+      vertex -1.19572 -14.9413 10.9516
+    endloop
+  endfacet
+  facet normal 0.0462961 0.998928 0
+    outer loop
+      vertex -1.47026 -14.9278 41
+      vertex -1.44221 -14.9291 10.8334
+      vertex -1.47026 -14.9278 10.8167
+    endloop
+  endfacet
+  facet normal 0.0495273 0.998773 -6.60634e-05
+    outer loop
+      vertex -1.47026 -14.9278 0
+      vertex -0.361519 -14.9822 8.7746
+      vertex -0.278867 -14.9863 8.7528
+    endloop
+  endfacet
+  facet normal 0.0490621 0.998796 -2.41204e-06
+    outer loop
+      vertex -1.47026 -14.9278 0
+      vertex -0.193397 -14.9905 8.73457
+      vertex 0 -15 8.69333
+    endloop
+  endfacet
+  facet normal 0.0490479 0.998796 0
+    outer loop
+      vertex -1.47026 -14.9278 0
+      vertex 0 -15 8.69333
+      vertex 0 -15 0
+    endloop
+  endfacet
+  facet normal 0.0490798 0.998795 -5.0024e-06
+    outer loop
+      vertex -0.193397 -14.9905 8.73457
+      vertex -1.47026 -14.9278 0
+      vertex -0.278867 -14.9863 8.7528
+    endloop
+  endfacet
+  facet normal 0.0488052 0.998808 2.54026e-05
+    outer loop
+      vertex -0.361519 -14.9822 8.7746
+      vertex -1.47026 -14.9278 0
+      vertex -0.611229 -14.97 8.84048
+    endloop
+  endfacet
+  facet normal 0.0491861 0.99879 -1.17063e-05
+    outer loop
+      vertex -0.611229 -14.97 8.84048
+      vertex -1.47026 -14.9278 0
+      vertex -0.917831 -14.9549 8.93934
+    endloop
+  endfacet
+  facet normal 0.0488846 0.998804 6.97071e-06
+    outer loop
+      vertex -0.917831 -14.9549 8.93934
+      vertex -1.47026 -14.9278 0
+      vertex -1.19572 -14.9413 9.04841
+    endloop
+  endfacet
+  facet normal 0.0494298 0.998778 -9.61038e-06
+    outer loop
+      vertex -1.19572 -14.9413 9.04841
+      vertex -1.47026 -14.9278 0
+      vertex -1.44221 -14.9291 9.16664
+    endloop
+  endfacet
+  facet normal 0.0462961 0.998928 0
+    outer loop
+      vertex -1.44221 -14.9291 9.16664
+      vertex -1.47026 -14.9278 0
+      vertex -1.47026 -14.9278 9.18329
+    endloop
+  endfacet
+  facet normal 0.146737 0.989176 -0
+    outer loop
+      vertex -1.47026 -14.9278 10.8167
+      vertex -2.92635 -14.7118 41
+      vertex -1.47026 -14.9278 41
+    endloop
+  endfacet
+  facet normal 0.147235 0.989102 2.45453e-05
+    outer loop
+      vertex -1.56497 -14.9137 10.7456
+      vertex -2.92635 -14.7118 41
+      vertex -1.47026 -14.9278 10.8167
+    endloop
+  endfacet
+  facet normal 0.146662 0.989187 -1.79296e-06
+    outer loop
+      vertex -1.61623 -14.9061 10.7071
+      vertex -2.92635 -14.7118 41
+      vertex -1.56497 -14.9137 10.7456
+    endloop
+  endfacet
+  facet normal 0.146459 0.989217 -1.07533e-05
+    outer loop
+      vertex -1.65946 -14.8997 10.666
+      vertex -2.92635 -14.7118 41
+      vertex -1.61623 -14.9061 10.7071
+    endloop
+  endfacet
+  facet normal 0.146448 0.989218 -1.12379e-05
+    outer loop
+      vertex -1.75606 -14.8854 10.574
+      vertex -2.92635 -14.7118 41
+      vertex -1.65946 -14.8997 10.666
+    endloop
+  endfacet
+  facet normal 0.147203 0.989106 1.84361e-05
+    outer loop
+      vertex -1.86624 -14.869 10.4354
+      vertex -2.92635 -14.7118 41
+      vertex -1.75606 -14.8854 10.574
+    endloop
+  endfacet
+  facet normal 0.146632 0.989191 -1.80869e-06
+    outer loop
+      vertex -1.92021 -14.861 10.3385
+      vertex -2.92635 -14.7118 41
+      vertex -1.86624 -14.869 10.4354
+    endloop
+  endfacet
+  facet normal 0.147353 0.989084 2.23749e-05
+    outer loop
+      vertex -1.94571 -14.8572 10.2926
+      vertex -2.92635 -14.7118 41
+      vertex -1.92021 -14.861 10.3385
+    endloop
+  endfacet
+  facet normal 0.146854 0.989158 6.11603e-06
+    outer loop
+      vertex -1.9612 -14.8549 10.2456
+      vertex -2.92635 -14.7118 41
+      vertex -1.94571 -14.8572 10.2926
+    endloop
+  endfacet
+  facet normal 0.146156 0.989262 -1.62937e-05
+    outer loop
+      vertex -1.9937 -14.8501 10.147
+      vertex -2.92635 -14.7118 41
+      vertex -1.9612 -14.8549 10.2456
+    endloop
+  endfacet
+  facet normal 0.136299 0.990668 -0.000320541
+    outer loop
+      vertex -1.9989 -14.8494 10.0993
+      vertex -2.92635 -14.7118 41
+      vertex -1.9937 -14.8501 10.147
+    endloop
+  endfacet
+  facet normal 0.153172 0.988199 0.000196874
+    outer loop
+      vertex -2.00974 -14.8477 10
+      vertex -2.92635 -14.7118 41
+      vertex -1.9989 -14.8494 10.0993
+    endloop
+  endfacet
+  facet normal 0.146737 0.989176 0
+    outer loop
+      vertex -2.92635 -14.7118 0
+      vertex -1.47026 -14.9278 9.18329
+      vertex -1.47026 -14.9278 0
+    endloop
+  endfacet
+  facet normal 0.147198 0.989107 -7.47023e-05
+    outer loop
+      vertex -1.47026 -14.9278 9.18329
+      vertex -2.92635 -14.7118 0
+      vertex -1.56497 -14.9137 9.25441
+    endloop
+  endfacet
+  facet normal 0.146665 0.989186 5.45687e-06
+    outer loop
+      vertex -1.56497 -14.9137 9.25441
+      vertex -2.92635 -14.7118 0
+      vertex -1.61623 -14.9061 9.2929
+    endloop
+  endfacet
+  facet normal 0.146479 0.989214 3.21777e-05
+    outer loop
+      vertex -1.61623 -14.9061 9.2929
+      vertex -2.92635 -14.7118 0
+      vertex -1.65946 -14.8997 9.33404
+    endloop
+  endfacet
+  facet normal 0.146469 0.989215 3.36299e-05
+    outer loop
+      vertex -1.65946 -14.8997 9.33404
+      vertex -2.92635 -14.7118 0
+      vertex -1.75606 -14.8854 9.42597
+    endloop
+  endfacet
+  facet normal 0.147159 0.989113 -5.39617e-05
+    outer loop
+      vertex -1.75606 -14.8854 9.42597
+      vertex -2.92635 -14.7118 0
+      vertex -1.86624 -14.869 9.56457
+    endloop
+  endfacet
+  facet normal 0.146637 0.98919 5.12015e-06
+    outer loop
+      vertex -1.86624 -14.869 9.56457
+      vertex -2.92635 -14.7118 0
+      vertex -1.92021 -14.861 9.66154
+    endloop
+  endfacet
+  facet normal 0.147281 0.989095 -6.3349e-05
+    outer loop
+      vertex -1.92021 -14.861 9.66154
+      vertex -2.92635 -14.7118 0
+      vertex -1.94571 -14.8572 9.70736
+    endloop
+  endfacet
+  facet normal 0.146824 0.989163 -1.62429e-05
+    outer loop
+      vertex -1.94571 -14.8572 9.70736
+      vertex -2.92635 -14.7118 0
+      vertex -1.9612 -14.8549 9.75436
+    endloop
+  endfacet
+  facet normal 0.146236 0.98925 4.32717e-05
+    outer loop
+      vertex -1.9612 -14.8549 9.75436
+      vertex -2.92635 -14.7118 0
+      vertex -1.9937 -14.8501 9.85297
+    endloop
+  endfacet
+  facet normal 0.13959 0.990209 0.000685828
+    outer loop
+      vertex -1.9937 -14.8501 9.85297
+      vertex -2.92635 -14.7118 0
+      vertex -1.9989 -14.8494 9.90068
+    endloop
+  endfacet
+  facet normal 0.146661 0.989187 0
+    outer loop
+      vertex -2.00974 -14.8477 10
+      vertex -2.92635 -14.7118 0
+      vertex -2.92635 -14.7118 41
+    endloop
+  endfacet
+  facet normal 0.151161 0.988509 -0.000421702
+    outer loop
+      vertex -1.9989 -14.8494 9.90068
+      vertex -2.92635 -14.7118 0
+      vertex -2.00974 -14.8477 10
+    endloop
+  endfacet
+  facet normal 0.989176 -0.146737 0
+    outer loop
+      vertex -14.9278 1.47026 41
+      vertex -14.7118 2.92635 0
+      vertex -14.7118 2.92635 41
+    endloop
+  endfacet
+  facet normal 0.989176 -0.146737 0
+    outer loop
+      vertex -14.7118 2.92635 0
+      vertex -14.9278 1.47026 41
+      vertex -14.9278 1.47026 0
+    endloop
+  endfacet
+  facet normal 0.998796 -0.0490479 0
+    outer loop
+      vertex -15 0 41
+      vertex -14.9278 1.47026 0
+      vertex -14.9278 1.47026 41
+    endloop
+  endfacet
+  facet normal 0.998796 -0.0490479 0
+    outer loop
+      vertex -14.9278 1.47026 0
+      vertex -15 0 41
+      vertex -15 0 0
+    endloop
+  endfacet
+  facet normal 0.336883 0.941547 -0
+    outer loop
+      vertex -4.35427 -14.3541 0
+      vertex -5.74025 -13.8582 41
+      vertex -4.35427 -14.3541 41
+    endloop
+  endfacet
+  facet normal 0.336883 0.941547 0
+    outer loop
+      vertex -5.74025 -13.8582 41
+      vertex -4.35427 -14.3541 0
+      vertex -5.74025 -13.8582 0
+    endloop
+  endfacet
+  facet normal -0.671577 0.740935 0
+    outer loop
+      vertex 10.6066 -10.6066 0
+      vertex 9.5159 -11.5952 41
+      vertex 10.6066 -10.6066 41
+    endloop
+  endfacet
+  facet normal -0.671577 0.740935 0
+    outer loop
+      vertex 9.5159 -11.5952 41
+      vertex 10.6066 -10.6066 0
+      vertex 9.5159 -11.5952 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.9278 -1.47026 41
+      vertex 14.9278 1.47026 41
+      vertex 15 0 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7118 -2.92635 41
+      vertex 14.9278 1.47026 41
+      vertex 14.9278 -1.47026 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7118 -2.92635 41
+      vertex 14.7118 2.92635 41
+      vertex 14.9278 1.47026 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.3541 -4.35427 41
+      vertex 14.7118 2.92635 41
+      vertex 14.7118 -2.92635 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.3541 -4.35427 41
+      vertex 14.3541 4.35427 41
+      vertex 14.7118 2.92635 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8582 -5.74025 41
+      vertex 14.3541 4.35427 41
+      vertex 14.3541 -4.35427 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8582 -5.74025 41
+      vertex 13.8582 5.74025 41
+      vertex 14.3541 4.35427 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.2288 -7.07095 41
+      vertex 13.8582 5.74025 41
+      vertex 13.8582 -5.74025 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.2288 -7.07095 41
+      vertex 13.2288 7.07095 41
+      vertex 13.8582 5.74025 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.472 -8.33355 41
+      vertex 13.2288 7.07095 41
+      vertex 13.2288 -7.07095 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.472 -8.33355 41
+      vertex 12.472 8.33355 41
+      vertex 13.2288 7.07095 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5952 -9.5159 41
+      vertex 12.472 8.33355 41
+      vertex 12.472 -8.33355 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5952 -9.5159 41
+      vertex 11.5952 9.5159 41
+      vertex 12.472 8.33355 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6066 -10.6066 41
+      vertex 11.5952 9.5159 41
+      vertex 11.5952 -9.5159 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6066 -10.6066 41
+      vertex 10.6066 10.6066 41
+      vertex 11.5952 9.5159 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.5159 -11.5952 41
+      vertex 10.6066 10.6066 41
+      vertex 10.6066 -10.6066 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.5159 -11.5952 41
+      vertex 9.5159 11.5952 41
+      vertex 10.6066 10.6066 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.33355 -12.472 41
+      vertex 9.5159 11.5952 41
+      vertex 9.5159 -11.5952 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.33355 -12.472 41
+      vertex 8.33355 12.472 41
+      vertex 9.5159 11.5952 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.07095 -13.2288 41
+      vertex 8.33355 12.472 41
+      vertex 8.33355 -12.472 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.07095 -13.2288 41
+      vertex 7.07095 13.2288 41
+      vertex 8.33355 12.472 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.74025 -13.8582 41
+      vertex 7.07095 13.2288 41
+      vertex 7.07095 -13.2288 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.74025 -13.8582 41
+      vertex 5.74025 13.8582 41
+      vertex 7.07095 13.2288 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.35427 -14.3541 41
+      vertex 5.74025 13.8582 41
+      vertex 5.74025 -13.8582 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.35427 -14.3541 41
+      vertex 4.35427 14.3541 41
+      vertex 5.74025 13.8582 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.92635 -14.7118 41
+      vertex 4.35427 14.3541 41
+      vertex 4.35427 -14.3541 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.92635 -14.7118 41
+      vertex 2.92635 14.7118 41
+      vertex 4.35427 14.3541 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.47026 -14.9278 41
+      vertex 2.92635 14.7118 41
+      vertex 2.92635 -14.7118 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.47026 -14.9278 41
+      vertex 1.47026 14.9278 41
+      vertex 2.92635 14.7118 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -15 41
+      vertex 1.47026 14.9278 41
+      vertex 1.47026 -14.9278 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -15 41
+      vertex 0 15 41
+      vertex 1.47026 14.9278 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.47026 -14.9278 41
+      vertex 0 15 41
+      vertex 0 -15 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.47026 -14.9278 41
+      vertex -1.47026 14.9278 41
+      vertex 0 15 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.92635 -14.7118 41
+      vertex -1.47026 14.9278 41
+      vertex -1.47026 -14.9278 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.92635 -14.7118 41
+      vertex -2.92635 14.7118 41
+      vertex -1.47026 14.9278 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.35427 -14.3541 41
+      vertex -2.92635 14.7118 41
+      vertex -2.92635 -14.7118 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.35427 -14.3541 41
+      vertex -4.35427 14.3541 41
+      vertex -2.92635 14.7118 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.74025 -13.8582 41
+      vertex -4.35427 14.3541 41
+      vertex -4.35427 -14.3541 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.74025 -13.8582 41
+      vertex -5.74025 13.8582 41
+      vertex -4.35427 14.3541 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.07095 -13.2288 41
+      vertex -5.74025 13.8582 41
+      vertex -5.74025 -13.8582 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.07095 -13.2288 41
+      vertex -7.07095 13.2288 41
+      vertex -5.74025 13.8582 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.33355 -12.472 41
+      vertex -7.07095 13.2288 41
+      vertex -7.07095 -13.2288 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.33355 -12.472 41
+      vertex -8.33355 12.472 41
+      vertex -7.07095 13.2288 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.5159 -11.5952 41
+      vertex -8.33355 12.472 41
+      vertex -8.33355 -12.472 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.5159 -11.5952 41
+      vertex -9.5159 11.5952 41
+      vertex -8.33355 12.472 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6066 -10.6066 41
+      vertex -9.5159 11.5952 41
+      vertex -9.5159 -11.5952 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6066 -10.6066 41
+      vertex -10.6066 10.6066 41
+      vertex -9.5159 11.5952 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.5952 -9.5159 41
+      vertex -10.6066 10.6066 41
+      vertex -10.6066 -10.6066 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.5952 -9.5159 41
+      vertex -11.5952 9.5159 41
+      vertex -10.6066 10.6066 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.472 -8.33355 41
+      vertex -11.5952 9.5159 41
+      vertex -11.5952 -9.5159 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.472 -8.33355 41
+      vertex -12.472 8.33355 41
+      vertex -11.5952 9.5159 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.2288 -7.07095 41
+      vertex -12.472 8.33355 41
+      vertex -12.472 -8.33355 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.2288 -7.07095 41
+      vertex -13.2288 7.07095 41
+      vertex -12.472 8.33355 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8582 -5.74025 41
+      vertex -13.2288 7.07095 41
+      vertex -13.2288 -7.07095 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8582 -5.74025 41
+      vertex -13.8582 5.74025 41
+      vertex -13.2288 7.07095 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.3541 -4.35427 41
+      vertex -13.8582 5.74025 41
+      vertex -13.8582 -5.74025 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.3541 -4.35427 41
+      vertex -14.3541 4.35427 41
+      vertex -13.8582 5.74025 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.3541 4.35427 41
+      vertex -14.3541 -4.35427 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7118 -2.92635 41
+      vertex -14.7118 2.92635 41
+      vertex -14.3541 4.35427 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.9278 -1.47026 41
+      vertex -14.7118 2.92635 41
+      vertex -14.7118 -2.92635 41
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.9278 -1.47026 41
+      vertex -14.9278 1.47026 41
+      vertex -14.7118 2.92635 41
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -14.9278 1.47026 41
+      vertex -14.9278 -1.47026 41
+      vertex -15 0 41
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/3d_models/trap_body_main.stl
+++ b/3d_models/trap_body_main.stl
@@ -1,0 +1,11090 @@
+solid OpenSCAD_Model
+  facet normal -0.0245379 0.999699 0
+    outer loop
+      vertex 0 54.8 0
+      vertex -2.68891 54.734 20
+      vertex 0 54.8 20
+    endloop
+  endfacet
+  facet normal -0.0245379 0.999699 0
+    outer loop
+      vertex -2.68891 54.734 20
+      vertex 0 54.8 0
+      vertex -2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal 0.170987 -0.985273 0
+    outer loop
+      vertex 8.04083 -54.2069 0
+      vertex 10.6909 -53.747 20
+      vertex 8.04083 -54.2069 20
+    endloop
+  endfacet
+  facet normal 0.170987 -0.985273 0
+    outer loop
+      vertex 10.6909 -53.747 20
+      vertex 8.04083 -54.2069 0
+      vertex 10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal 0.359896 -0.932992 0
+    outer loop
+      vertex 18.4616 -51.5966 0
+      vertex 20.5267 -50.8 20
+      vertex 18.4616 -51.5966 20
+    endloop
+  endfacet
+  facet normal 0.359896 -0.932992 0
+    outer loop
+      vertex 20.5267 -50.8 20
+      vertex 18.4616 -51.5966 0
+      vertex 20.5267 -50.8 0
+    endloop
+  endfacet
+  facet normal 0.359896 0.932992 -0
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 18.4616 51.5966 20
+      vertex 20.5267 50.8 20
+    endloop
+  endfacet
+  facet normal 0.359896 0.932992 0
+    outer loop
+      vertex 18.4616 51.5966 20
+      vertex 20.5267 50.8 0
+      vertex 18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0.0245379 -0.999699 0
+    outer loop
+      vertex 0 -54.8 0
+      vertex 2.68891 -54.734 20
+      vertex 0 -54.8 20
+    endloop
+  endfacet
+  facet normal 0.0245379 -0.999699 0
+    outer loop
+      vertex 2.68891 -54.734 20
+      vertex 0 -54.8 0
+      vertex 2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal -0.0735764 -0.99729 0
+    outer loop
+      vertex -5.37134 -54.5361 0
+      vertex -2.68891 -54.734 20
+      vertex -5.37134 -54.5361 20
+    endloop
+  endfacet
+  facet normal -0.0735764 -0.99729 -0
+    outer loop
+      vertex -2.68891 -54.734 20
+      vertex -5.37134 -54.5361 0
+      vertex -2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal 0.0735764 -0.99729 0
+    outer loop
+      vertex 2.68891 -54.734 0
+      vertex 5.37134 -54.5361 20
+      vertex 2.68891 -54.734 20
+    endloop
+  endfacet
+  facet normal 0.0735764 -0.99729 0
+    outer loop
+      vertex 5.37134 -54.5361 20
+      vertex 2.68891 -54.734 0
+      vertex 5.37134 -54.5361 0
+    endloop
+  endfacet
+  facet normal 0.122392 -0.992482 0
+    outer loop
+      vertex 5.37134 -54.5361 0
+      vertex 8.04083 -54.2069 20
+      vertex 5.37134 -54.5361 20
+    endloop
+  endfacet
+  facet normal 0.122392 -0.992482 0
+    outer loop
+      vertex 8.04083 -54.2069 20
+      vertex 5.37134 -54.5361 0
+      vertex 8.04083 -54.2069 0
+    endloop
+  endfacet
+  facet normal -0.219091 0.975704 0
+    outer loop
+      vertex -10.6909 53.747 0
+      vertex -13.3153 53.1577 20
+      vertex -10.6909 53.747 20
+    endloop
+  endfacet
+  facet normal -0.219091 0.975704 0
+    outer loop
+      vertex -13.3153 53.1577 20
+      vertex -10.6909 53.747 0
+      vertex -13.3153 53.1577 0
+    endloop
+  endfacet
+  facet normal -0.0735764 0.99729 0
+    outer loop
+      vertex -2.68891 54.734 0
+      vertex -5.37134 54.5361 20
+      vertex -2.68891 54.734 20
+    endloop
+  endfacet
+  facet normal -0.0735764 0.99729 0
+    outer loop
+      vertex -5.37134 54.5361 20
+      vertex -2.68891 54.734 0
+      vertex -5.37134 54.5361 0
+    endloop
+  endfacet
+  facet normal -0.170987 -0.985273 0
+    outer loop
+      vertex -10.6909 -53.747 0
+      vertex -8.04083 -54.2069 20
+      vertex -10.6909 -53.747 20
+    endloop
+  endfacet
+  facet normal -0.170987 -0.985273 -0
+    outer loop
+      vertex -8.04083 -54.2069 20
+      vertex -10.6909 -53.747 0
+      vertex -8.04083 -54.2069 0
+    endloop
+  endfacet
+  facet normal -0.266718 0.963775 0
+    outer loop
+      vertex -13.3153 53.1577 0
+      vertex -15.9076 52.4403 20
+      vertex -13.3153 53.1577 20
+    endloop
+  endfacet
+  facet normal -0.266718 0.963775 0
+    outer loop
+      vertex -15.9076 52.4403 20
+      vertex -13.3153 53.1577 0
+      vertex -15.9076 52.4403 0
+    endloop
+  endfacet
+  facet normal 0.219091 0.975704 -0
+    outer loop
+      vertex 13.3153 53.1577 0
+      vertex 10.6909 53.747 20
+      vertex 13.3153 53.1577 20
+    endloop
+  endfacet
+  facet normal 0.219091 0.975704 0
+    outer loop
+      vertex 10.6909 53.747 20
+      vertex 13.3153 53.1577 0
+      vertex 10.6909 53.747 0
+    endloop
+  endfacet
+  facet normal 0.266718 -0.963775 0
+    outer loop
+      vertex 13.3153 -53.1577 0
+      vertex 15.9076 -52.4403 20
+      vertex 13.3153 -53.1577 20
+    endloop
+  endfacet
+  facet normal 0.266718 -0.963775 0
+    outer loop
+      vertex 15.9076 -52.4403 20
+      vertex 13.3153 -53.1577 0
+      vertex 15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal -0.0245379 -0.999699 0
+    outer loop
+      vertex -2.68891 -54.734 0
+      vertex 0 -54.8 20
+      vertex -2.68891 -54.734 20
+    endloop
+  endfacet
+  facet normal -0.0245379 -0.999699 -0
+    outer loop
+      vertex 0 -54.8 20
+      vertex -2.68891 -54.734 0
+      vertex 0 -54.8 0
+    endloop
+  endfacet
+  facet normal -0.122392 -0.992482 0
+    outer loop
+      vertex -8.04083 -54.2069 0
+      vertex -5.37134 -54.5361 20
+      vertex -8.04083 -54.2069 20
+    endloop
+  endfacet
+  facet normal -0.122392 -0.992482 -0
+    outer loop
+      vertex -5.37134 -54.5361 20
+      vertex -8.04083 -54.2069 0
+      vertex -5.37134 -54.5361 0
+    endloop
+  endfacet
+  facet normal 0.313672 -0.949531 0
+    outer loop
+      vertex 15.9076 -52.4403 0
+      vertex 18.4616 -51.5966 20
+      vertex 15.9076 -52.4403 20
+    endloop
+  endfacet
+  facet normal 0.313672 -0.949531 0
+    outer loop
+      vertex 18.4616 -51.5966 20
+      vertex 15.9076 -52.4403 0
+      vertex 18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal -0.359896 0.932992 0
+    outer loop
+      vertex -18.4616 51.5966 0
+      vertex -20.5267 50.8 20
+      vertex -18.4616 51.5966 20
+    endloop
+  endfacet
+  facet normal -0.359896 0.932992 0
+    outer loop
+      vertex -20.5267 50.8 20
+      vertex -18.4616 51.5966 0
+      vertex -20.5267 50.8 0
+    endloop
+  endfacet
+  facet normal 0.122392 0.992482 -0
+    outer loop
+      vertex 8.04083 54.2069 0
+      vertex 5.37134 54.5361 20
+      vertex 8.04083 54.2069 20
+    endloop
+  endfacet
+  facet normal 0.122392 0.992482 0
+    outer loop
+      vertex 5.37134 54.5361 20
+      vertex 8.04083 54.2069 0
+      vertex 5.37134 54.5361 0
+    endloop
+  endfacet
+  facet normal -0.170987 0.985273 0
+    outer loop
+      vertex -8.04083 54.2069 0
+      vertex -10.6909 53.747 20
+      vertex -8.04083 54.2069 20
+    endloop
+  endfacet
+  facet normal -0.170987 0.985273 0
+    outer loop
+      vertex -10.6909 53.747 20
+      vertex -8.04083 54.2069 0
+      vertex -10.6909 53.747 0
+    endloop
+  endfacet
+  facet normal -0.313672 -0.949531 0
+    outer loop
+      vertex -18.4616 -51.5966 0
+      vertex -15.9076 -52.4403 20
+      vertex -18.4616 -51.5966 20
+    endloop
+  endfacet
+  facet normal -0.313672 -0.949531 -0
+    outer loop
+      vertex -15.9076 -52.4403 20
+      vertex -18.4616 -51.5966 0
+      vertex -15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal -0.122392 0.992482 0
+    outer loop
+      vertex -5.37134 54.5361 0
+      vertex -8.04083 54.2069 20
+      vertex -5.37134 54.5361 20
+    endloop
+  endfacet
+  facet normal -0.122392 0.992482 0
+    outer loop
+      vertex -8.04083 54.2069 20
+      vertex -5.37134 54.5361 0
+      vertex -8.04083 54.2069 0
+    endloop
+  endfacet
+  facet normal 0.266718 0.963775 -0
+    outer loop
+      vertex 15.9076 52.4403 0
+      vertex 13.3153 53.1577 20
+      vertex 15.9076 52.4403 20
+    endloop
+  endfacet
+  facet normal 0.266718 0.963775 0
+    outer loop
+      vertex 13.3153 53.1577 20
+      vertex 15.9076 52.4403 0
+      vertex 13.3153 53.1577 0
+    endloop
+  endfacet
+  facet normal -0.266718 -0.963775 0
+    outer loop
+      vertex -15.9076 -52.4403 0
+      vertex -13.3153 -53.1577 20
+      vertex -15.9076 -52.4403 20
+    endloop
+  endfacet
+  facet normal -0.266718 -0.963775 -0
+    outer loop
+      vertex -13.3153 -53.1577 20
+      vertex -15.9076 -52.4403 0
+      vertex -13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal 0.0735764 0.99729 -0
+    outer loop
+      vertex 5.37134 54.5361 0
+      vertex 2.68891 54.734 20
+      vertex 5.37134 54.5361 20
+    endloop
+  endfacet
+  facet normal 0.0735764 0.99729 0
+    outer loop
+      vertex 2.68891 54.734 20
+      vertex 5.37134 54.5361 0
+      vertex 2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal -0.359896 -0.932992 0
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -18.4616 -51.5966 20
+      vertex -20.5267 -50.8 20
+    endloop
+  endfacet
+  facet normal -0.359896 -0.932992 -0
+    outer loop
+      vertex -18.4616 -51.5966 20
+      vertex -20.5267 -50.8 0
+      vertex -18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal 0.219091 -0.975704 0
+    outer loop
+      vertex 10.6909 -53.747 0
+      vertex 13.3153 -53.1577 20
+      vertex 10.6909 -53.747 20
+    endloop
+  endfacet
+  facet normal 0.219091 -0.975704 0
+    outer loop
+      vertex 13.3153 -53.1577 20
+      vertex 10.6909 -53.747 0
+      vertex 13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal 0.0245379 0.999699 -0
+    outer loop
+      vertex 2.68891 54.734 0
+      vertex 0 54.8 20
+      vertex 2.68891 54.734 20
+    endloop
+  endfacet
+  facet normal 0.0245379 0.999699 0
+    outer loop
+      vertex 0 54.8 20
+      vertex 2.68891 54.734 0
+      vertex 0 54.8 0
+    endloop
+  endfacet
+  facet normal -0.313672 0.949531 0
+    outer loop
+      vertex -15.9076 52.4403 0
+      vertex -18.4616 51.5966 20
+      vertex -15.9076 52.4403 20
+    endloop
+  endfacet
+  facet normal -0.313672 0.949531 0
+    outer loop
+      vertex -18.4616 51.5966 20
+      vertex -15.9076 52.4403 0
+      vertex -18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0.313672 0.949531 -0
+    outer loop
+      vertex 18.4616 51.5966 0
+      vertex 15.9076 52.4403 20
+      vertex 18.4616 51.5966 20
+    endloop
+  endfacet
+  facet normal 0.313672 0.949531 0
+    outer loop
+      vertex 15.9076 52.4403 20
+      vertex 18.4616 51.5966 0
+      vertex 15.9076 52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.8 0 0
+      vertex 54.8 50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.7388 -2.49264 0
+      vertex 50.8 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.5554 -4.97927 0
+      vertex 50.7388 -2.49264 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.2502 -7.45391 0
+      vertex 50.5554 -4.97927 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 49.8239 -9.91059 0
+      vertex 50.2502 -7.45391 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 49.2776 -12.3434 0
+      vertex 49.8239 -9.91059 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 48.6126 -14.7465 0
+      vertex 49.2776 -12.3434 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 47.8304 -17.114 0
+      vertex 48.6126 -14.7465 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 46.9331 -19.4403 0
+      vertex 47.8304 -17.114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 45.9227 -21.7198 0
+      vertex 46.9331 -19.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 44.8016 -23.947 0
+      vertex 45.9227 -21.7198 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 43.5726 -26.1164 0
+      vertex 44.8016 -23.947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 42.2387 -28.223 0
+      vertex 43.5726 -26.1164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 40.8029 -30.2615 0
+      vertex 42.2387 -28.223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 39.2689 -32.2272 0
+      vertex 40.8029 -30.2615 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 37.6403 -34.1152 0
+      vertex 39.2689 -32.2272 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 35.921 -35.921 0
+      vertex 37.6403 -34.1152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 34.1152 -37.6403 0
+      vertex 35.921 -35.921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 32.2272 -39.2689 0
+      vertex 34.1152 -37.6403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 30.2615 -40.8029 0
+      vertex 32.2272 -39.2689 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 28.223 -42.2387 0
+      vertex 30.2615 -40.8029 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 28.223 -42.2387 0
+      vertex 54.8 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.223 -42.2387 0
+      vertex 20.5267 -50.8 0
+      vertex 26.1164 -43.5726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1164 -43.5726 0
+      vertex 20.5267 -50.8 0
+      vertex 23.947 -44.8016 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.947 -44.8016 0
+      vertex 20.5267 -50.8 0
+      vertex 21.7198 -45.9227 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 19.4403 -46.9331 0
+      vertex 21.7198 -45.9227 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.114 -47.8304 0
+      vertex 20.5267 -50.8 0
+      vertex 18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 17.114 -47.8304 0
+      vertex 19.4403 -46.9331 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9076 -52.4403 0
+      vertex 17.114 -47.8304 0
+      vertex 18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9076 -52.4403 0
+      vertex 14.7465 -48.6126 0
+      vertex 17.114 -47.8304 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.3153 -53.1577 0
+      vertex 14.7465 -48.6126 0
+      vertex 15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.3153 -53.1577 0
+      vertex 12.3434 -49.2776 0
+      vertex 14.7465 -48.6126 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6909 -53.747 0
+      vertex 12.3434 -49.2776 0
+      vertex 13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6909 -53.747 0
+      vertex 9.91059 -49.8239 0
+      vertex 12.3434 -49.2776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.04083 -54.2069 0
+      vertex 9.91059 -49.8239 0
+      vertex 10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.04083 -54.2069 0
+      vertex 7.45391 -50.2502 0
+      vertex 9.91059 -49.8239 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.37134 -54.5361 0
+      vertex 7.45391 -50.2502 0
+      vertex 8.04083 -54.2069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.37134 -54.5361 0
+      vertex 4.97927 -50.5554 0
+      vertex 7.45391 -50.2502 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.68891 -54.734 0
+      vertex 4.97927 -50.5554 0
+      vertex 5.37134 -54.5361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.68891 -54.734 0
+      vertex 2.49264 -50.7388 0
+      vertex 4.97927 -50.5554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -54.8 0
+      vertex 2.49264 -50.7388 0
+      vertex 2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -54.8 0
+      vertex 0 -50.8 0
+      vertex 2.49264 -50.7388 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -54.8 0
+      vertex -2.49264 -50.7388 0
+      vertex 0 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.68891 -54.734 0
+      vertex -2.49264 -50.7388 0
+      vertex 0 -54.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.68891 -54.734 0
+      vertex -4.97927 -50.5554 0
+      vertex -2.49264 -50.7388 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.37134 -54.5361 0
+      vertex -4.97927 -50.5554 0
+      vertex -2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.37134 -54.5361 0
+      vertex -7.45391 -50.2502 0
+      vertex -4.97927 -50.5554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.04083 -54.2069 0
+      vertex -7.45391 -50.2502 0
+      vertex -5.37134 -54.5361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.04083 -54.2069 0
+      vertex -9.91059 -49.8239 0
+      vertex -7.45391 -50.2502 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6909 -53.747 0
+      vertex -9.91059 -49.8239 0
+      vertex -8.04083 -54.2069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6909 -53.747 0
+      vertex -12.3434 -49.2776 0
+      vertex -9.91059 -49.8239 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.3153 -53.1577 0
+      vertex -12.3434 -49.2776 0
+      vertex -10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.3153 -53.1577 0
+      vertex -14.7465 -48.6126 0
+      vertex -12.3434 -49.2776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9076 -52.4403 0
+      vertex -14.7465 -48.6126 0
+      vertex -13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9076 -52.4403 0
+      vertex -17.114 -47.8304 0
+      vertex -14.7465 -48.6126 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.4616 -51.5966 0
+      vertex -17.114 -47.8304 0
+      vertex -15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -17.114 -47.8304 0
+      vertex -18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.114 -47.8304 0
+      vertex -20.5267 -50.8 0
+      vertex -19.4403 -46.9331 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -21.7198 -45.9227 0
+      vertex -19.4403 -46.9331 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -23.947 -44.8016 0
+      vertex -21.7198 -45.9227 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -26.1164 -43.5726 0
+      vertex -23.947 -44.8016 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -28.223 -42.2387 0
+      vertex -26.1164 -43.5726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -28.223 -42.2387 0
+      vertex -20.5267 -50.8 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -28.223 -42.2387 0
+      vertex -54.8 -50.8 0
+      vertex -30.2615 -40.8029 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -30.2615 -40.8029 0
+      vertex -54.8 -50.8 0
+      vertex -32.2272 -39.2689 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -32.2272 -39.2689 0
+      vertex -54.8 -50.8 0
+      vertex -34.1152 -37.6403 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -50.7388 -2.49264 0
+      vertex -54.8 -50.8 0
+      vertex -50.8 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -50.5554 -4.97927 0
+      vertex -54.8 -50.8 0
+      vertex -50.7388 -2.49264 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -50.2502 -7.45391 0
+      vertex -54.8 -50.8 0
+      vertex -50.5554 -4.97927 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -49.8239 -9.91059 0
+      vertex -54.8 -50.8 0
+      vertex -50.2502 -7.45391 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -49.2776 -12.3434 0
+      vertex -54.8 -50.8 0
+      vertex -49.8239 -9.91059 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -48.6126 -14.7465 0
+      vertex -54.8 -50.8 0
+      vertex -49.2776 -12.3434 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -47.8304 -17.114 0
+      vertex -54.8 -50.8 0
+      vertex -48.6126 -14.7465 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -46.9331 -19.4403 0
+      vertex -54.8 -50.8 0
+      vertex -47.8304 -17.114 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -45.9227 -21.7198 0
+      vertex -54.8 -50.8 0
+      vertex -46.9331 -19.4403 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -44.8016 -23.947 0
+      vertex -54.8 -50.8 0
+      vertex -45.9227 -21.7198 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -43.5726 -26.1164 0
+      vertex -54.8 -50.8 0
+      vertex -44.8016 -23.947 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -42.2387 -28.223 0
+      vertex -54.8 -50.8 0
+      vertex -43.5726 -26.1164 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -40.8029 -30.2615 0
+      vertex -54.8 -50.8 0
+      vertex -42.2387 -28.223 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -39.2689 -32.2272 0
+      vertex -54.8 -50.8 0
+      vertex -40.8029 -30.2615 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -37.6403 -34.1152 0
+      vertex -54.8 -50.8 0
+      vertex -39.2689 -32.2272 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -35.921 -35.921 0
+      vertex -54.8 -50.8 0
+      vertex -37.6403 -34.1152 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -34.1152 -37.6403 0
+      vertex -54.8 -50.8 0
+      vertex -35.921 -35.921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.7388 2.49264 0
+      vertex 54.8 50.8 0
+      vertex 50.8 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.5554 4.97927 0
+      vertex 54.8 50.8 0
+      vertex 50.7388 2.49264 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.2502 7.45391 0
+      vertex 54.8 50.8 0
+      vertex 50.5554 4.97927 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.8239 9.91059 0
+      vertex 54.8 50.8 0
+      vertex 50.2502 7.45391 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.2776 12.3434 0
+      vertex 54.8 50.8 0
+      vertex 49.8239 9.91059 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 48.6126 14.7465 0
+      vertex 54.8 50.8 0
+      vertex 49.2776 12.3434 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.8304 17.114 0
+      vertex 54.8 50.8 0
+      vertex 48.6126 14.7465 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 46.9331 19.4403 0
+      vertex 54.8 50.8 0
+      vertex 47.8304 17.114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 45.9227 21.7198 0
+      vertex 54.8 50.8 0
+      vertex 46.9331 19.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 44.8016 23.947 0
+      vertex 54.8 50.8 0
+      vertex 45.9227 21.7198 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 43.5726 26.1164 0
+      vertex 54.8 50.8 0
+      vertex 44.8016 23.947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 42.2387 28.223 0
+      vertex 54.8 50.8 0
+      vertex 43.5726 26.1164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40.8029 30.2615 0
+      vertex 54.8 50.8 0
+      vertex 42.2387 28.223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 39.2689 32.2272 0
+      vertex 54.8 50.8 0
+      vertex 40.8029 30.2615 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 37.6403 34.1152 0
+      vertex 54.8 50.8 0
+      vertex 39.2689 32.2272 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.921 35.921 0
+      vertex 54.8 50.8 0
+      vertex 37.6403 34.1152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34.1152 37.6403 0
+      vertex 54.8 50.8 0
+      vertex 35.921 35.921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.2272 39.2689 0
+      vertex 54.8 50.8 0
+      vertex 34.1152 37.6403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.2615 40.8029 0
+      vertex 54.8 50.8 0
+      vertex 32.2272 39.2689 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.223 42.2387 0
+      vertex 54.8 50.8 0
+      vertex 30.2615 40.8029 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 28.223 42.2387 0
+      vertex 26.1164 43.5726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 26.1164 43.5726 0
+      vertex 23.947 44.8016 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 23.947 44.8016 0
+      vertex 21.7198 45.9227 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.223 42.2387 0
+      vertex 20.5267 50.8 0
+      vertex 54.8 50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.4403 46.9331 0
+      vertex 20.5267 50.8 0
+      vertex 21.7198 45.9227 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.114 47.8304 0
+      vertex 20.5267 50.8 0
+      vertex 19.4403 46.9331 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 17.114 47.8304 0
+      vertex 18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.114 47.8304 0
+      vertex 15.9076 52.4403 0
+      vertex 18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7465 48.6126 0
+      vertex 15.9076 52.4403 0
+      vertex 17.114 47.8304 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7465 48.6126 0
+      vertex 13.3153 53.1577 0
+      vertex 15.9076 52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.3434 49.2776 0
+      vertex 13.3153 53.1577 0
+      vertex 14.7465 48.6126 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.3434 49.2776 0
+      vertex 10.6909 53.747 0
+      vertex 13.3153 53.1577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.91059 49.8239 0
+      vertex 10.6909 53.747 0
+      vertex 12.3434 49.2776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.91059 49.8239 0
+      vertex 8.04083 54.2069 0
+      vertex 10.6909 53.747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.45391 50.2502 0
+      vertex 8.04083 54.2069 0
+      vertex 9.91059 49.8239 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.45391 50.2502 0
+      vertex 5.37134 54.5361 0
+      vertex 8.04083 54.2069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.97927 50.5554 0
+      vertex 5.37134 54.5361 0
+      vertex 7.45391 50.2502 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.97927 50.5554 0
+      vertex 2.68891 54.734 0
+      vertex 5.37134 54.5361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.49264 50.7388 0
+      vertex 2.68891 54.734 0
+      vertex 4.97927 50.5554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 50.8 0
+      vertex 2.68891 54.734 0
+      vertex 2.49264 50.7388 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 50.8 0
+      vertex 0 54.8 0
+      vertex 2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.49264 50.7388 0
+      vertex 0 54.8 0
+      vertex 0 50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.49264 50.7388 0
+      vertex -2.68891 54.734 0
+      vertex 0 54.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.97927 50.5554 0
+      vertex -2.68891 54.734 0
+      vertex -2.49264 50.7388 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.97927 50.5554 0
+      vertex -5.37134 54.5361 0
+      vertex -2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.45391 50.2502 0
+      vertex -5.37134 54.5361 0
+      vertex -4.97927 50.5554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.45391 50.2502 0
+      vertex -8.04083 54.2069 0
+      vertex -5.37134 54.5361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.91059 49.8239 0
+      vertex -8.04083 54.2069 0
+      vertex -7.45391 50.2502 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.91059 49.8239 0
+      vertex -10.6909 53.747 0
+      vertex -8.04083 54.2069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3434 49.2776 0
+      vertex -10.6909 53.747 0
+      vertex -9.91059 49.8239 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3434 49.2776 0
+      vertex -13.3153 53.1577 0
+      vertex -10.6909 53.747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7465 48.6126 0
+      vertex -13.3153 53.1577 0
+      vertex -12.3434 49.2776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7465 48.6126 0
+      vertex -15.9076 52.4403 0
+      vertex -13.3153 53.1577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.114 47.8304 0
+      vertex -15.9076 52.4403 0
+      vertex -14.7465 48.6126 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.114 47.8304 0
+      vertex -18.4616 51.5966 0
+      vertex -15.9076 52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 50.8 0
+      vertex -17.114 47.8304 0
+      vertex -19.4403 46.9331 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.114 47.8304 0
+      vertex -20.5267 50.8 0
+      vertex -18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.7198 45.9227 0
+      vertex -20.5267 50.8 0
+      vertex -19.4403 46.9331 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.947 44.8016 0
+      vertex -20.5267 50.8 0
+      vertex -21.7198 45.9227 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1164 43.5726 0
+      vertex -20.5267 50.8 0
+      vertex -23.947 44.8016 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.223 42.2387 0
+      vertex -20.5267 50.8 0
+      vertex -26.1164 43.5726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -28.223 42.2387 0
+      vertex -30.2615 40.8029 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -30.2615 40.8029 0
+      vertex -32.2272 39.2689 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -32.2272 39.2689 0
+      vertex -34.1152 37.6403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -34.1152 37.6403 0
+      vertex -35.921 35.921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -50.8 0 0
+      vertex -54.8 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.8 0 0
+      vertex -54.8 50.8 0
+      vertex -50.7388 2.49264 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.223 42.2387 0
+      vertex -54.8 50.8 0
+      vertex -20.5267 50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -37.6403 34.1152 0
+      vertex -54.8 50.8 0
+      vertex -35.921 35.921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -39.2689 32.2272 0
+      vertex -54.8 50.8 0
+      vertex -37.6403 34.1152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -40.8029 30.2615 0
+      vertex -54.8 50.8 0
+      vertex -39.2689 32.2272 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -42.2387 28.223 0
+      vertex -54.8 50.8 0
+      vertex -40.8029 30.2615 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -43.5726 26.1164 0
+      vertex -54.8 50.8 0
+      vertex -42.2387 28.223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.8016 23.947 0
+      vertex -54.8 50.8 0
+      vertex -43.5726 26.1164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -45.9227 21.7198 0
+      vertex -54.8 50.8 0
+      vertex -44.8016 23.947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -46.9331 19.4403 0
+      vertex -54.8 50.8 0
+      vertex -45.9227 21.7198 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -47.8304 17.114 0
+      vertex -54.8 50.8 0
+      vertex -46.9331 19.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -48.6126 14.7465 0
+      vertex -54.8 50.8 0
+      vertex -47.8304 17.114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -49.2776 12.3434 0
+      vertex -54.8 50.8 0
+      vertex -48.6126 14.7465 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -49.8239 9.91059 0
+      vertex -54.8 50.8 0
+      vertex -49.2776 12.3434 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.2502 7.45391 0
+      vertex -54.8 50.8 0
+      vertex -49.8239 9.91059 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.5554 4.97927 0
+      vertex -54.8 50.8 0
+      vertex -50.2502 7.45391 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.7388 2.49264 0
+      vertex -54.8 50.8 0
+      vertex -50.5554 4.97927 0
+    endloop
+  endfacet
+  facet normal -0.219091 -0.975704 0
+    outer loop
+      vertex -13.3153 -53.1577 0
+      vertex -10.6909 -53.747 20
+      vertex -13.3153 -53.1577 20
+    endloop
+  endfacet
+  facet normal -0.219091 -0.975704 -0
+    outer loop
+      vertex -10.6909 -53.747 20
+      vertex -13.3153 -53.1577 0
+      vertex -10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal 0.170987 0.985273 -0
+    outer loop
+      vertex 10.6909 53.747 0
+      vertex 8.04083 54.2069 20
+      vertex 10.6909 53.747 20
+    endloop
+  endfacet
+  facet normal 0.170987 0.985273 0
+    outer loop
+      vertex 8.04083 54.2069 20
+      vertex 10.6909 53.747 0
+      vertex 8.04083 54.2069 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 54.8 50.8 0
+      vertex 54.8 50.8 20
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 54.8 -10.4701 20
+      vertex 54.8 50.8 0
+      vertex 54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 54.8 -10.4701 20
+      vertex 54.8 -50.8 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 54.8 -10.4701 20
+      vertex 54.8 -50.8 0
+      vertex 54.8 50.8 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -23.8576 50.4426 20
+      vertex -23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -26.3039 49.2112 20
+      vertex -23.8576 50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -28.6869 47.8613 20
+      vertex -26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -31.0008 46.396 20
+      vertex -28.6869 47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -33.24 44.819 20
+      vertex -31.0008 46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -35.3991 43.134 20
+      vertex -33.24 44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -37.473 41.3451 20
+      vertex -35.3991 43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -39.4566 39.4566 20
+      vertex -37.473 41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -41.3451 37.473 20
+      vertex -39.4566 39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -43.134 35.3991 20
+      vertex -41.3451 37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -44.819 33.24 20
+      vertex -43.134 35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -46.396 31.0008 20
+      vertex -44.819 33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -47.8613 28.6869 20
+      vertex -46.396 31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -49.2112 26.3039 20
+      vertex -47.8613 28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -50.4426 23.8576 20
+      vertex -49.2112 26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -51.5525 21.3537 20
+      vertex -50.4426 23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -52.5382 18.7985 20
+      vertex -51.5525 21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -53.3973 16.1979 20
+      vertex -52.5382 18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -54.1277 13.5583 20
+      vertex -53.3973 16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -54.7278 10.886 20
+      vertex -54.1277 13.5583 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.7278 10.886 20
+      vertex -54.8 50.8 20
+      vertex -54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 54.7278 10.886 20
+      vertex 54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 54.1277 13.5583 20
+      vertex 54.7278 10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 53.3973 16.1979 20
+      vertex 54.1277 13.5583 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 52.5382 18.7985 20
+      vertex 53.3973 16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 51.5525 21.3537 20
+      vertex 52.5382 18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 50.4426 23.8576 20
+      vertex 51.5525 21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 49.2112 26.3039 20
+      vertex 50.4426 23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 47.8613 28.6869 20
+      vertex 49.2112 26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 46.396 31.0008 20
+      vertex 47.8613 28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 44.819 33.24 20
+      vertex 46.396 31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 43.134 35.3991 20
+      vertex 44.819 33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 41.3451 37.473 20
+      vertex 43.134 35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 39.4566 39.4566 20
+      vertex 41.3451 37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 37.473 41.3451 20
+      vertex 39.4566 39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 35.3991 43.134 20
+      vertex 37.473 41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 33.24 44.819 20
+      vertex 35.3991 43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 31.0008 46.396 20
+      vertex 33.24 44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 28.6869 47.8613 20
+      vertex 31.0008 46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 26.3039 49.2112 20
+      vertex 28.6869 47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 23.8576 50.4426 20
+      vertex 26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 23.8576 50.4426 20
+      vertex 54.8 50.8 20
+      vertex 23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.8576 -50.4426 20
+      vertex -54.8 -50.8 20
+      vertex -23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.3039 -49.2112 20
+      vertex -54.8 -50.8 20
+      vertex -23.8576 -50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.6869 -47.8613 20
+      vertex -54.8 -50.8 20
+      vertex -26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.0008 -46.396 20
+      vertex -54.8 -50.8 20
+      vertex -28.6869 -47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.24 -44.819 20
+      vertex -54.8 -50.8 20
+      vertex -31.0008 -46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.3991 -43.134 20
+      vertex -54.8 -50.8 20
+      vertex -33.24 -44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.473 -41.3451 20
+      vertex -54.8 -50.8 20
+      vertex -35.3991 -43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -39.4566 -39.4566 20
+      vertex -54.8 -50.8 20
+      vertex -37.473 -41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.3451 -37.473 20
+      vertex -54.8 -50.8 20
+      vertex -39.4566 -39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.134 -35.3991 20
+      vertex -54.8 -50.8 20
+      vertex -41.3451 -37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.819 -33.24 20
+      vertex -54.8 -50.8 20
+      vertex -43.134 -35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.396 -31.0008 20
+      vertex -54.8 -50.8 20
+      vertex -44.819 -33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.8613 -28.6869 20
+      vertex -54.8 -50.8 20
+      vertex -46.396 -31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.2112 -26.3039 20
+      vertex -54.8 -50.8 20
+      vertex -47.8613 -28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.4426 -23.8576 20
+      vertex -54.8 -50.8 20
+      vertex -49.2112 -26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -51.5525 -21.3537 20
+      vertex -54.8 -50.8 20
+      vertex -50.4426 -23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -52.5382 -18.7985 20
+      vertex -54.8 -50.8 20
+      vertex -51.5525 -21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -53.3973 -16.1979 20
+      vertex -54.8 -50.8 20
+      vertex -52.5382 -18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.1277 -13.5583 20
+      vertex -54.8 -50.8 20
+      vertex -53.3973 -16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.7278 -10.886 20
+      vertex -54.8 -50.8 20
+      vertex -54.1277 -13.5583 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -50.8 20
+      vertex -54.7278 -10.886 20
+      vertex -54.8 -10.4701 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 54.7278 -10.886 20
+      vertex 54.8 -50.8 20
+      vertex 54.8 -10.4701 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 54.1277 -13.5583 20
+      vertex 54.8 -50.8 20
+      vertex 54.7278 -10.886 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 53.3973 -16.1979 20
+      vertex 54.8 -50.8 20
+      vertex 54.1277 -13.5583 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 52.5382 -18.7985 20
+      vertex 54.8 -50.8 20
+      vertex 53.3973 -16.1979 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 51.5525 -21.3537 20
+      vertex 54.8 -50.8 20
+      vertex 52.5382 -18.7985 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 50.4426 -23.8576 20
+      vertex 54.8 -50.8 20
+      vertex 51.5525 -21.3537 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 49.2112 -26.3039 20
+      vertex 54.8 -50.8 20
+      vertex 50.4426 -23.8576 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 47.8613 -28.6869 20
+      vertex 54.8 -50.8 20
+      vertex 49.2112 -26.3039 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 46.396 -31.0008 20
+      vertex 54.8 -50.8 20
+      vertex 47.8613 -28.6869 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 44.819 -33.24 20
+      vertex 54.8 -50.8 20
+      vertex 46.396 -31.0008 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 43.134 -35.3991 20
+      vertex 54.8 -50.8 20
+      vertex 44.819 -33.24 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 41.3451 -37.473 20
+      vertex 54.8 -50.8 20
+      vertex 43.134 -35.3991 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 39.4566 -39.4566 20
+      vertex 54.8 -50.8 20
+      vertex 41.3451 -37.473 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 37.473 -41.3451 20
+      vertex 54.8 -50.8 20
+      vertex 39.4566 -39.4566 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35.3991 -43.134 20
+      vertex 54.8 -50.8 20
+      vertex 37.473 -41.3451 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 33.24 -44.819 20
+      vertex 54.8 -50.8 20
+      vertex 35.3991 -43.134 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 31.0008 -46.396 20
+      vertex 54.8 -50.8 20
+      vertex 33.24 -44.819 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 28.6869 -47.8613 20
+      vertex 54.8 -50.8 20
+      vertex 31.0008 -46.396 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.3039 -49.2112 20
+      vertex 54.8 -50.8 20
+      vertex 28.6869 -47.8613 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.8576 -50.4426 20
+      vertex 54.8 -50.8 20
+      vertex 26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 -50.8 20
+      vertex 23.8576 -50.4426 20
+      vertex 23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.8239 9.91059 20
+      vertex 54.8 10.4701 20
+      vertex 54.7278 10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 50.8 0 20
+      vertex 54.8 -10.4701 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.8239 9.91059 20
+      vertex 54.7278 10.886 20
+      vertex 54.1277 13.5583 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 50.7388 -2.49264 20
+      vertex 54.8 -10.4701 20
+      vertex 50.8 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.2776 12.3434 20
+      vertex 54.1277 13.5583 20
+      vertex 53.3973 16.1979 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 50.5554 -4.97927 20
+      vertex 54.8 -10.4701 20
+      vertex 50.7388 -2.49264 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.6126 14.7465 20
+      vertex 53.3973 16.1979 20
+      vertex 52.5382 18.7985 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 50.2502 -7.45391 20
+      vertex 54.8 -10.4701 20
+      vertex 50.5554 -4.97927 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 47.8304 17.114 20
+      vertex 52.5382 18.7985 20
+      vertex 51.5525 21.3537 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 49.8239 -9.91059 20
+      vertex 54.8 -10.4701 20
+      vertex 50.2502 -7.45391 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 -10.4701 20
+      vertex 49.8239 -9.91059 20
+      vertex 54.7278 -10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 50.7388 2.49264 20
+      vertex 50.8 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 50.5554 4.97927 20
+      vertex 50.7388 2.49264 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 46.9331 19.4403 20
+      vertex 51.5525 21.3537 20
+      vertex 50.4426 23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 50.2502 7.45391 20
+      vertex 50.5554 4.97927 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 49.8239 9.91059 20
+      vertex 50.2502 7.45391 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.1277 13.5583 20
+      vertex 49.2776 12.3434 20
+      vertex 49.8239 9.91059 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.9227 21.7198 20
+      vertex 50.4426 23.8576 20
+      vertex 49.2112 26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 53.3973 16.1979 20
+      vertex 48.6126 14.7465 20
+      vertex 49.2776 12.3434 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 44.8016 23.947 20
+      vertex 49.2112 26.3039 20
+      vertex 47.8613 28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 52.5382 18.7985 20
+      vertex 47.8304 17.114 20
+      vertex 48.6126 14.7465 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.5525 21.3537 20
+      vertex 46.9331 19.4403 20
+      vertex 47.8304 17.114 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.5726 26.1164 20
+      vertex 47.8613 28.6869 20
+      vertex 46.396 31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 50.4426 23.8576 20
+      vertex 45.9227 21.7198 20
+      vertex 46.9331 19.4403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.2387 28.223 20
+      vertex 46.396 31.0008 20
+      vertex 44.819 33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.2112 26.3039 20
+      vertex 44.8016 23.947 20
+      vertex 45.9227 21.7198 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 47.8613 28.6869 20
+      vertex 43.5726 26.1164 20
+      vertex 44.8016 23.947 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.8029 30.2615 20
+      vertex 44.819 33.24 20
+      vertex 43.134 35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 46.396 31.0008 20
+      vertex 42.2387 28.223 20
+      vertex 43.5726 26.1164 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.2689 32.2272 20
+      vertex 43.134 35.3991 20
+      vertex 41.3451 37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 44.819 33.24 20
+      vertex 40.8029 30.2615 20
+      vertex 42.2387 28.223 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 37.6403 34.1152 20
+      vertex 41.3451 37.473 20
+      vertex 39.4566 39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.134 35.3991 20
+      vertex 39.2689 32.2272 20
+      vertex 40.8029 30.2615 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.3451 37.473 20
+      vertex 37.6403 34.1152 20
+      vertex 39.2689 32.2272 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.921 35.921 20
+      vertex 39.4566 39.4566 20
+      vertex 37.473 41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.4566 39.4566 20
+      vertex 35.921 35.921 20
+      vertex 37.6403 34.1152 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.1152 37.6403 20
+      vertex 37.473 41.3451 20
+      vertex 35.3991 43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 37.473 41.3451 20
+      vertex 34.1152 37.6403 20
+      vertex 35.921 35.921 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 32.2272 39.2689 20
+      vertex 35.3991 43.134 20
+      vertex 33.24 44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.3991 43.134 20
+      vertex 32.2272 39.2689 20
+      vertex 34.1152 37.6403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.2615 40.8029 20
+      vertex 33.24 44.819 20
+      vertex 31.0008 46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.24 44.819 20
+      vertex 30.2615 40.8029 20
+      vertex 32.2272 39.2689 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.223 42.2387 20
+      vertex 31.0008 46.396 20
+      vertex 28.6869 47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.0008 46.396 20
+      vertex 28.223 42.2387 20
+      vertex 30.2615 40.8029 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.1164 43.5726 20
+      vertex 28.6869 47.8613 20
+      vertex 26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.6869 47.8613 20
+      vertex 26.1164 43.5726 20
+      vertex 28.223 42.2387 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.3039 49.2112 20
+      vertex 23.947 44.8016 20
+      vertex 26.1164 43.5726 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.8576 50.4426 20
+      vertex 23.947 44.8016 20
+      vertex 26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.7198 45.9227 20
+      vertex 23.8576 50.4426 20
+      vertex 23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.8576 50.4426 20
+      vertex 21.7198 45.9227 20
+      vertex 23.947 44.8016 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.5267 50.8 20
+      vertex 21.7198 45.9227 20
+      vertex 23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5267 50.8 20
+      vertex 19.4403 46.9331 20
+      vertex 21.7198 45.9227 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.114 47.8304 20
+      vertex 20.5267 50.8 20
+      vertex 18.4616 51.5966 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5267 50.8 20
+      vertex 17.114 47.8304 20
+      vertex 19.4403 46.9331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.9076 52.4403 20
+      vertex 17.114 47.8304 20
+      vertex 18.4616 51.5966 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.9076 52.4403 20
+      vertex 14.7465 48.6126 20
+      vertex 17.114 47.8304 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.3153 53.1577 20
+      vertex 14.7465 48.6126 20
+      vertex 15.9076 52.4403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.3153 53.1577 20
+      vertex 12.3434 49.2776 20
+      vertex 14.7465 48.6126 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6909 53.747 20
+      vertex 12.3434 49.2776 20
+      vertex 13.3153 53.1577 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6909 53.747 20
+      vertex 9.91059 49.8239 20
+      vertex 12.3434 49.2776 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.04083 54.2069 20
+      vertex 9.91059 49.8239 20
+      vertex 10.6909 53.747 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.04083 54.2069 20
+      vertex 7.45391 50.2502 20
+      vertex 9.91059 49.8239 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.37134 54.5361 20
+      vertex 7.45391 50.2502 20
+      vertex 8.04083 54.2069 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.37134 54.5361 20
+      vertex 4.97927 50.5554 20
+      vertex 7.45391 50.2502 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.68891 54.734 20
+      vertex 4.97927 50.5554 20
+      vertex 5.37134 54.5361 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.68891 54.734 20
+      vertex 2.49264 50.7388 20
+      vertex 4.97927 50.5554 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 54.8 20
+      vertex 2.49264 50.7388 20
+      vertex 2.68891 54.734 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 54.8 20
+      vertex 0 50.8 20
+      vertex 2.49264 50.7388 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 54.8 20
+      vertex -2.49264 50.7388 20
+      vertex 0 50.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.68891 54.734 20
+      vertex -2.49264 50.7388 20
+      vertex 0 54.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.68891 54.734 20
+      vertex -4.97927 50.5554 20
+      vertex -2.49264 50.7388 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.37134 54.5361 20
+      vertex -4.97927 50.5554 20
+      vertex -2.68891 54.734 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.37134 54.5361 20
+      vertex -7.45391 50.2502 20
+      vertex -4.97927 50.5554 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8.04083 54.2069 20
+      vertex -7.45391 50.2502 20
+      vertex -5.37134 54.5361 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.04083 54.2069 20
+      vertex -9.91059 49.8239 20
+      vertex -7.45391 50.2502 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.6909 53.747 20
+      vertex -9.91059 49.8239 20
+      vertex -8.04083 54.2069 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6909 53.747 20
+      vertex -12.3434 49.2776 20
+      vertex -9.91059 49.8239 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.3153 53.1577 20
+      vertex -12.3434 49.2776 20
+      vertex -10.6909 53.747 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.3153 53.1577 20
+      vertex -14.7465 48.6126 20
+      vertex -12.3434 49.2776 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.9076 52.4403 20
+      vertex -14.7465 48.6126 20
+      vertex -13.3153 53.1577 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.9076 52.4403 20
+      vertex -17.114 47.8304 20
+      vertex -14.7465 48.6126 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.4616 51.5966 20
+      vertex -17.114 47.8304 20
+      vertex -15.9076 52.4403 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.5267 50.8 20
+      vertex -17.114 47.8304 20
+      vertex -18.4616 51.5966 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.114 47.8304 20
+      vertex -20.5267 50.8 20
+      vertex -19.4403 46.9331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5267 50.8 20
+      vertex -21.7198 45.9227 20
+      vertex -19.4403 46.9331 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.0513 50.8 20
+      vertex -21.7198 45.9227 20
+      vertex -20.5267 50.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.8576 50.4426 20
+      vertex -21.7198 45.9227 20
+      vertex -23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.8576 50.4426 20
+      vertex -23.947 44.8016 20
+      vertex -21.7198 45.9227 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.3039 49.2112 20
+      vertex -23.947 44.8016 20
+      vertex -23.8576 50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.947 44.8016 20
+      vertex -26.3039 49.2112 20
+      vertex -26.1164 43.5726 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.6869 47.8613 20
+      vertex -26.1164 43.5726 20
+      vertex -26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1164 43.5726 20
+      vertex -28.6869 47.8613 20
+      vertex -28.223 42.2387 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.0008 46.396 20
+      vertex -28.223 42.2387 20
+      vertex -28.6869 47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.223 42.2387 20
+      vertex -31.0008 46.396 20
+      vertex -30.2615 40.8029 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -33.24 44.819 20
+      vertex -30.2615 40.8029 20
+      vertex -31.0008 46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.2615 40.8029 20
+      vertex -33.24 44.819 20
+      vertex -32.2272 39.2689 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.3991 43.134 20
+      vertex -32.2272 39.2689 20
+      vertex -33.24 44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -32.2272 39.2689 20
+      vertex -35.3991 43.134 20
+      vertex -34.1152 37.6403 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -37.473 41.3451 20
+      vertex -34.1152 37.6403 20
+      vertex -35.3991 43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.1152 37.6403 20
+      vertex -37.473 41.3451 20
+      vertex -35.921 35.921 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -39.4566 39.4566 20
+      vertex -35.921 35.921 20
+      vertex -37.473 41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.921 35.921 20
+      vertex -39.4566 39.4566 20
+      vertex -37.6403 34.1152 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -41.3451 37.473 20
+      vertex -37.6403 34.1152 20
+      vertex -39.4566 39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.6403 34.1152 20
+      vertex -41.3451 37.473 20
+      vertex -39.2689 32.2272 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -43.134 35.3991 20
+      vertex -39.2689 32.2272 20
+      vertex -41.3451 37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -39.2689 32.2272 20
+      vertex -43.134 35.3991 20
+      vertex -40.8029 30.2615 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -44.819 33.24 20
+      vertex -40.8029 30.2615 20
+      vertex -43.134 35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -40.8029 30.2615 20
+      vertex -44.819 33.24 20
+      vertex -42.2387 28.223 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -46.396 31.0008 20
+      vertex -42.2387 28.223 20
+      vertex -44.819 33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -42.2387 28.223 20
+      vertex -46.396 31.0008 20
+      vertex -43.5726 26.1164 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -47.8613 28.6869 20
+      vertex -43.5726 26.1164 20
+      vertex -46.396 31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.5726 26.1164 20
+      vertex -47.8613 28.6869 20
+      vertex -44.8016 23.947 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -49.2112 26.3039 20
+      vertex -44.8016 23.947 20
+      vertex -47.8613 28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.8016 23.947 20
+      vertex -49.2112 26.3039 20
+      vertex -45.9227 21.7198 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -50.4426 23.8576 20
+      vertex -45.9227 21.7198 20
+      vertex -49.2112 26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -45.9227 21.7198 20
+      vertex -50.4426 23.8576 20
+      vertex -46.9331 19.4403 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -51.5525 21.3537 20
+      vertex -46.9331 19.4403 20
+      vertex -50.4426 23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.9331 19.4403 20
+      vertex -51.5525 21.3537 20
+      vertex -47.8304 17.114 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -52.5382 18.7985 20
+      vertex -47.8304 17.114 20
+      vertex -51.5525 21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.8304 17.114 20
+      vertex -52.5382 18.7985 20
+      vertex -48.6126 14.7465 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -53.3973 16.1979 20
+      vertex -48.6126 14.7465 20
+      vertex -52.5382 18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.6126 14.7465 20
+      vertex -53.3973 16.1979 20
+      vertex -49.2776 12.3434 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -54.1277 13.5583 20
+      vertex -49.2776 12.3434 20
+      vertex -53.3973 16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.2776 12.3434 20
+      vertex -54.1277 13.5583 20
+      vertex -49.8239 9.91059 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -54.7278 10.886 20
+      vertex -49.8239 9.91059 20
+      vertex -54.1277 13.5583 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.7278 -10.886 20
+      vertex 49.8239 -9.91059 20
+      vertex 54.1277 -13.5583 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 49.2776 -12.3434 20
+      vertex 54.1277 -13.5583 20
+      vertex 49.8239 -9.91059 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.1277 -13.5583 20
+      vertex 49.2776 -12.3434 20
+      vertex 53.3973 -16.1979 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 48.6126 -14.7465 20
+      vertex 53.3973 -16.1979 20
+      vertex 49.2776 -12.3434 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 53.3973 -16.1979 20
+      vertex 48.6126 -14.7465 20
+      vertex 52.5382 -18.7985 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 47.8304 -17.114 20
+      vertex 52.5382 -18.7985 20
+      vertex 48.6126 -14.7465 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 52.5382 -18.7985 20
+      vertex 47.8304 -17.114 20
+      vertex 51.5525 -21.3537 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 46.9331 -19.4403 20
+      vertex 51.5525 -21.3537 20
+      vertex 47.8304 -17.114 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.5525 -21.3537 20
+      vertex 46.9331 -19.4403 20
+      vertex 50.4426 -23.8576 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 45.9227 -21.7198 20
+      vertex 50.4426 -23.8576 20
+      vertex 46.9331 -19.4403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 50.4426 -23.8576 20
+      vertex 45.9227 -21.7198 20
+      vertex 49.2112 -26.3039 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 44.8016 -23.947 20
+      vertex 49.2112 -26.3039 20
+      vertex 45.9227 -21.7198 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.2112 -26.3039 20
+      vertex 44.8016 -23.947 20
+      vertex 47.8613 -28.6869 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 43.5726 -26.1164 20
+      vertex 47.8613 -28.6869 20
+      vertex 44.8016 -23.947 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 47.8613 -28.6869 20
+      vertex 43.5726 -26.1164 20
+      vertex 46.396 -31.0008 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.2387 -28.223 20
+      vertex 46.396 -31.0008 20
+      vertex 43.5726 -26.1164 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 46.396 -31.0008 20
+      vertex 42.2387 -28.223 20
+      vertex 44.819 -33.24 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 40.8029 -30.2615 20
+      vertex 44.819 -33.24 20
+      vertex 42.2387 -28.223 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 44.819 -33.24 20
+      vertex 40.8029 -30.2615 20
+      vertex 43.134 -35.3991 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 39.2689 -32.2272 20
+      vertex 43.134 -35.3991 20
+      vertex 40.8029 -30.2615 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.134 -35.3991 20
+      vertex 39.2689 -32.2272 20
+      vertex 41.3451 -37.473 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 37.6403 -34.1152 20
+      vertex 41.3451 -37.473 20
+      vertex 39.2689 -32.2272 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.3451 -37.473 20
+      vertex 37.6403 -34.1152 20
+      vertex 39.4566 -39.4566 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35.921 -35.921 20
+      vertex 39.4566 -39.4566 20
+      vertex 37.6403 -34.1152 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.4566 -39.4566 20
+      vertex 35.921 -35.921 20
+      vertex 37.473 -41.3451 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 34.1152 -37.6403 20
+      vertex 37.473 -41.3451 20
+      vertex 35.921 -35.921 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 37.473 -41.3451 20
+      vertex 34.1152 -37.6403 20
+      vertex 35.3991 -43.134 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 32.2272 -39.2689 20
+      vertex 35.3991 -43.134 20
+      vertex 34.1152 -37.6403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.3991 -43.134 20
+      vertex 32.2272 -39.2689 20
+      vertex 33.24 -44.819 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 30.2615 -40.8029 20
+      vertex 33.24 -44.819 20
+      vertex 32.2272 -39.2689 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.24 -44.819 20
+      vertex 30.2615 -40.8029 20
+      vertex 31.0008 -46.396 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 28.223 -42.2387 20
+      vertex 31.0008 -46.396 20
+      vertex 30.2615 -40.8029 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.0008 -46.396 20
+      vertex 28.223 -42.2387 20
+      vertex 28.6869 -47.8613 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.1164 -43.5726 20
+      vertex 28.6869 -47.8613 20
+      vertex 28.223 -42.2387 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.6869 -47.8613 20
+      vertex 26.1164 -43.5726 20
+      vertex 26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.947 -44.8016 20
+      vertex 26.3039 -49.2112 20
+      vertex 26.1164 -43.5726 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.947 -44.8016 20
+      vertex 23.8576 -50.4426 20
+      vertex 26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.7198 -45.9227 20
+      vertex 23.8576 -50.4426 20
+      vertex 23.947 -44.8016 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.8576 -50.4426 20
+      vertex 21.7198 -45.9227 20
+      vertex 23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.7198 -45.9227 20
+      vertex 20.5267 -50.8 20
+      vertex 23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.4403 -46.9331 20
+      vertex 20.5267 -50.8 20
+      vertex 21.7198 -45.9227 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.114 -47.8304 20
+      vertex 20.5267 -50.8 20
+      vertex 19.4403 -46.9331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5267 -50.8 20
+      vertex 17.114 -47.8304 20
+      vertex 18.4616 -51.5966 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.114 -47.8304 20
+      vertex 15.9076 -52.4403 20
+      vertex 18.4616 -51.5966 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.7465 -48.6126 20
+      vertex 15.9076 -52.4403 20
+      vertex 17.114 -47.8304 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.7465 -48.6126 20
+      vertex 13.3153 -53.1577 20
+      vertex 15.9076 -52.4403 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.3434 -49.2776 20
+      vertex 13.3153 -53.1577 20
+      vertex 14.7465 -48.6126 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3434 -49.2776 20
+      vertex 10.6909 -53.747 20
+      vertex 13.3153 -53.1577 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.91059 -49.8239 20
+      vertex 10.6909 -53.747 20
+      vertex 12.3434 -49.2776 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.91059 -49.8239 20
+      vertex 8.04083 -54.2069 20
+      vertex 10.6909 -53.747 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.45391 -50.2502 20
+      vertex 8.04083 -54.2069 20
+      vertex 9.91059 -49.8239 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.45391 -50.2502 20
+      vertex 5.37134 -54.5361 20
+      vertex 8.04083 -54.2069 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.97927 -50.5554 20
+      vertex 5.37134 -54.5361 20
+      vertex 7.45391 -50.2502 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.97927 -50.5554 20
+      vertex 2.68891 -54.734 20
+      vertex 5.37134 -54.5361 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.49264 -50.7388 20
+      vertex 2.68891 -54.734 20
+      vertex 4.97927 -50.5554 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -50.8 20
+      vertex 2.68891 -54.734 20
+      vertex 2.49264 -50.7388 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -50.8 20
+      vertex 0 -54.8 20
+      vertex 2.68891 -54.734 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.49264 -50.7388 20
+      vertex 0 -54.8 20
+      vertex 0 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.49264 -50.7388 20
+      vertex -2.68891 -54.734 20
+      vertex 0 -54.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.97927 -50.5554 20
+      vertex -2.68891 -54.734 20
+      vertex -2.49264 -50.7388 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.97927 -50.5554 20
+      vertex -5.37134 -54.5361 20
+      vertex -2.68891 -54.734 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.45391 -50.2502 20
+      vertex -5.37134 -54.5361 20
+      vertex -4.97927 -50.5554 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.45391 -50.2502 20
+      vertex -8.04083 -54.2069 20
+      vertex -5.37134 -54.5361 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.91059 -49.8239 20
+      vertex -8.04083 -54.2069 20
+      vertex -7.45391 -50.2502 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.91059 -49.8239 20
+      vertex -10.6909 -53.747 20
+      vertex -8.04083 -54.2069 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3434 -49.2776 20
+      vertex -10.6909 -53.747 20
+      vertex -9.91059 -49.8239 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3434 -49.2776 20
+      vertex -13.3153 -53.1577 20
+      vertex -10.6909 -53.747 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.7465 -48.6126 20
+      vertex -13.3153 -53.1577 20
+      vertex -12.3434 -49.2776 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.7465 -48.6126 20
+      vertex -15.9076 -52.4403 20
+      vertex -13.3153 -53.1577 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.114 -47.8304 20
+      vertex -15.9076 -52.4403 20
+      vertex -14.7465 -48.6126 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.114 -47.8304 20
+      vertex -18.4616 -51.5966 20
+      vertex -15.9076 -52.4403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5267 -50.8 20
+      vertex -17.114 -47.8304 20
+      vertex -19.4403 -46.9331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.114 -47.8304 20
+      vertex -20.5267 -50.8 20
+      vertex -18.4616 -51.5966 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7198 -45.9227 20
+      vertex -20.5267 -50.8 20
+      vertex -19.4403 -46.9331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7198 -45.9227 20
+      vertex -23.0513 -50.8 20
+      vertex -20.5267 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7198 -45.9227 20
+      vertex -23.8576 -50.4426 20
+      vertex -23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.947 -44.8016 20
+      vertex -23.8576 -50.4426 20
+      vertex -21.7198 -45.9227 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.3039 -49.2112 20
+      vertex -23.947 -44.8016 20
+      vertex -26.1164 -43.5726 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.947 -44.8016 20
+      vertex -26.3039 -49.2112 20
+      vertex -23.8576 -50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.6869 -47.8613 20
+      vertex -26.1164 -43.5726 20
+      vertex -28.223 -42.2387 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1164 -43.5726 20
+      vertex -28.6869 -47.8613 20
+      vertex -26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.0008 -46.396 20
+      vertex -28.223 -42.2387 20
+      vertex -30.2615 -40.8029 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.223 -42.2387 20
+      vertex -31.0008 -46.396 20
+      vertex -28.6869 -47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.24 -44.819 20
+      vertex -30.2615 -40.8029 20
+      vertex -32.2272 -39.2689 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.2615 -40.8029 20
+      vertex -33.24 -44.819 20
+      vertex -31.0008 -46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.3991 -43.134 20
+      vertex -32.2272 -39.2689 20
+      vertex -34.1152 -37.6403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -32.2272 -39.2689 20
+      vertex -35.3991 -43.134 20
+      vertex -33.24 -44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.473 -41.3451 20
+      vertex -34.1152 -37.6403 20
+      vertex -35.921 -35.921 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.1152 -37.6403 20
+      vertex -37.473 -41.3451 20
+      vertex -35.3991 -43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -39.4566 -39.4566 20
+      vertex -35.921 -35.921 20
+      vertex -37.6403 -34.1152 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.3451 -37.473 20
+      vertex -37.6403 -34.1152 20
+      vertex -39.2689 -32.2272 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.921 -35.921 20
+      vertex -39.4566 -39.4566 20
+      vertex -37.473 -41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.134 -35.3991 20
+      vertex -39.2689 -32.2272 20
+      vertex -40.8029 -30.2615 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.6403 -34.1152 20
+      vertex -41.3451 -37.473 20
+      vertex -39.4566 -39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.819 -33.24 20
+      vertex -40.8029 -30.2615 20
+      vertex -42.2387 -28.223 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -39.2689 -32.2272 20
+      vertex -43.134 -35.3991 20
+      vertex -41.3451 -37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.396 -31.0008 20
+      vertex -42.2387 -28.223 20
+      vertex -43.5726 -26.1164 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.8613 -28.6869 20
+      vertex -43.5726 -26.1164 20
+      vertex -44.8016 -23.947 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -40.8029 -30.2615 20
+      vertex -44.819 -33.24 20
+      vertex -43.134 -35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.2112 -26.3039 20
+      vertex -44.8016 -23.947 20
+      vertex -45.9227 -21.7198 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -42.2387 -28.223 20
+      vertex -46.396 -31.0008 20
+      vertex -44.819 -33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.4426 -23.8576 20
+      vertex -45.9227 -21.7198 20
+      vertex -46.9331 -19.4403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -51.5525 -21.3537 20
+      vertex -46.9331 -19.4403 20
+      vertex -47.8304 -17.114 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.5726 -26.1164 20
+      vertex -47.8613 -28.6869 20
+      vertex -46.396 -31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -52.5382 -18.7985 20
+      vertex -47.8304 -17.114 20
+      vertex -48.6126 -14.7465 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.8016 -23.947 20
+      vertex -49.2112 -26.3039 20
+      vertex -47.8613 -28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -53.3973 -16.1979 20
+      vertex -48.6126 -14.7465 20
+      vertex -49.2776 -12.3434 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.1277 -13.5583 20
+      vertex -49.2776 -12.3434 20
+      vertex -49.8239 -9.91059 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -49.8239 -9.91059 20
+      vertex -50.2502 -7.45391 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -45.9227 -21.7198 20
+      vertex -50.4426 -23.8576 20
+      vertex -49.2112 -26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -50.2502 -7.45391 20
+      vertex -50.5554 -4.97927 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -50.5554 -4.97927 20
+      vertex -50.7388 -2.49264 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -50.7388 -2.49264 20
+      vertex -50.8 0 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -54.8 10.4701 20
+      vertex -49.8239 9.91059 20
+      vertex -54.7278 10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.9331 -19.4403 20
+      vertex -51.5525 -21.3537 20
+      vertex -50.4426 -23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.8239 9.91059 20
+      vertex -54.8 10.4701 20
+      vertex -50.2502 7.45391 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.8304 -17.114 20
+      vertex -52.5382 -18.7985 20
+      vertex -51.5525 -21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.2502 7.45391 20
+      vertex -54.8 10.4701 20
+      vertex -50.5554 4.97927 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.6126 -14.7465 20
+      vertex -53.3973 -16.1979 20
+      vertex -52.5382 -18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.5554 4.97927 20
+      vertex -54.8 10.4701 20
+      vertex -50.7388 2.49264 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.2776 -12.3434 20
+      vertex -54.1277 -13.5583 20
+      vertex -53.3973 -16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.7388 2.49264 20
+      vertex -54.8 10.4701 20
+      vertex -50.8 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -50.8 0 20
+      vertex -54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.8239 -9.91059 20
+      vertex -54.8 -10.4701 20
+      vertex -54.7278 -10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.8239 -9.91059 20
+      vertex -54.7278 -10.886 20
+      vertex -54.1277 -13.5583 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -54.8 10.4701 20
+      vertex -54.8 50.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -54.8 -10.4701 20
+      vertex -54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -54.8 -10.4701 20
+      vertex -54.8 50.8 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -54.8 -50.8 0
+      vertex -54.8 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -20.5267 50.8 0
+      vertex -23.0513 50.8 20
+      vertex -20.5267 50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -23.0513 50.8 20
+      vertex -20.5267 50.8 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -23.0513 50.8 20
+      vertex -54.8 50.8 0
+      vertex -54.8 50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 54.8 50.8 0
+      vertex 23.0513 50.8 20
+      vertex 54.8 50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 23.0513 50.8 20
+      vertex 54.8 50.8 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 23.0513 50.8 20
+      vertex 20.5267 50.8 0
+      vertex 20.5267 50.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -23.0513 -50.8 20
+      vertex -54.8 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -23.0513 -50.8 20
+      vertex -54.8 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -23.0513 -50.8 20
+      vertex -20.5267 -50.8 0
+      vertex -20.5267 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 23.0513 -50.8 20
+      vertex 20.5267 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 23.0513 -50.8 20
+      vertex 20.5267 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 23.0513 -50.8 20
+      vertex 54.8 -50.8 0
+      vertex 54.8 -50.8 20
+    endloop
+  endfacet
+  facet normal -0.997291 -0.0735547 0
+    outer loop
+      vertex 50.7388 2.49264 0
+      vertex 50.5554 4.97927 20
+      vertex 50.5554 4.97927 0
+    endloop
+  endfacet
+  facet normal -0.997291 -0.0735547 0
+    outer loop
+      vertex 50.5554 4.97927 20
+      vertex 50.7388 2.49264 0
+      vertex 50.7388 2.49264 20
+    endloop
+  endfacet
+  facet normal -0.999699 -0.0245449 0
+    outer loop
+      vertex 50.8 0 0
+      vertex 50.7388 2.49264 20
+      vertex 50.7388 2.49264 0
+    endloop
+  endfacet
+  facet normal -0.999699 -0.0245449 0
+    outer loop
+      vertex 50.7388 2.49264 20
+      vertex 50.8 0 0
+      vertex 50.8 0 20
+    endloop
+  endfacet
+  facet normal -0.99248 -0.122404 0
+    outer loop
+      vertex 50.5554 4.97927 0
+      vertex 50.2502 7.45391 20
+      vertex 50.2502 7.45391 0
+    endloop
+  endfacet
+  facet normal -0.99248 -0.122404 0
+    outer loop
+      vertex 50.2502 7.45391 20
+      vertex 50.5554 4.97927 0
+      vertex 50.5554 4.97927 20
+    endloop
+  endfacet
+  facet normal 0.170972 0.985276 -0
+    outer loop
+      vertex -7.45391 -50.2502 0
+      vertex -9.91059 -49.8239 20
+      vertex -7.45391 -50.2502 20
+    endloop
+  endfacet
+  facet normal 0.170972 0.985276 0
+    outer loop
+      vertex -9.91059 -49.8239 20
+      vertex -7.45391 -50.2502 0
+      vertex -9.91059 -49.8239 0
+    endloop
+  endfacet
+  facet normal 0.359877 0.933 -0
+    outer loop
+      vertex -17.114 -47.8304 0
+      vertex -19.4403 -46.9331 20
+      vertex -17.114 -47.8304 20
+    endloop
+  endfacet
+  facet normal 0.359877 0.933 0
+    outer loop
+      vertex -19.4403 -46.9331 20
+      vertex -17.114 -47.8304 0
+      vertex -19.4403 -46.9331 0
+    endloop
+  endfacet
+  facet normal -0.893221 0.449618 0
+    outer loop
+      vertex 44.8016 -23.947 0
+      vertex 45.9227 -21.7198 20
+      vertex 45.9227 -21.7198 0
+    endloop
+  endfacet
+  facet normal -0.893221 0.449618 0
+    outer loop
+      vertex 45.9227 -21.7198 20
+      vertex 44.8016 -23.947 0
+      vertex 44.8016 -23.947 20
+    endloop
+  endfacet
+  facet normal 0.0245449 0.999699 -0
+    outer loop
+      vertex 0 -50.8 0
+      vertex -2.49264 -50.7388 20
+      vertex 0 -50.8 20
+    endloop
+  endfacet
+  facet normal 0.0245449 0.999699 0
+    outer loop
+      vertex -2.49264 -50.7388 20
+      vertex 0 -50.8 0
+      vertex -2.49264 -50.7388 0
+    endloop
+  endfacet
+  facet normal 0.933 -0.359877 0
+    outer loop
+      vertex -47.8304 17.114 20
+      vertex -46.9331 19.4403 0
+      vertex -46.9331 19.4403 20
+    endloop
+  endfacet
+  facet normal 0.933 -0.359877 0
+    outer loop
+      vertex -46.9331 19.4403 0
+      vertex -47.8304 17.114 20
+      vertex -47.8304 17.114 0
+    endloop
+  endfacet
+  facet normal 0.359877 -0.933 0
+    outer loop
+      vertex -19.4403 46.9331 0
+      vertex -17.114 47.8304 20
+      vertex -19.4403 46.9331 20
+    endloop
+  endfacet
+  facet normal 0.359877 -0.933 0
+    outer loop
+      vertex -17.114 47.8304 20
+      vertex -19.4403 46.9331 0
+      vertex -17.114 47.8304 0
+    endloop
+  endfacet
+  facet normal 0.170972 -0.985276 0
+    outer loop
+      vertex -9.91059 49.8239 0
+      vertex -7.45391 50.2502 20
+      vertex -9.91059 49.8239 20
+    endloop
+  endfacet
+  facet normal 0.170972 -0.985276 0
+    outer loop
+      vertex -7.45391 50.2502 20
+      vertex -9.91059 49.8239 0
+      vertex -7.45391 50.2502 0
+    endloop
+  endfacet
+  facet normal -0.817561 -0.575842 0
+    outer loop
+      vertex 42.2387 28.223 0
+      vertex 40.8029 30.2615 20
+      vertex 40.8029 30.2615 0
+    endloop
+  endfacet
+  facet normal -0.817561 -0.575842 0
+    outer loop
+      vertex 40.8029 30.2615 20
+      vertex 42.2387 28.223 0
+      vertex 42.2387 28.223 20
+    endloop
+  endfacet
+  facet normal 0.949518 0.313712 0
+    outer loop
+      vertex -47.8304 -17.114 20
+      vertex -48.6126 -14.7465 0
+      vertex -48.6126 -14.7465 20
+    endloop
+  endfacet
+  facet normal 0.949518 0.313712 0
+    outer loop
+      vertex -48.6126 -14.7465 0
+      vertex -47.8304 -17.114 20
+      vertex -47.8304 -17.114 0
+    endloop
+  endfacet
+  facet normal 0.575842 -0.817561 0
+    outer loop
+      vertex -30.2615 40.8029 0
+      vertex -28.223 42.2387 20
+      vertex -30.2615 40.8029 20
+    endloop
+  endfacet
+  facet normal 0.575842 -0.817561 0
+    outer loop
+      vertex -28.223 42.2387 20
+      vertex -30.2615 40.8029 0
+      vertex -28.223 42.2387 0
+    endloop
+  endfacet
+  facet normal -0.266703 0.963779 0
+    outer loop
+      vertex 14.7465 -48.6126 0
+      vertex 12.3434 -49.2776 20
+      vertex 14.7465 -48.6126 20
+    endloop
+  endfacet
+  facet normal -0.266703 0.963779 0
+    outer loop
+      vertex 12.3434 -49.2776 20
+      vertex 14.7465 -48.6126 0
+      vertex 12.3434 -49.2776 0
+    endloop
+  endfacet
+  facet normal 0.122404 -0.99248 0
+    outer loop
+      vertex -7.45391 50.2502 0
+      vertex -4.97927 50.5554 20
+      vertex -7.45391 50.2502 20
+    endloop
+  endfacet
+  facet normal 0.122404 -0.99248 0
+    outer loop
+      vertex -4.97927 50.5554 20
+      vertex -7.45391 50.2502 0
+      vertex -4.97927 50.5554 0
+    endloop
+  endfacet
+  facet normal -0.788356 0.61522 0
+    outer loop
+      vertex 39.2689 -32.2272 0
+      vertex 40.8029 -30.2615 20
+      vertex 40.8029 -30.2615 0
+    endloop
+  endfacet
+  facet normal -0.788356 0.61522 0
+    outer loop
+      vertex 40.8029 -30.2615 20
+      vertex 39.2689 -32.2272 0
+      vertex 39.2689 -32.2272 20
+    endloop
+  endfacet
+  facet normal 0.0735547 -0.997291 0
+    outer loop
+      vertex -4.97927 50.5554 0
+      vertex -2.49264 50.7388 20
+      vertex -4.97927 50.5554 20
+    endloop
+  endfacet
+  facet normal 0.0735547 -0.997291 0
+    outer loop
+      vertex -2.49264 50.7388 20
+      vertex -4.97927 50.5554 0
+      vertex -2.49264 50.7388 0
+    endloop
+  endfacet
+  facet normal -0.122404 -0.99248 0
+    outer loop
+      vertex 4.97927 50.5554 0
+      vertex 7.45391 50.2502 20
+      vertex 4.97927 50.5554 20
+    endloop
+  endfacet
+  facet normal -0.122404 -0.99248 -0
+    outer loop
+      vertex 7.45391 50.2502 20
+      vertex 4.97927 50.5554 0
+      vertex 7.45391 50.2502 0
+    endloop
+  endfacet
+  facet normal -0.0735547 0.997291 0
+    outer loop
+      vertex 4.97927 -50.5554 0
+      vertex 2.49264 -50.7388 20
+      vertex 4.97927 -50.5554 20
+    endloop
+  endfacet
+  facet normal -0.0735547 0.997291 0
+    outer loop
+      vertex 2.49264 -50.7388 20
+      vertex 4.97927 -50.5554 0
+      vertex 2.49264 -50.7388 0
+    endloop
+  endfacet
+  facet normal 0.757209 0.653173 0
+    outer loop
+      vertex -37.6403 -34.1152 20
+      vertex -39.2689 -32.2272 0
+      vertex -39.2689 -32.2272 20
+    endloop
+  endfacet
+  facet normal 0.757209 0.653173 0
+    outer loop
+      vertex -39.2689 -32.2272 0
+      vertex -37.6403 -34.1152 20
+      vertex -37.6403 -34.1152 0
+    endloop
+  endfacet
+  facet normal -0.575842 0.817561 0
+    outer loop
+      vertex 30.2615 -40.8029 0
+      vertex 28.223 -42.2387 20
+      vertex 30.2615 -40.8029 20
+    endloop
+  endfacet
+  facet normal -0.575842 0.817561 0
+    outer loop
+      vertex 28.223 -42.2387 20
+      vertex 30.2615 -40.8029 0
+      vertex 28.223 -42.2387 0
+    endloop
+  endfacet
+  facet normal -0.61522 -0.788356 0
+    outer loop
+      vertex 30.2615 40.8029 0
+      vertex 32.2272 39.2689 20
+      vertex 30.2615 40.8029 20
+    endloop
+  endfacet
+  facet normal -0.61522 -0.788356 -0
+    outer loop
+      vertex 32.2272 39.2689 20
+      vertex 30.2615 40.8029 0
+      vertex 32.2272 39.2689 0
+    endloop
+  endfacet
+  facet normal -0.575842 -0.817561 0
+    outer loop
+      vertex 28.223 42.2387 0
+      vertex 30.2615 40.8029 20
+      vertex 28.223 42.2387 20
+    endloop
+  endfacet
+  facet normal -0.575842 -0.817561 -0
+    outer loop
+      vertex 30.2615 40.8029 20
+      vertex 28.223 42.2387 0
+      vertex 30.2615 40.8029 0
+    endloop
+  endfacet
+  facet normal 0.997291 0.0735547 0
+    outer loop
+      vertex -50.5554 -4.97927 20
+      vertex -50.7388 -2.49264 0
+      vertex -50.7388 -2.49264 20
+    endloop
+  endfacet
+  facet normal 0.997291 0.0735547 0
+    outer loop
+      vertex -50.7388 -2.49264 0
+      vertex -50.5554 -4.97927 20
+      vertex -50.5554 -4.97927 0
+    endloop
+  endfacet
+  facet normal 0.61522 -0.788356 0
+    outer loop
+      vertex -32.2272 39.2689 0
+      vertex -30.2615 40.8029 20
+      vertex -32.2272 39.2689 20
+    endloop
+  endfacet
+  facet normal 0.61522 -0.788356 0
+    outer loop
+      vertex -30.2615 40.8029 20
+      vertex -32.2272 39.2689 0
+      vertex -30.2615 40.8029 0
+    endloop
+  endfacet
+  facet normal 0.0245449 -0.999699 0
+    outer loop
+      vertex -2.49264 50.7388 0
+      vertex 0 50.8 20
+      vertex -2.49264 50.7388 20
+    endloop
+  endfacet
+  facet normal 0.0245449 -0.999699 0
+    outer loop
+      vertex 0 50.8 20
+      vertex -2.49264 50.7388 0
+      vertex 0 50.8 0
+    endloop
+  endfacet
+  facet normal -0.449618 -0.893221 0
+    outer loop
+      vertex 21.7198 45.9227 0
+      vertex 23.947 44.8016 20
+      vertex 21.7198 45.9227 20
+    endloop
+  endfacet
+  facet normal -0.449618 -0.893221 -0
+    outer loop
+      vertex 23.947 44.8016 20
+      vertex 21.7198 45.9227 0
+      vertex 23.947 44.8016 0
+    endloop
+  endfacet
+  facet normal 0.534972 0.84487 -0
+    outer loop
+      vertex -26.1164 -43.5726 0
+      vertex -28.223 -42.2387 20
+      vertex -26.1164 -43.5726 20
+    endloop
+  endfacet
+  facet normal 0.534972 0.84487 0
+    outer loop
+      vertex -28.223 -42.2387 20
+      vertex -26.1164 -43.5726 0
+      vertex -28.223 -42.2387 0
+    endloop
+  endfacet
+  facet normal 0.985276 0.170972 0
+    outer loop
+      vertex -49.8239 -9.91059 20
+      vertex -50.2502 -7.45391 0
+      vertex -50.2502 -7.45391 20
+    endloop
+  endfacet
+  facet normal 0.985276 0.170972 0
+    outer loop
+      vertex -50.2502 -7.45391 0
+      vertex -49.8239 -9.91059 20
+      vertex -49.8239 -9.91059 0
+    endloop
+  endfacet
+  facet normal -0.985276 0.170972 0
+    outer loop
+      vertex 49.8239 -9.91059 0
+      vertex 50.2502 -7.45391 20
+      vertex 50.2502 -7.45391 0
+    endloop
+  endfacet
+  facet normal -0.985276 0.170972 0
+    outer loop
+      vertex 50.2502 -7.45391 20
+      vertex 49.8239 -9.91059 0
+      vertex 49.8239 -9.91059 20
+    endloop
+  endfacet
+  facet normal -0.99248 0.122404 0
+    outer loop
+      vertex 50.2502 -7.45391 0
+      vertex 50.5554 -4.97927 20
+      vertex 50.5554 -4.97927 0
+    endloop
+  endfacet
+  facet normal -0.99248 0.122404 0
+    outer loop
+      vertex 50.5554 -4.97927 20
+      vertex 50.2502 -7.45391 0
+      vertex 50.2502 -7.45391 20
+    endloop
+  endfacet
+  facet normal -0.534972 0.84487 0
+    outer loop
+      vertex 28.223 -42.2387 0
+      vertex 26.1164 -43.5726 20
+      vertex 28.223 -42.2387 20
+    endloop
+  endfacet
+  facet normal -0.534972 0.84487 0
+    outer loop
+      vertex 26.1164 -43.5726 20
+      vertex 28.223 -42.2387 0
+      vertex 26.1164 -43.5726 0
+    endloop
+  endfacet
+  facet normal -0.84487 0.534972 0
+    outer loop
+      vertex 42.2387 -28.223 0
+      vertex 43.5726 -26.1164 20
+      vertex 43.5726 -26.1164 0
+    endloop
+  endfacet
+  facet normal -0.84487 0.534972 0
+    outer loop
+      vertex 43.5726 -26.1164 20
+      vertex 42.2387 -28.223 0
+      vertex 42.2387 -28.223 20
+    endloop
+  endfacet
+  facet normal -0.359877 -0.933 0
+    outer loop
+      vertex 17.114 47.8304 0
+      vertex 19.4403 46.9331 20
+      vertex 17.114 47.8304 20
+    endloop
+  endfacet
+  facet normal -0.359877 -0.933 -0
+    outer loop
+      vertex 19.4403 46.9331 20
+      vertex 17.114 47.8304 0
+      vertex 19.4403 46.9331 0
+    endloop
+  endfacet
+  facet normal 0.999699 0.0245449 0
+    outer loop
+      vertex -50.7388 -2.49264 20
+      vertex -50.8 0 0
+      vertex -50.8 0 20
+    endloop
+  endfacet
+  facet normal 0.999699 0.0245449 0
+    outer loop
+      vertex -50.8 0 0
+      vertex -50.7388 -2.49264 20
+      vertex -50.7388 -2.49264 0
+    endloop
+  endfacet
+  facet normal -0.870078 -0.492913 0
+    outer loop
+      vertex 44.8016 23.947 0
+      vertex 43.5726 26.1164 20
+      vertex 43.5726 26.1164 0
+    endloop
+  endfacet
+  facet normal -0.870078 -0.492913 0
+    outer loop
+      vertex 43.5726 26.1164 20
+      vertex 44.8016 23.947 0
+      vertex 44.8016 23.947 20
+    endloop
+  endfacet
+  facet normal -0.893221 -0.449618 0
+    outer loop
+      vertex 45.9227 21.7198 0
+      vertex 44.8016 23.947 20
+      vertex 44.8016 23.947 0
+    endloop
+  endfacet
+  facet normal -0.893221 -0.449618 0
+    outer loop
+      vertex 44.8016 23.947 20
+      vertex 45.9227 21.7198 0
+      vertex 45.9227 21.7198 20
+    endloop
+  endfacet
+  facet normal 0.72424 -0.689548 0
+    outer loop
+      vertex -37.6403 34.1152 20
+      vertex -35.921 35.921 0
+      vertex -35.921 35.921 20
+    endloop
+  endfacet
+  facet normal 0.72424 -0.689548 0
+    outer loop
+      vertex -35.921 35.921 0
+      vertex -37.6403 34.1152 20
+      vertex -37.6403 34.1152 0
+    endloop
+  endfacet
+  facet normal -0.933 -0.359877 0
+    outer loop
+      vertex 47.8304 17.114 0
+      vertex 46.9331 19.4403 20
+      vertex 46.9331 19.4403 0
+    endloop
+  endfacet
+  facet normal -0.933 -0.359877 0
+    outer loop
+      vertex 46.9331 19.4403 20
+      vertex 47.8304 17.114 0
+      vertex 47.8304 17.114 20
+    endloop
+  endfacet
+  facet normal 0.449618 0.893221 -0
+    outer loop
+      vertex -21.7198 -45.9227 0
+      vertex -23.947 -44.8016 20
+      vertex -21.7198 -45.9227 20
+    endloop
+  endfacet
+  facet normal 0.449618 0.893221 0
+    outer loop
+      vertex -23.947 -44.8016 20
+      vertex -21.7198 -45.9227 0
+      vertex -23.947 -44.8016 0
+    endloop
+  endfacet
+  facet normal -0.492913 -0.870078 0
+    outer loop
+      vertex 23.947 44.8016 0
+      vertex 26.1164 43.5726 20
+      vertex 23.947 44.8016 20
+    endloop
+  endfacet
+  facet normal -0.492913 -0.870078 -0
+    outer loop
+      vertex 26.1164 43.5726 20
+      vertex 23.947 44.8016 0
+      vertex 26.1164 43.5726 0
+    endloop
+  endfacet
+  facet normal 0.575842 0.817561 -0
+    outer loop
+      vertex -28.223 -42.2387 0
+      vertex -30.2615 -40.8029 20
+      vertex -28.223 -42.2387 20
+    endloop
+  endfacet
+  facet normal 0.575842 0.817561 0
+    outer loop
+      vertex -30.2615 -40.8029 20
+      vertex -28.223 -42.2387 0
+      vertex -30.2615 -40.8029 0
+    endloop
+  endfacet
+  facet normal -0.0735547 -0.997291 0
+    outer loop
+      vertex 2.49264 50.7388 0
+      vertex 4.97927 50.5554 20
+      vertex 2.49264 50.7388 20
+    endloop
+  endfacet
+  facet normal -0.0735547 -0.997291 -0
+    outer loop
+      vertex 4.97927 50.5554 20
+      vertex 2.49264 50.7388 0
+      vertex 4.97927 50.5554 0
+    endloop
+  endfacet
+  facet normal -0.313712 -0.949518 0
+    outer loop
+      vertex 14.7465 48.6126 0
+      vertex 17.114 47.8304 20
+      vertex 14.7465 48.6126 20
+    endloop
+  endfacet
+  facet normal -0.313712 -0.949518 -0
+    outer loop
+      vertex 17.114 47.8304 20
+      vertex 14.7465 48.6126 0
+      vertex 17.114 47.8304 0
+    endloop
+  endfacet
+  facet normal -0.975703 0.219099 0
+    outer loop
+      vertex 49.2776 -12.3434 0
+      vertex 49.8239 -9.91059 20
+      vertex 49.8239 -9.91059 0
+    endloop
+  endfacet
+  facet normal -0.975703 0.219099 0
+    outer loop
+      vertex 49.8239 -9.91059 20
+      vertex 49.2776 -12.3434 0
+      vertex 49.2776 -12.3434 20
+    endloop
+  endfacet
+  facet normal -0.914215 0.40523 0
+    outer loop
+      vertex 45.9227 -21.7198 0
+      vertex 46.9331 -19.4403 20
+      vertex 46.9331 -19.4403 0
+    endloop
+  endfacet
+  facet normal -0.914215 0.40523 0
+    outer loop
+      vertex 46.9331 -19.4403 20
+      vertex 45.9227 -21.7198 0
+      vertex 45.9227 -21.7198 20
+    endloop
+  endfacet
+  facet normal -0.933 0.359877 0
+    outer loop
+      vertex 46.9331 -19.4403 0
+      vertex 47.8304 -17.114 20
+      vertex 47.8304 -17.114 0
+    endloop
+  endfacet
+  facet normal -0.933 0.359877 0
+    outer loop
+      vertex 47.8304 -17.114 20
+      vertex 46.9331 -19.4403 0
+      vertex 46.9331 -19.4403 20
+    endloop
+  endfacet
+  facet normal -0.999699 0.0245449 0
+    outer loop
+      vertex 50.7388 -2.49264 0
+      vertex 50.8 0 20
+      vertex 50.8 0 0
+    endloop
+  endfacet
+  facet normal -0.999699 0.0245449 0
+    outer loop
+      vertex 50.8 0 20
+      vertex 50.7388 -2.49264 0
+      vertex 50.7388 -2.49264 20
+    endloop
+  endfacet
+  facet normal 0.757209 -0.653173 0
+    outer loop
+      vertex -39.2689 32.2272 20
+      vertex -37.6403 34.1152 0
+      vertex -37.6403 34.1152 20
+    endloop
+  endfacet
+  facet normal 0.757209 -0.653173 0
+    outer loop
+      vertex -37.6403 34.1152 0
+      vertex -39.2689 32.2272 20
+      vertex -39.2689 32.2272 0
+    endloop
+  endfacet
+  facet normal 0.266703 0.963779 -0
+    outer loop
+      vertex -12.3434 -49.2776 0
+      vertex -14.7465 -48.6126 20
+      vertex -12.3434 -49.2776 20
+    endloop
+  endfacet
+  facet normal 0.266703 0.963779 0
+    outer loop
+      vertex -14.7465 -48.6126 20
+      vertex -12.3434 -49.2776 0
+      vertex -14.7465 -48.6126 0
+    endloop
+  endfacet
+  facet normal -0.40523 0.914215 0
+    outer loop
+      vertex 21.7198 -45.9227 0
+      vertex 19.4403 -46.9331 20
+      vertex 21.7198 -45.9227 20
+    endloop
+  endfacet
+  facet normal -0.40523 0.914215 0
+    outer loop
+      vertex 19.4403 -46.9331 20
+      vertex 21.7198 -45.9227 0
+      vertex 19.4403 -46.9331 0
+    endloop
+  endfacet
+  facet normal -0.359877 0.933 0
+    outer loop
+      vertex 19.4403 -46.9331 0
+      vertex 17.114 -47.8304 20
+      vertex 19.4403 -46.9331 20
+    endloop
+  endfacet
+  facet normal -0.359877 0.933 0
+    outer loop
+      vertex 17.114 -47.8304 20
+      vertex 19.4403 -46.9331 0
+      vertex 17.114 -47.8304 0
+    endloop
+  endfacet
+  facet normal -0.997291 0.0735547 0
+    outer loop
+      vertex 50.5554 -4.97927 0
+      vertex 50.7388 -2.49264 20
+      vertex 50.7388 -2.49264 0
+    endloop
+  endfacet
+  facet normal -0.997291 0.0735547 0
+    outer loop
+      vertex 50.7388 -2.49264 20
+      vertex 50.5554 -4.97927 0
+      vertex 50.5554 -4.97927 20
+    endloop
+  endfacet
+  facet normal -0.653173 -0.757209 0
+    outer loop
+      vertex 32.2272 39.2689 0
+      vertex 34.1152 37.6403 20
+      vertex 32.2272 39.2689 20
+    endloop
+  endfacet
+  facet normal -0.653173 -0.757209 -0
+    outer loop
+      vertex 34.1152 37.6403 20
+      vertex 32.2272 39.2689 0
+      vertex 34.1152 37.6403 0
+    endloop
+  endfacet
+  facet normal -0.788356 -0.61522 0
+    outer loop
+      vertex 40.8029 30.2615 0
+      vertex 39.2689 32.2272 20
+      vertex 39.2689 32.2272 0
+    endloop
+  endfacet
+  facet normal -0.788356 -0.61522 0
+    outer loop
+      vertex 39.2689 32.2272 20
+      vertex 40.8029 30.2615 0
+      vertex 40.8029 30.2615 20
+    endloop
+  endfacet
+  facet normal -0.170972 -0.985276 0
+    outer loop
+      vertex 7.45391 50.2502 0
+      vertex 9.91059 49.8239 20
+      vertex 7.45391 50.2502 20
+    endloop
+  endfacet
+  facet normal -0.170972 -0.985276 -0
+    outer loop
+      vertex 9.91059 49.8239 20
+      vertex 7.45391 50.2502 0
+      vertex 9.91059 49.8239 0
+    endloop
+  endfacet
+  facet normal -0.689548 -0.72424 0
+    outer loop
+      vertex 34.1152 37.6403 0
+      vertex 35.921 35.921 20
+      vertex 34.1152 37.6403 20
+    endloop
+  endfacet
+  facet normal -0.689548 -0.72424 -0
+    outer loop
+      vertex 35.921 35.921 20
+      vertex 34.1152 37.6403 0
+      vertex 35.921 35.921 0
+    endloop
+  endfacet
+  facet normal 0.999699 -0.0245449 0
+    outer loop
+      vertex -50.8 0 20
+      vertex -50.7388 2.49264 0
+      vertex -50.7388 2.49264 20
+    endloop
+  endfacet
+  facet normal 0.999699 -0.0245449 0
+    outer loop
+      vertex -50.7388 2.49264 0
+      vertex -50.8 0 20
+      vertex -50.8 0 0
+    endloop
+  endfacet
+  facet normal -0.949518 0.313712 0
+    outer loop
+      vertex 47.8304 -17.114 0
+      vertex 48.6126 -14.7465 20
+      vertex 48.6126 -14.7465 0
+    endloop
+  endfacet
+  facet normal -0.949518 0.313712 0
+    outer loop
+      vertex 48.6126 -14.7465 20
+      vertex 47.8304 -17.114 0
+      vertex 47.8304 -17.114 20
+    endloop
+  endfacet
+  facet normal 0.40523 -0.914215 0
+    outer loop
+      vertex -21.7198 45.9227 0
+      vertex -19.4403 46.9331 20
+      vertex -21.7198 45.9227 20
+    endloop
+  endfacet
+  facet normal 0.40523 -0.914215 0
+    outer loop
+      vertex -19.4403 46.9331 20
+      vertex -21.7198 45.9227 0
+      vertex -19.4403 46.9331 0
+    endloop
+  endfacet
+  facet normal -0.84487 -0.534972 0
+    outer loop
+      vertex 43.5726 26.1164 0
+      vertex 42.2387 28.223 20
+      vertex 42.2387 28.223 0
+    endloop
+  endfacet
+  facet normal -0.84487 -0.534972 0
+    outer loop
+      vertex 42.2387 28.223 20
+      vertex 43.5726 26.1164 0
+      vertex 43.5726 26.1164 20
+    endloop
+  endfacet
+  facet normal -0.963779 -0.266703 0
+    outer loop
+      vertex 49.2776 12.3434 0
+      vertex 48.6126 14.7465 20
+      vertex 48.6126 14.7465 0
+    endloop
+  endfacet
+  facet normal -0.963779 -0.266703 0
+    outer loop
+      vertex 48.6126 14.7465 20
+      vertex 49.2776 12.3434 0
+      vertex 49.2776 12.3434 20
+    endloop
+  endfacet
+  facet normal -0.949518 -0.313712 0
+    outer loop
+      vertex 48.6126 14.7465 0
+      vertex 47.8304 17.114 20
+      vertex 47.8304 17.114 0
+    endloop
+  endfacet
+  facet normal -0.949518 -0.313712 0
+    outer loop
+      vertex 47.8304 17.114 20
+      vertex 48.6126 14.7465 0
+      vertex 48.6126 14.7465 20
+    endloop
+  endfacet
+  facet normal 0.997291 -0.0735547 0
+    outer loop
+      vertex -50.7388 2.49264 20
+      vertex -50.5554 4.97927 0
+      vertex -50.5554 4.97927 20
+    endloop
+  endfacet
+  facet normal 0.997291 -0.0735547 0
+    outer loop
+      vertex -50.5554 4.97927 0
+      vertex -50.7388 2.49264 20
+      vertex -50.7388 2.49264 0
+    endloop
+  endfacet
+  facet normal 0.266703 -0.963779 0
+    outer loop
+      vertex -14.7465 48.6126 0
+      vertex -12.3434 49.2776 20
+      vertex -14.7465 48.6126 20
+    endloop
+  endfacet
+  facet normal 0.266703 -0.963779 0
+    outer loop
+      vertex -12.3434 49.2776 20
+      vertex -14.7465 48.6126 0
+      vertex -12.3434 49.2776 0
+    endloop
+  endfacet
+  facet normal -0.963779 0.266703 0
+    outer loop
+      vertex 48.6126 -14.7465 0
+      vertex 49.2776 -12.3434 20
+      vertex 49.2776 -12.3434 0
+    endloop
+  endfacet
+  facet normal -0.963779 0.266703 0
+    outer loop
+      vertex 49.2776 -12.3434 20
+      vertex 48.6126 -14.7465 0
+      vertex 48.6126 -14.7465 20
+    endloop
+  endfacet
+  facet normal -0.975703 -0.219099 0
+    outer loop
+      vertex 49.8239 9.91059 0
+      vertex 49.2776 12.3434 20
+      vertex 49.2776 12.3434 0
+    endloop
+  endfacet
+  facet normal -0.975703 -0.219099 0
+    outer loop
+      vertex 49.2776 12.3434 20
+      vertex 49.8239 9.91059 0
+      vertex 49.8239 9.91059 20
+    endloop
+  endfacet
+  facet normal 0.689548 -0.72424 0
+    outer loop
+      vertex -35.921 35.921 0
+      vertex -34.1152 37.6403 20
+      vertex -35.921 35.921 20
+    endloop
+  endfacet
+  facet normal 0.689548 -0.72424 0
+    outer loop
+      vertex -34.1152 37.6403 20
+      vertex -35.921 35.921 0
+      vertex -34.1152 37.6403 0
+    endloop
+  endfacet
+  facet normal -0.40523 -0.914215 0
+    outer loop
+      vertex 19.4403 46.9331 0
+      vertex 21.7198 45.9227 20
+      vertex 19.4403 46.9331 20
+    endloop
+  endfacet
+  facet normal -0.40523 -0.914215 -0
+    outer loop
+      vertex 21.7198 45.9227 20
+      vertex 19.4403 46.9331 0
+      vertex 21.7198 45.9227 0
+    endloop
+  endfacet
+  facet normal -0.689548 0.72424 0
+    outer loop
+      vertex 35.921 -35.921 0
+      vertex 34.1152 -37.6403 20
+      vertex 35.921 -35.921 20
+    endloop
+  endfacet
+  facet normal -0.689548 0.72424 0
+    outer loop
+      vertex 34.1152 -37.6403 20
+      vertex 35.921 -35.921 0
+      vertex 34.1152 -37.6403 0
+    endloop
+  endfacet
+  facet normal -0.985276 -0.170972 0
+    outer loop
+      vertex 50.2502 7.45391 0
+      vertex 49.8239 9.91059 20
+      vertex 49.8239 9.91059 0
+    endloop
+  endfacet
+  facet normal -0.985276 -0.170972 0
+    outer loop
+      vertex 49.8239 9.91059 20
+      vertex 50.2502 7.45391 0
+      vertex 50.2502 7.45391 20
+    endloop
+  endfacet
+  facet normal -0.914215 -0.40523 0
+    outer loop
+      vertex 46.9331 19.4403 0
+      vertex 45.9227 21.7198 20
+      vertex 45.9227 21.7198 0
+    endloop
+  endfacet
+  facet normal -0.914215 -0.40523 0
+    outer loop
+      vertex 45.9227 21.7198 20
+      vertex 46.9331 19.4403 0
+      vertex 46.9331 19.4403 20
+    endloop
+  endfacet
+  facet normal -0.757209 0.653173 0
+    outer loop
+      vertex 37.6403 -34.1152 0
+      vertex 39.2689 -32.2272 20
+      vertex 39.2689 -32.2272 0
+    endloop
+  endfacet
+  facet normal -0.757209 0.653173 0
+    outer loop
+      vertex 39.2689 -32.2272 20
+      vertex 37.6403 -34.1152 0
+      vertex 37.6403 -34.1152 20
+    endloop
+  endfacet
+  facet normal 0.449618 -0.893221 0
+    outer loop
+      vertex -23.947 44.8016 0
+      vertex -21.7198 45.9227 20
+      vertex -23.947 44.8016 20
+    endloop
+  endfacet
+  facet normal 0.449618 -0.893221 0
+    outer loop
+      vertex -21.7198 45.9227 20
+      vertex -23.947 44.8016 0
+      vertex -21.7198 45.9227 0
+    endloop
+  endfacet
+  facet normal -0.534972 -0.84487 0
+    outer loop
+      vertex 26.1164 43.5726 0
+      vertex 28.223 42.2387 20
+      vertex 26.1164 43.5726 20
+    endloop
+  endfacet
+  facet normal -0.534972 -0.84487 -0
+    outer loop
+      vertex 28.223 42.2387 20
+      vertex 26.1164 43.5726 0
+      vertex 28.223 42.2387 0
+    endloop
+  endfacet
+  facet normal 0.99248 0.122404 0
+    outer loop
+      vertex -50.2502 -7.45391 20
+      vertex -50.5554 -4.97927 0
+      vertex -50.5554 -4.97927 20
+    endloop
+  endfacet
+  facet normal 0.99248 0.122404 0
+    outer loop
+      vertex -50.5554 -4.97927 0
+      vertex -50.2502 -7.45391 20
+      vertex -50.2502 -7.45391 0
+    endloop
+  endfacet
+  facet normal -0.61522 0.788356 0
+    outer loop
+      vertex 32.2272 -39.2689 0
+      vertex 30.2615 -40.8029 20
+      vertex 32.2272 -39.2689 20
+    endloop
+  endfacet
+  facet normal -0.61522 0.788356 0
+    outer loop
+      vertex 30.2615 -40.8029 20
+      vertex 32.2272 -39.2689 0
+      vertex 30.2615 -40.8029 0
+    endloop
+  endfacet
+  facet normal 0.313712 -0.949518 0
+    outer loop
+      vertex -17.114 47.8304 0
+      vertex -14.7465 48.6126 20
+      vertex -17.114 47.8304 20
+    endloop
+  endfacet
+  facet normal 0.313712 -0.949518 0
+    outer loop
+      vertex -14.7465 48.6126 20
+      vertex -17.114 47.8304 0
+      vertex -14.7465 48.6126 0
+    endloop
+  endfacet
+  facet normal -0.122404 0.99248 0
+    outer loop
+      vertex 7.45391 -50.2502 0
+      vertex 4.97927 -50.5554 20
+      vertex 7.45391 -50.2502 20
+    endloop
+  endfacet
+  facet normal -0.122404 0.99248 0
+    outer loop
+      vertex 4.97927 -50.5554 20
+      vertex 7.45391 -50.2502 0
+      vertex 4.97927 -50.5554 0
+    endloop
+  endfacet
+  facet normal 0.689548 0.72424 -0
+    outer loop
+      vertex -34.1152 -37.6403 0
+      vertex -35.921 -35.921 20
+      vertex -34.1152 -37.6403 20
+    endloop
+  endfacet
+  facet normal 0.689548 0.72424 0
+    outer loop
+      vertex -35.921 -35.921 20
+      vertex -34.1152 -37.6403 0
+      vertex -35.921 -35.921 0
+    endloop
+  endfacet
+  facet normal 0.72424 0.689548 0
+    outer loop
+      vertex -35.921 -35.921 20
+      vertex -37.6403 -34.1152 0
+      vertex -37.6403 -34.1152 20
+    endloop
+  endfacet
+  facet normal 0.72424 0.689548 0
+    outer loop
+      vertex -37.6403 -34.1152 0
+      vertex -35.921 -35.921 20
+      vertex -35.921 -35.921 0
+    endloop
+  endfacet
+  facet normal 0.219099 -0.975703 0
+    outer loop
+      vertex -12.3434 49.2776 0
+      vertex -9.91059 49.8239 20
+      vertex -12.3434 49.2776 20
+    endloop
+  endfacet
+  facet normal 0.219099 -0.975703 0
+    outer loop
+      vertex -9.91059 49.8239 20
+      vertex -12.3434 49.2776 0
+      vertex -9.91059 49.8239 0
+    endloop
+  endfacet
+  facet normal 0.788356 -0.61522 0
+    outer loop
+      vertex -40.8029 30.2615 20
+      vertex -39.2689 32.2272 0
+      vertex -39.2689 32.2272 20
+    endloop
+  endfacet
+  facet normal 0.788356 -0.61522 0
+    outer loop
+      vertex -39.2689 32.2272 0
+      vertex -40.8029 30.2615 20
+      vertex -40.8029 30.2615 0
+    endloop
+  endfacet
+  facet normal 0.870078 -0.492913 0
+    outer loop
+      vertex -44.8016 23.947 20
+      vertex -43.5726 26.1164 0
+      vertex -43.5726 26.1164 20
+    endloop
+  endfacet
+  facet normal 0.870078 -0.492913 0
+    outer loop
+      vertex -43.5726 26.1164 0
+      vertex -44.8016 23.947 20
+      vertex -44.8016 23.947 0
+    endloop
+  endfacet
+  facet normal 0.985276 -0.170972 0
+    outer loop
+      vertex -50.2502 7.45391 20
+      vertex -49.8239 9.91059 0
+      vertex -49.8239 9.91059 20
+    endloop
+  endfacet
+  facet normal 0.985276 -0.170972 0
+    outer loop
+      vertex -49.8239 9.91059 0
+      vertex -50.2502 7.45391 20
+      vertex -50.2502 7.45391 0
+    endloop
+  endfacet
+  facet normal 0.99248 -0.122404 0
+    outer loop
+      vertex -50.5554 4.97927 20
+      vertex -50.2502 7.45391 0
+      vertex -50.2502 7.45391 20
+    endloop
+  endfacet
+  facet normal 0.99248 -0.122404 0
+    outer loop
+      vertex -50.2502 7.45391 0
+      vertex -50.5554 4.97927 20
+      vertex -50.5554 4.97927 0
+    endloop
+  endfacet
+  facet normal 0.653173 -0.757209 0
+    outer loop
+      vertex -34.1152 37.6403 0
+      vertex -32.2272 39.2689 20
+      vertex -34.1152 37.6403 20
+    endloop
+  endfacet
+  facet normal 0.653173 -0.757209 0
+    outer loop
+      vertex -32.2272 39.2689 20
+      vertex -34.1152 37.6403 0
+      vertex -32.2272 39.2689 0
+    endloop
+  endfacet
+  facet normal -0.653173 0.757209 0
+    outer loop
+      vertex 34.1152 -37.6403 0
+      vertex 32.2272 -39.2689 20
+      vertex 34.1152 -37.6403 20
+    endloop
+  endfacet
+  facet normal -0.653173 0.757209 0
+    outer loop
+      vertex 32.2272 -39.2689 20
+      vertex 34.1152 -37.6403 0
+      vertex 32.2272 -39.2689 0
+    endloop
+  endfacet
+  facet normal 0.219099 0.975703 -0
+    outer loop
+      vertex -9.91059 -49.8239 0
+      vertex -12.3434 -49.2776 20
+      vertex -9.91059 -49.8239 20
+    endloop
+  endfacet
+  facet normal 0.219099 0.975703 0
+    outer loop
+      vertex -12.3434 -49.2776 20
+      vertex -9.91059 -49.8239 0
+      vertex -12.3434 -49.2776 0
+    endloop
+  endfacet
+  facet normal 0.975703 -0.219099 0
+    outer loop
+      vertex -49.8239 9.91059 20
+      vertex -49.2776 12.3434 0
+      vertex -49.2776 12.3434 20
+    endloop
+  endfacet
+  facet normal 0.975703 -0.219099 0
+    outer loop
+      vertex -49.2776 12.3434 0
+      vertex -49.8239 9.91059 20
+      vertex -49.8239 9.91059 0
+    endloop
+  endfacet
+  facet normal -0.0245449 0.999699 0
+    outer loop
+      vertex 2.49264 -50.7388 0
+      vertex 0 -50.8 20
+      vertex 2.49264 -50.7388 20
+    endloop
+  endfacet
+  facet normal -0.0245449 0.999699 0
+    outer loop
+      vertex 0 -50.8 20
+      vertex 2.49264 -50.7388 0
+      vertex 0 -50.8 0
+    endloop
+  endfacet
+  facet normal 0.313712 0.949518 -0
+    outer loop
+      vertex -14.7465 -48.6126 0
+      vertex -17.114 -47.8304 20
+      vertex -14.7465 -48.6126 20
+    endloop
+  endfacet
+  facet normal 0.313712 0.949518 0
+    outer loop
+      vertex -17.114 -47.8304 20
+      vertex -14.7465 -48.6126 0
+      vertex -17.114 -47.8304 0
+    endloop
+  endfacet
+  facet normal 0.975703 0.219099 0
+    outer loop
+      vertex -49.2776 -12.3434 20
+      vertex -49.8239 -9.91059 0
+      vertex -49.8239 -9.91059 20
+    endloop
+  endfacet
+  facet normal 0.975703 0.219099 0
+    outer loop
+      vertex -49.8239 -9.91059 0
+      vertex -49.2776 -12.3434 20
+      vertex -49.2776 -12.3434 0
+    endloop
+  endfacet
+  facet normal 0.963779 -0.266703 0
+    outer loop
+      vertex -49.2776 12.3434 20
+      vertex -48.6126 14.7465 0
+      vertex -48.6126 14.7465 20
+    endloop
+  endfacet
+  facet normal 0.963779 -0.266703 0
+    outer loop
+      vertex -48.6126 14.7465 0
+      vertex -49.2776 12.3434 20
+      vertex -49.2776 12.3434 0
+    endloop
+  endfacet
+  facet normal 0.933 0.359877 0
+    outer loop
+      vertex -46.9331 -19.4403 20
+      vertex -47.8304 -17.114 0
+      vertex -47.8304 -17.114 20
+    endloop
+  endfacet
+  facet normal 0.933 0.359877 0
+    outer loop
+      vertex -47.8304 -17.114 0
+      vertex -46.9331 -19.4403 20
+      vertex -46.9331 -19.4403 0
+    endloop
+  endfacet
+  facet normal 0.84487 -0.534972 0
+    outer loop
+      vertex -43.5726 26.1164 20
+      vertex -42.2387 28.223 0
+      vertex -42.2387 28.223 20
+    endloop
+  endfacet
+  facet normal 0.84487 -0.534972 0
+    outer loop
+      vertex -42.2387 28.223 0
+      vertex -43.5726 26.1164 20
+      vertex -43.5726 26.1164 0
+    endloop
+  endfacet
+  facet normal -0.72424 -0.689548 0
+    outer loop
+      vertex 37.6403 34.1152 0
+      vertex 35.921 35.921 20
+      vertex 35.921 35.921 0
+    endloop
+  endfacet
+  facet normal -0.72424 -0.689548 0
+    outer loop
+      vertex 35.921 35.921 20
+      vertex 37.6403 34.1152 0
+      vertex 37.6403 34.1152 20
+    endloop
+  endfacet
+  facet normal -0.449618 0.893221 0
+    outer loop
+      vertex 23.947 -44.8016 0
+      vertex 21.7198 -45.9227 20
+      vertex 23.947 -44.8016 20
+    endloop
+  endfacet
+  facet normal -0.449618 0.893221 0
+    outer loop
+      vertex 21.7198 -45.9227 20
+      vertex 23.947 -44.8016 0
+      vertex 21.7198 -45.9227 0
+    endloop
+  endfacet
+  facet normal -0.757209 -0.653173 0
+    outer loop
+      vertex 39.2689 32.2272 0
+      vertex 37.6403 34.1152 20
+      vertex 37.6403 34.1152 0
+    endloop
+  endfacet
+  facet normal -0.757209 -0.653173 0
+    outer loop
+      vertex 37.6403 34.1152 20
+      vertex 39.2689 32.2272 0
+      vertex 39.2689 32.2272 20
+    endloop
+  endfacet
+  facet normal 0.949518 -0.313712 0
+    outer loop
+      vertex -48.6126 14.7465 20
+      vertex -47.8304 17.114 0
+      vertex -47.8304 17.114 20
+    endloop
+  endfacet
+  facet normal 0.949518 -0.313712 0
+    outer loop
+      vertex -47.8304 17.114 0
+      vertex -48.6126 14.7465 20
+      vertex -48.6126 14.7465 0
+    endloop
+  endfacet
+  facet normal -0.313712 0.949518 0
+    outer loop
+      vertex 17.114 -47.8304 0
+      vertex 14.7465 -48.6126 20
+      vertex 17.114 -47.8304 20
+    endloop
+  endfacet
+  facet normal -0.313712 0.949518 0
+    outer loop
+      vertex 14.7465 -48.6126 20
+      vertex 17.114 -47.8304 0
+      vertex 14.7465 -48.6126 0
+    endloop
+  endfacet
+  facet normal 0.534972 -0.84487 0
+    outer loop
+      vertex -28.223 42.2387 0
+      vertex -26.1164 43.5726 20
+      vertex -28.223 42.2387 20
+    endloop
+  endfacet
+  facet normal 0.534972 -0.84487 0
+    outer loop
+      vertex -26.1164 43.5726 20
+      vertex -28.223 42.2387 0
+      vertex -26.1164 43.5726 0
+    endloop
+  endfacet
+  facet normal 0.40523 0.914215 -0
+    outer loop
+      vertex -19.4403 -46.9331 0
+      vertex -21.7198 -45.9227 20
+      vertex -19.4403 -46.9331 20
+    endloop
+  endfacet
+  facet normal 0.40523 0.914215 0
+    outer loop
+      vertex -21.7198 -45.9227 20
+      vertex -19.4403 -46.9331 0
+      vertex -21.7198 -45.9227 0
+    endloop
+  endfacet
+  facet normal -0.219099 -0.975703 0
+    outer loop
+      vertex 9.91059 49.8239 0
+      vertex 12.3434 49.2776 20
+      vertex 9.91059 49.8239 20
+    endloop
+  endfacet
+  facet normal -0.219099 -0.975703 -0
+    outer loop
+      vertex 12.3434 49.2776 20
+      vertex 9.91059 49.8239 0
+      vertex 12.3434 49.2776 0
+    endloop
+  endfacet
+  facet normal -0.266703 -0.963779 0
+    outer loop
+      vertex 12.3434 49.2776 0
+      vertex 14.7465 48.6126 20
+      vertex 12.3434 49.2776 20
+    endloop
+  endfacet
+  facet normal -0.266703 -0.963779 -0
+    outer loop
+      vertex 14.7465 48.6126 20
+      vertex 12.3434 49.2776 0
+      vertex 14.7465 48.6126 0
+    endloop
+  endfacet
+  facet normal -0.170972 0.985276 0
+    outer loop
+      vertex 9.91059 -49.8239 0
+      vertex 7.45391 -50.2502 20
+      vertex 9.91059 -49.8239 20
+    endloop
+  endfacet
+  facet normal -0.170972 0.985276 0
+    outer loop
+      vertex 7.45391 -50.2502 20
+      vertex 9.91059 -49.8239 0
+      vertex 7.45391 -50.2502 0
+    endloop
+  endfacet
+  facet normal -0.870078 0.492913 0
+    outer loop
+      vertex 43.5726 -26.1164 0
+      vertex 44.8016 -23.947 20
+      vertex 44.8016 -23.947 0
+    endloop
+  endfacet
+  facet normal -0.870078 0.492913 0
+    outer loop
+      vertex 44.8016 -23.947 20
+      vertex 43.5726 -26.1164 0
+      vertex 43.5726 -26.1164 20
+    endloop
+  endfacet
+  facet normal 0.0735547 0.997291 -0
+    outer loop
+      vertex -2.49264 -50.7388 0
+      vertex -4.97927 -50.5554 20
+      vertex -2.49264 -50.7388 20
+    endloop
+  endfacet
+  facet normal 0.0735547 0.997291 0
+    outer loop
+      vertex -4.97927 -50.5554 20
+      vertex -2.49264 -50.7388 0
+      vertex -4.97927 -50.5554 0
+    endloop
+  endfacet
+  facet normal -0.0245449 -0.999699 0
+    outer loop
+      vertex 0 50.8 0
+      vertex 2.49264 50.7388 20
+      vertex 0 50.8 20
+    endloop
+  endfacet
+  facet normal -0.0245449 -0.999699 -0
+    outer loop
+      vertex 2.49264 50.7388 20
+      vertex 0 50.8 0
+      vertex 2.49264 50.7388 0
+    endloop
+  endfacet
+  facet normal 0.653173 0.757209 -0
+    outer loop
+      vertex -32.2272 -39.2689 0
+      vertex -34.1152 -37.6403 20
+      vertex -32.2272 -39.2689 20
+    endloop
+  endfacet
+  facet normal 0.653173 0.757209 0
+    outer loop
+      vertex -34.1152 -37.6403 20
+      vertex -32.2272 -39.2689 0
+      vertex -34.1152 -37.6403 0
+    endloop
+  endfacet
+  facet normal -0.72424 0.689548 0
+    outer loop
+      vertex 35.921 -35.921 0
+      vertex 37.6403 -34.1152 20
+      vertex 37.6403 -34.1152 0
+    endloop
+  endfacet
+  facet normal -0.72424 0.689548 0
+    outer loop
+      vertex 37.6403 -34.1152 20
+      vertex 35.921 -35.921 0
+      vertex 35.921 -35.921 20
+    endloop
+  endfacet
+  facet normal 0.870078 0.492913 0
+    outer loop
+      vertex -43.5726 -26.1164 20
+      vertex -44.8016 -23.947 0
+      vertex -44.8016 -23.947 20
+    endloop
+  endfacet
+  facet normal 0.870078 0.492913 0
+    outer loop
+      vertex -44.8016 -23.947 0
+      vertex -43.5726 -26.1164 20
+      vertex -43.5726 -26.1164 0
+    endloop
+  endfacet
+  facet normal -0.817561 0.575842 0
+    outer loop
+      vertex 40.8029 -30.2615 0
+      vertex 42.2387 -28.223 20
+      vertex 42.2387 -28.223 0
+    endloop
+  endfacet
+  facet normal -0.817561 0.575842 0
+    outer loop
+      vertex 42.2387 -28.223 20
+      vertex 40.8029 -30.2615 0
+      vertex 40.8029 -30.2615 20
+    endloop
+  endfacet
+  facet normal 0.122404 0.99248 -0
+    outer loop
+      vertex -4.97927 -50.5554 0
+      vertex -7.45391 -50.2502 20
+      vertex -4.97927 -50.5554 20
+    endloop
+  endfacet
+  facet normal 0.122404 0.99248 0
+    outer loop
+      vertex -7.45391 -50.2502 20
+      vertex -4.97927 -50.5554 0
+      vertex -7.45391 -50.2502 0
+    endloop
+  endfacet
+  facet normal 0.817561 0.575842 0
+    outer loop
+      vertex -40.8029 -30.2615 20
+      vertex -42.2387 -28.223 0
+      vertex -42.2387 -28.223 20
+    endloop
+  endfacet
+  facet normal 0.817561 0.575842 0
+    outer loop
+      vertex -42.2387 -28.223 0
+      vertex -40.8029 -30.2615 20
+      vertex -40.8029 -30.2615 0
+    endloop
+  endfacet
+  facet normal 0.788356 0.61522 0
+    outer loop
+      vertex -39.2689 -32.2272 20
+      vertex -40.8029 -30.2615 0
+      vertex -40.8029 -30.2615 20
+    endloop
+  endfacet
+  facet normal 0.788356 0.61522 0
+    outer loop
+      vertex -40.8029 -30.2615 0
+      vertex -39.2689 -32.2272 20
+      vertex -39.2689 -32.2272 0
+    endloop
+  endfacet
+  facet normal 0.817561 -0.575842 0
+    outer loop
+      vertex -42.2387 28.223 20
+      vertex -40.8029 30.2615 0
+      vertex -40.8029 30.2615 20
+    endloop
+  endfacet
+  facet normal 0.817561 -0.575842 0
+    outer loop
+      vertex -40.8029 30.2615 0
+      vertex -42.2387 28.223 20
+      vertex -42.2387 28.223 0
+    endloop
+  endfacet
+  facet normal -0.492913 0.870078 0
+    outer loop
+      vertex 26.1164 -43.5726 0
+      vertex 23.947 -44.8016 20
+      vertex 26.1164 -43.5726 20
+    endloop
+  endfacet
+  facet normal -0.492913 0.870078 0
+    outer loop
+      vertex 23.947 -44.8016 20
+      vertex 26.1164 -43.5726 0
+      vertex 23.947 -44.8016 0
+    endloop
+  endfacet
+  facet normal 0.492913 -0.870078 0
+    outer loop
+      vertex -26.1164 43.5726 0
+      vertex -23.947 44.8016 20
+      vertex -26.1164 43.5726 20
+    endloop
+  endfacet
+  facet normal 0.492913 -0.870078 0
+    outer loop
+      vertex -23.947 44.8016 20
+      vertex -26.1164 43.5726 0
+      vertex -23.947 44.8016 0
+    endloop
+  endfacet
+  facet normal 0.61522 0.788356 -0
+    outer loop
+      vertex -30.2615 -40.8029 0
+      vertex -32.2272 -39.2689 20
+      vertex -30.2615 -40.8029 20
+    endloop
+  endfacet
+  facet normal 0.61522 0.788356 0
+    outer loop
+      vertex -32.2272 -39.2689 20
+      vertex -30.2615 -40.8029 0
+      vertex -32.2272 -39.2689 0
+    endloop
+  endfacet
+  facet normal 0.84487 0.534972 0
+    outer loop
+      vertex -42.2387 -28.223 20
+      vertex -43.5726 -26.1164 0
+      vertex -43.5726 -26.1164 20
+    endloop
+  endfacet
+  facet normal 0.84487 0.534972 0
+    outer loop
+      vertex -43.5726 -26.1164 0
+      vertex -42.2387 -28.223 20
+      vertex -42.2387 -28.223 0
+    endloop
+  endfacet
+  facet normal -0.219099 0.975703 0
+    outer loop
+      vertex 12.3434 -49.2776 0
+      vertex 9.91059 -49.8239 20
+      vertex 12.3434 -49.2776 20
+    endloop
+  endfacet
+  facet normal -0.219099 0.975703 0
+    outer loop
+      vertex 9.91059 -49.8239 20
+      vertex 12.3434 -49.2776 0
+      vertex 9.91059 -49.8239 0
+    endloop
+  endfacet
+  facet normal 0.963779 0.266703 0
+    outer loop
+      vertex -48.6126 -14.7465 20
+      vertex -49.2776 -12.3434 0
+      vertex -49.2776 -12.3434 20
+    endloop
+  endfacet
+  facet normal 0.963779 0.266703 0
+    outer loop
+      vertex -49.2776 -12.3434 0
+      vertex -48.6126 -14.7465 20
+      vertex -48.6126 -14.7465 0
+    endloop
+  endfacet
+  facet normal 0.914215 -0.40523 0
+    outer loop
+      vertex -46.9331 19.4403 20
+      vertex -45.9227 21.7198 0
+      vertex -45.9227 21.7198 20
+    endloop
+  endfacet
+  facet normal 0.914215 -0.40523 0
+    outer loop
+      vertex -45.9227 21.7198 0
+      vertex -46.9331 19.4403 20
+      vertex -46.9331 19.4403 0
+    endloop
+  endfacet
+  facet normal 0.893221 -0.449618 0
+    outer loop
+      vertex -45.9227 21.7198 20
+      vertex -44.8016 23.947 0
+      vertex -44.8016 23.947 20
+    endloop
+  endfacet
+  facet normal 0.893221 -0.449618 0
+    outer loop
+      vertex -44.8016 23.947 0
+      vertex -45.9227 21.7198 20
+      vertex -45.9227 21.7198 0
+    endloop
+  endfacet
+  facet normal 0.914215 0.40523 0
+    outer loop
+      vertex -45.9227 -21.7198 20
+      vertex -46.9331 -19.4403 0
+      vertex -46.9331 -19.4403 20
+    endloop
+  endfacet
+  facet normal 0.914215 0.40523 0
+    outer loop
+      vertex -46.9331 -19.4403 0
+      vertex -45.9227 -21.7198 20
+      vertex -45.9227 -21.7198 0
+    endloop
+  endfacet
+  facet normal 0.492913 0.870078 -0
+    outer loop
+      vertex -23.947 -44.8016 0
+      vertex -26.1164 -43.5726 20
+      vertex -23.947 -44.8016 20
+    endloop
+  endfacet
+  facet normal 0.492913 0.870078 0
+    outer loop
+      vertex -26.1164 -43.5726 20
+      vertex -23.947 -44.8016 0
+      vertex -26.1164 -43.5726 0
+    endloop
+  endfacet
+  facet normal 0.893221 0.449618 0
+    outer loop
+      vertex -44.8016 -23.947 20
+      vertex -45.9227 -21.7198 0
+      vertex -45.9227 -21.7198 20
+    endloop
+  endfacet
+  facet normal 0.893221 0.449618 0
+    outer loop
+      vertex -45.9227 -21.7198 0
+      vertex -44.8016 -23.947 20
+      vertex -44.8016 -23.947 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -54.8 -50 190
+      vertex -54.8 50 110
+      vertex -54.8 50 190
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -54.8 50 110
+      vertex -54.8 -50 190
+      vertex -54.8 -50 110
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -59.8 50 190
+      vertex -54.8 -50 190
+      vertex -54.8 50 190
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -50 190
+      vertex -59.8 50 190
+      vertex -59.8 -50 190
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.8 -50 110
+      vertex -54.8 50 110
+      vertex -54.8 -50 110
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -54.8 50 110
+      vertex -59.8 -50 110
+      vertex -59.8 50 110
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 -41.7314 127
+      vertex -59.8 -38.2686 180
+      vertex -59.8 -38.2686 127
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -59.8 -38.2686 180
+      vertex -59.8 -41.7314 127
+      vertex -59.8 -41.7314 180
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 38.2686 127
+      vertex -59.8 41.7314 180
+      vertex -59.8 41.7314 127
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -59.8 41.7314 180
+      vertex -59.8 38.2686 127
+      vertex -59.8 38.2686 180
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 41.7314 127
+      vertex -59.8 50 110
+      vertex -59.8 41.7314 120
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 50 110
+      vertex -59.8 38.2686 120
+      vertex -59.8 41.7314 120
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 -38.2686 127
+      vertex -59.8 38.2686 127
+      vertex -59.8 38.2686 120
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 38.2686 127
+      vertex -59.8 -38.2686 127
+      vertex -59.8 38.2686 180
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 -38.2686 127
+      vertex -59.8 38.2686 120
+      vertex -59.8 -38.2686 120
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 50 110
+      vertex -59.8 -38.2686 120
+      vertex -59.8 38.2686 120
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 -50 110
+      vertex -59.8 -38.2686 120
+      vertex -59.8 50 110
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 -50 110
+      vertex -59.8 -41.7314 127
+      vertex -59.8 -41.7314 120
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 -41.7314 127
+      vertex -59.8 -50 190
+      vertex -59.8 -41.7314 180
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -59.8 -41.7314 127
+      vertex -59.8 -50 110
+      vertex -59.8 -50 190
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -59.8 -38.2686 120
+      vertex -59.8 -50 110
+      vertex -59.8 -41.7314 120
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 50 110
+      vertex -59.8 41.7314 127
+      vertex -59.8 50 190
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 41.7314 180
+      vertex -59.8 50 190
+      vertex -59.8 41.7314 127
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 41.7314 187
+      vertex -59.8 50 190
+      vertex -59.8 41.7314 180
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 38.2686 187
+      vertex -59.8 50 190
+      vertex -59.8 41.7314 187
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 -38.2686 180
+      vertex -59.8 38.2686 180
+      vertex -59.8 -38.2686 127
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 38.2686 180
+      vertex -59.8 -38.2686 180
+      vertex -59.8 38.2686 187
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 -38.2686 187
+      vertex -59.8 38.2686 187
+      vertex -59.8 -38.2686 180
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 38.2686 187
+      vertex -59.8 -38.2686 187
+      vertex -59.8 50 190
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 -50 190
+      vertex -59.8 -38.2686 187
+      vertex -59.8 -41.7314 187
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 -38.2686 187
+      vertex -59.8 -50 190
+      vertex -59.8 50 190
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -59.8 -41.7314 180
+      vertex -59.8 -50 190
+      vertex -59.8 -41.7314 187
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -54.8 50 110
+      vertex -59.8 50 190
+      vertex -54.8 50 190
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -59.8 50 190
+      vertex -54.8 50 110
+      vertex -59.8 50 110
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -59.8 -50 110
+      vertex -54.8 -50 190
+      vertex -59.8 -50 190
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -54.8 -50 190
+      vertex -59.8 -50 110
+      vertex -54.8 -50 110
+    endloop
+  endfacet
+  facet normal -0.997307 -0.0733463 0
+    outer loop
+      vertex -58.8024 -39.9019 120
+      vertex -58.8096 -39.804 127
+      vertex -58.8096 -39.804 120
+    endloop
+  endfacet
+  facet normal -0.997307 -0.0733463 0
+    outer loop
+      vertex -58.8096 -39.804 127
+      vertex -58.8024 -39.9019 120
+      vertex -58.8024 -39.9019 127
+    endloop
+  endfacet
+  facet normal -0.999701 -0.0244575 0
+    outer loop
+      vertex -58.8 -40 120
+      vertex -58.8024 -39.9019 127
+      vertex -58.8024 -39.9019 120
+    endloop
+  endfacet
+  facet normal -0.999701 -0.0244575 0
+    outer loop
+      vertex -58.8024 -39.9019 127
+      vertex -58.8 -40 120
+      vertex -58.8 -40 127
+    endloop
+  endfacet
+  facet normal -0.992511 -0.122155 0
+    outer loop
+      vertex -58.8096 -39.804 120
+      vertex -58.8216 -39.7065 127
+      vertex -58.8216 -39.7065 120
+    endloop
+  endfacet
+  facet normal -0.992511 -0.122155 0
+    outer loop
+      vertex -58.8216 -39.7065 127
+      vertex -58.8096 -39.804 120
+      vertex -58.8096 -39.804 127
+    endloop
+  endfacet
+  facet normal -0.757167 -0.653222 0
+    outer loop
+      vertex -59.254 -38.7312 120
+      vertex -59.3181 -38.6569 127
+      vertex -59.3181 -38.6569 120
+    endloop
+  endfacet
+  facet normal -0.757167 -0.653222 0
+    outer loop
+      vertex -59.3181 -38.6569 127
+      vertex -59.254 -38.7312 120
+      vertex -59.254 -38.7312 127
+    endloop
+  endfacet
+  facet normal -0.653222 -0.757167 0
+    outer loop
+      vertex -59.5312 -38.454 120
+      vertex -59.4569 -38.5181 127
+      vertex -59.5312 -38.454 127
+    endloop
+  endfacet
+  facet normal -0.653222 -0.757167 -0
+    outer loop
+      vertex -59.4569 -38.5181 127
+      vertex -59.5312 -38.454 120
+      vertex -59.4569 -38.5181 120
+    endloop
+  endfacet
+  facet normal -0.788364 0.615209 0
+    outer loop
+      vertex -59.254 -41.2688 120
+      vertex -59.1936 -41.1914 127
+      vertex -59.1936 -41.1914 120
+    endloop
+  endfacet
+  facet normal -0.788364 0.615209 0
+    outer loop
+      vertex -59.1936 -41.1914 127
+      vertex -59.254 -41.2688 120
+      vertex -59.254 -41.2688 127
+    endloop
+  endfacet
+  facet normal -0.788364 -0.615209 0
+    outer loop
+      vertex -59.1936 -38.8086 120
+      vertex -59.254 -38.7312 127
+      vertex -59.254 -38.7312 120
+    endloop
+  endfacet
+  facet normal -0.788364 -0.615209 0
+    outer loop
+      vertex -59.254 -38.7312 127
+      vertex -59.1936 -38.8086 120
+      vertex -59.1936 -38.8086 127
+    endloop
+  endfacet
+  facet normal -0.724211 0.689579 0
+    outer loop
+      vertex -59.3858 -41.4142 120
+      vertex -59.3181 -41.3431 127
+      vertex -59.3181 -41.3431 120
+    endloop
+  endfacet
+  facet normal -0.724211 0.689579 0
+    outer loop
+      vertex -59.3181 -41.3431 127
+      vertex -59.3858 -41.4142 120
+      vertex -59.3858 -41.4142 127
+    endloop
+  endfacet
+  facet normal -0.97573 0.218979 0
+    outer loop
+      vertex -58.8599 -40.486 120
+      vertex -58.8384 -40.3902 127
+      vertex -58.8384 -40.3902 120
+    endloop
+  endfacet
+  facet normal -0.97573 0.218979 0
+    outer loop
+      vertex -58.8384 -40.3902 127
+      vertex -58.8599 -40.486 120
+      vertex -58.8599 -40.486 127
+    endloop
+  endfacet
+  facet normal -0.997307 0.0733463 0
+    outer loop
+      vertex -58.8096 -40.196 120
+      vertex -58.8024 -40.0981 127
+      vertex -58.8024 -40.0981 120
+    endloop
+  endfacet
+  facet normal -0.997307 0.0733463 0
+    outer loop
+      vertex -58.8024 -40.0981 127
+      vertex -58.8096 -40.196 120
+      vertex -58.8096 -40.196 127
+    endloop
+  endfacet
+  facet normal -0.949495 -0.313782 0
+    outer loop
+      vertex -58.8861 -39.4194 120
+      vertex -58.9169 -39.3262 127
+      vertex -58.9169 -39.3262 120
+    endloop
+  endfacet
+  facet normal -0.949495 -0.313782 0
+    outer loop
+      vertex -58.9169 -39.3262 127
+      vertex -58.8861 -39.4194 120
+      vertex -58.8861 -39.4194 127
+    endloop
+  endfacet
+  facet normal -0.892997 0.450062 0
+    outer loop
+      vertex -59.0362 -40.9428 120
+      vertex -58.992 -40.8551 127
+      vertex -58.992 -40.8551 120
+    endloop
+  endfacet
+  facet normal -0.892997 0.450062 0
+    outer loop
+      vertex -58.992 -40.8551 127
+      vertex -59.0362 -40.9428 120
+      vertex -59.0362 -40.9428 127
+    endloop
+  endfacet
+  facet normal -0.87043 -0.492292 0
+    outer loop
+      vertex -59.0362 -39.0572 120
+      vertex -59.0845 -38.9718 127
+      vertex -59.0845 -38.9718 120
+    endloop
+  endfacet
+  facet normal -0.87043 -0.492292 0
+    outer loop
+      vertex -59.0845 -38.9718 127
+      vertex -59.0362 -39.0572 120
+      vertex -59.0362 -39.0572 127
+    endloop
+  endfacet
+  facet normal -0.575443 -0.817842 0
+    outer loop
+      vertex -59.6889 -38.3371 120
+      vertex -59.6086 -38.3936 127
+      vertex -59.6889 -38.3371 127
+    endloop
+  endfacet
+  facet normal -0.575443 -0.817842 -0
+    outer loop
+      vertex -59.6086 -38.3936 127
+      vertex -59.6889 -38.3371 120
+      vertex -59.6086 -38.3936 120
+    endloop
+  endfacet
+  facet normal -0.844374 0.535755 0
+    outer loop
+      vertex -59.1371 -41.1111 120
+      vertex -59.0845 -41.0282 127
+      vertex -59.0845 -41.0282 120
+    endloop
+  endfacet
+  facet normal -0.844374 0.535755 0
+    outer loop
+      vertex -59.0845 -41.0282 127
+      vertex -59.1371 -41.1111 120
+      vertex -59.1371 -41.1111 127
+    endloop
+  endfacet
+  facet normal -0.844374 -0.535755 0
+    outer loop
+      vertex -59.0845 -38.9718 120
+      vertex -59.1371 -38.8889 127
+      vertex -59.1371 -38.8889 120
+    endloop
+  endfacet
+  facet normal -0.844374 -0.535755 0
+    outer loop
+      vertex -59.1371 -38.8889 127
+      vertex -59.0845 -38.9718 120
+      vertex -59.0845 -38.9718 127
+    endloop
+  endfacet
+  facet normal -0.892997 -0.450062 0
+    outer loop
+      vertex -58.992 -39.1449 120
+      vertex -59.0362 -39.0572 127
+      vertex -59.0362 -39.0572 120
+    endloop
+  endfacet
+  facet normal -0.892997 -0.450062 0
+    outer loop
+      vertex -59.0362 -39.0572 127
+      vertex -58.992 -39.1449 120
+      vertex -58.992 -39.1449 127
+    endloop
+  endfacet
+  facet normal -0.985242 0.171169 0
+    outer loop
+      vertex -58.8384 -40.3902 120
+      vertex -58.8216 -40.2935 127
+      vertex -58.8216 -40.2935 120
+    endloop
+  endfacet
+  facet normal -0.985242 0.171169 0
+    outer loop
+      vertex -58.8216 -40.2935 127
+      vertex -58.8384 -40.3902 120
+      vertex -58.8384 -40.3902 127
+    endloop
+  endfacet
+  facet normal -0.535755 0.844374 0
+    outer loop
+      vertex -59.6889 -41.6629 120
+      vertex -59.7718 -41.7155 127
+      vertex -59.6889 -41.6629 127
+    endloop
+  endfacet
+  facet normal -0.535755 0.844374 0
+    outer loop
+      vertex -59.7718 -41.7155 127
+      vertex -59.6889 -41.6629 120
+      vertex -59.7718 -41.7155 120
+    endloop
+  endfacet
+  facet normal -0.963722 0.266908 0
+    outer loop
+      vertex -58.8861 -40.5806 120
+      vertex -58.8599 -40.486 127
+      vertex -58.8599 -40.486 120
+    endloop
+  endfacet
+  facet normal -0.963722 0.266908 0
+    outer loop
+      vertex -58.8599 -40.486 127
+      vertex -58.8861 -40.5806 120
+      vertex -58.8861 -40.5806 127
+    endloop
+  endfacet
+  facet normal -0.992511 0.122155 0
+    outer loop
+      vertex -58.8216 -40.2935 120
+      vertex -58.8096 -40.196 127
+      vertex -58.8096 -40.196 120
+    endloop
+  endfacet
+  facet normal -0.992511 0.122155 0
+    outer loop
+      vertex -58.8096 -40.196 127
+      vertex -58.8216 -40.2935 120
+      vertex -58.8216 -40.2935 127
+    endloop
+  endfacet
+  facet normal -0.933109 -0.359593 0
+    outer loop
+      vertex -58.9169 -39.3262 120
+      vertex -58.9522 -39.2346 127
+      vertex -58.9522 -39.2346 120
+    endloop
+  endfacet
+  facet normal -0.933109 -0.359593 0
+    outer loop
+      vertex -58.9522 -39.2346 127
+      vertex -58.9169 -39.3262 120
+      vertex -58.9169 -39.3262 127
+    endloop
+  endfacet
+  facet normal -0.757167 0.653222 0
+    outer loop
+      vertex -59.3181 -41.3431 120
+      vertex -59.254 -41.2688 127
+      vertex -59.254 -41.2688 120
+    endloop
+  endfacet
+  facet normal -0.757167 0.653222 0
+    outer loop
+      vertex -59.254 -41.2688 127
+      vertex -59.3181 -41.3431 120
+      vertex -59.3181 -41.3431 127
+    endloop
+  endfacet
+  facet normal -0.87043 0.492292 0
+    outer loop
+      vertex -59.0845 -41.0282 120
+      vertex -59.0362 -40.9428 127
+      vertex -59.0362 -40.9428 120
+    endloop
+  endfacet
+  facet normal -0.87043 0.492292 0
+    outer loop
+      vertex -59.0362 -40.9428 127
+      vertex -59.0845 -41.0282 120
+      vertex -59.0845 -41.0282 127
+    endloop
+  endfacet
+  facet normal -0.575443 0.817842 0
+    outer loop
+      vertex -59.6086 -41.6064 120
+      vertex -59.6889 -41.6629 127
+      vertex -59.6086 -41.6064 127
+    endloop
+  endfacet
+  facet normal -0.575443 0.817842 0
+    outer loop
+      vertex -59.6889 -41.6629 127
+      vertex -59.6086 -41.6064 120
+      vertex -59.6889 -41.6629 120
+    endloop
+  endfacet
+  facet normal -0.949495 0.313782 0
+    outer loop
+      vertex -58.9169 -40.6738 120
+      vertex -58.8861 -40.5806 127
+      vertex -58.8861 -40.5806 120
+    endloop
+  endfacet
+  facet normal -0.949495 0.313782 0
+    outer loop
+      vertex -58.8861 -40.5806 127
+      vertex -58.9169 -40.6738 120
+      vertex -58.9169 -40.6738 127
+    endloop
+  endfacet
+  facet normal -0.689579 0.724211 0
+    outer loop
+      vertex -59.3858 -41.4142 120
+      vertex -59.4569 -41.4819 127
+      vertex -59.3858 -41.4142 127
+    endloop
+  endfacet
+  facet normal -0.689579 0.724211 0
+    outer loop
+      vertex -59.4569 -41.4819 127
+      vertex -59.3858 -41.4142 120
+      vertex -59.4569 -41.4819 120
+    endloop
+  endfacet
+  facet normal -0.491141 -0.87108 0
+    outer loop
+      vertex -59.8 -38.2686 120
+      vertex -59.7718 -38.2845 127
+      vertex -59.8 -38.2686 127
+    endloop
+  endfacet
+  facet normal -0.491141 -0.87108 -0
+    outer loop
+      vertex -59.7718 -38.2845 127
+      vertex -59.8 -38.2686 120
+      vertex -59.7718 -38.2845 120
+    endloop
+  endfacet
+  facet normal -0.689579 -0.724211 0
+    outer loop
+      vertex -59.4569 -38.5181 120
+      vertex -59.3858 -38.5858 127
+      vertex -59.4569 -38.5181 127
+    endloop
+  endfacet
+  facet normal -0.689579 -0.724211 -0
+    outer loop
+      vertex -59.3858 -38.5858 127
+      vertex -59.4569 -38.5181 120
+      vertex -59.3858 -38.5858 120
+    endloop
+  endfacet
+  facet normal -0.817842 -0.575443 0
+    outer loop
+      vertex -59.1371 -38.8889 120
+      vertex -59.1936 -38.8086 127
+      vertex -59.1936 -38.8086 120
+    endloop
+  endfacet
+  facet normal -0.817842 -0.575443 0
+    outer loop
+      vertex -59.1936 -38.8086 127
+      vertex -59.1371 -38.8889 120
+      vertex -59.1371 -38.8889 127
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8024 -39.9019 120
+      vertex -58.8024 -40.0981 120
+      vertex -58.8 -40 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8096 -39.804 120
+      vertex -58.8024 -40.0981 120
+      vertex -58.8024 -39.9019 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8096 -39.804 120
+      vertex -58.8096 -40.196 120
+      vertex -58.8024 -40.0981 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8216 -39.7065 120
+      vertex -58.8096 -40.196 120
+      vertex -58.8096 -39.804 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8216 -39.7065 120
+      vertex -58.8216 -40.2935 120
+      vertex -58.8096 -40.196 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8384 -39.6098 120
+      vertex -58.8216 -40.2935 120
+      vertex -58.8216 -39.7065 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8384 -39.6098 120
+      vertex -58.8384 -40.3902 120
+      vertex -58.8216 -40.2935 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8599 -39.514 120
+      vertex -58.8384 -40.3902 120
+      vertex -58.8384 -39.6098 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8599 -39.514 120
+      vertex -58.8599 -40.486 120
+      vertex -58.8384 -40.3902 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8861 -39.4194 120
+      vertex -58.8599 -40.486 120
+      vertex -58.8599 -39.514 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8861 -39.4194 120
+      vertex -58.8861 -40.5806 120
+      vertex -58.8599 -40.486 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9169 -39.3262 120
+      vertex -58.8861 -40.5806 120
+      vertex -58.8861 -39.4194 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9169 -39.3262 120
+      vertex -58.9169 -40.6738 120
+      vertex -58.8861 -40.5806 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9522 -39.2346 120
+      vertex -58.9169 -40.6738 120
+      vertex -58.9169 -39.3262 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9522 -39.2346 120
+      vertex -58.9522 -40.7654 120
+      vertex -58.9169 -40.6738 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.992 -39.1449 120
+      vertex -58.9522 -40.7654 120
+      vertex -58.9522 -39.2346 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.992 -39.1449 120
+      vertex -58.992 -40.8551 120
+      vertex -58.9522 -40.7654 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0362 -39.0572 120
+      vertex -58.992 -40.8551 120
+      vertex -58.992 -39.1449 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0362 -39.0572 120
+      vertex -59.0362 -40.9428 120
+      vertex -58.992 -40.8551 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0845 -38.9718 120
+      vertex -59.0362 -40.9428 120
+      vertex -59.0362 -39.0572 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0845 -38.9718 120
+      vertex -59.0845 -41.0282 120
+      vertex -59.0362 -40.9428 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1371 -38.8889 120
+      vertex -59.0845 -41.0282 120
+      vertex -59.0845 -38.9718 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1371 -38.8889 120
+      vertex -59.1371 -41.1111 120
+      vertex -59.0845 -41.0282 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1936 -38.8086 120
+      vertex -59.1371 -41.1111 120
+      vertex -59.1371 -38.8889 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1936 -38.8086 120
+      vertex -59.1936 -41.1914 120
+      vertex -59.1371 -41.1111 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.254 -38.7312 120
+      vertex -59.1936 -41.1914 120
+      vertex -59.1936 -38.8086 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.254 -38.7312 120
+      vertex -59.254 -41.2688 120
+      vertex -59.1936 -41.1914 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3181 -38.6569 120
+      vertex -59.254 -41.2688 120
+      vertex -59.254 -38.7312 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3181 -38.6569 120
+      vertex -59.3181 -41.3431 120
+      vertex -59.254 -41.2688 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3858 -38.5858 120
+      vertex -59.3181 -41.3431 120
+      vertex -59.3181 -38.6569 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3858 -38.5858 120
+      vertex -59.3858 -41.4142 120
+      vertex -59.3181 -41.3431 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.4569 -38.5181 120
+      vertex -59.3858 -41.4142 120
+      vertex -59.3858 -38.5858 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.4569 -38.5181 120
+      vertex -59.4569 -41.4819 120
+      vertex -59.3858 -41.4142 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.5312 -38.454 120
+      vertex -59.4569 -41.4819 120
+      vertex -59.4569 -38.5181 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.5312 -38.454 120
+      vertex -59.5312 -41.546 120
+      vertex -59.4569 -41.4819 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6086 -38.3936 120
+      vertex -59.5312 -41.546 120
+      vertex -59.5312 -38.454 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6086 -38.3936 120
+      vertex -59.6086 -41.6064 120
+      vertex -59.5312 -41.546 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 -38.3371 120
+      vertex -59.6086 -41.6064 120
+      vertex -59.6086 -38.3936 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 -38.3371 120
+      vertex -59.6889 -41.6629 120
+      vertex -59.6086 -41.6064 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.8 -38.2686 120
+      vertex -59.6889 -38.3371 120
+      vertex -59.7718 -38.2845 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 -38.3371 120
+      vertex -59.8 -38.2686 120
+      vertex -59.6889 -41.6629 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.8 -41.7314 120
+      vertex -59.6889 -41.6629 120
+      vertex -59.8 -38.2686 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 -41.6629 120
+      vertex -59.8 -41.7314 120
+      vertex -59.7718 -41.7155 120
+    endloop
+  endfacet
+  facet normal -0.653222 0.757167 0
+    outer loop
+      vertex -59.4569 -41.4819 120
+      vertex -59.5312 -41.546 127
+      vertex -59.4569 -41.4819 127
+    endloop
+  endfacet
+  facet normal -0.653222 0.757167 0
+    outer loop
+      vertex -59.5312 -41.546 127
+      vertex -59.4569 -41.4819 120
+      vertex -59.5312 -41.546 120
+    endloop
+  endfacet
+  facet normal -0.985242 -0.171169 0
+    outer loop
+      vertex -58.8216 -39.7065 120
+      vertex -58.8384 -39.6098 127
+      vertex -58.8384 -39.6098 120
+    endloop
+  endfacet
+  facet normal -0.985242 -0.171169 0
+    outer loop
+      vertex -58.8384 -39.6098 127
+      vertex -58.8216 -39.7065 120
+      vertex -58.8216 -39.7065 127
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244575 0
+    outer loop
+      vertex -58.8024 -40.0981 120
+      vertex -58.8 -40 127
+      vertex -58.8 -40 120
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244575 0
+    outer loop
+      vertex -58.8 -40 127
+      vertex -58.8024 -40.0981 120
+      vertex -58.8024 -40.0981 127
+    endloop
+  endfacet
+  facet normal -0.914064 -0.405571 0
+    outer loop
+      vertex -58.9522 -39.2346 120
+      vertex -58.992 -39.1449 127
+      vertex -58.992 -39.1449 120
+    endloop
+  endfacet
+  facet normal -0.914064 -0.405571 0
+    outer loop
+      vertex -58.992 -39.1449 127
+      vertex -58.9522 -39.2346 120
+      vertex -58.9522 -39.2346 127
+    endloop
+  endfacet
+  facet normal -0.97573 -0.218979 0
+    outer loop
+      vertex -58.8384 -39.6098 120
+      vertex -58.8599 -39.514 127
+      vertex -58.8599 -39.514 120
+    endloop
+  endfacet
+  facet normal -0.97573 -0.218979 0
+    outer loop
+      vertex -58.8599 -39.514 127
+      vertex -58.8384 -39.6098 120
+      vertex -58.8384 -39.6098 127
+    endloop
+  endfacet
+  facet normal -0.724211 -0.689579 0
+    outer loop
+      vertex -59.3181 -38.6569 120
+      vertex -59.3858 -38.5858 127
+      vertex -59.3858 -38.5858 120
+    endloop
+  endfacet
+  facet normal -0.724211 -0.689579 0
+    outer loop
+      vertex -59.3858 -38.5858 127
+      vertex -59.3181 -38.6569 120
+      vertex -59.3181 -38.6569 127
+    endloop
+  endfacet
+  facet normal -0.963722 -0.266908 0
+    outer loop
+      vertex -58.8599 -39.514 120
+      vertex -58.8861 -39.4194 127
+      vertex -58.8861 -39.4194 120
+    endloop
+  endfacet
+  facet normal -0.963722 -0.266908 0
+    outer loop
+      vertex -58.8861 -39.4194 127
+      vertex -58.8599 -39.514 120
+      vertex -58.8599 -39.514 127
+    endloop
+  endfacet
+  facet normal -0.535755 -0.844374 0
+    outer loop
+      vertex -59.7718 -38.2845 120
+      vertex -59.6889 -38.3371 127
+      vertex -59.7718 -38.2845 127
+    endloop
+  endfacet
+  facet normal -0.535755 -0.844374 -0
+    outer loop
+      vertex -59.6889 -38.3371 127
+      vertex -59.7718 -38.2845 120
+      vertex -59.6889 -38.3371 120
+    endloop
+  endfacet
+  facet normal -0.817842 0.575443 0
+    outer loop
+      vertex -59.1936 -41.1914 120
+      vertex -59.1371 -41.1111 127
+      vertex -59.1371 -41.1111 120
+    endloop
+  endfacet
+  facet normal -0.817842 0.575443 0
+    outer loop
+      vertex -59.1371 -41.1111 127
+      vertex -59.1936 -41.1914 120
+      vertex -59.1936 -41.1914 127
+    endloop
+  endfacet
+  facet normal -0.615209 -0.788364 0
+    outer loop
+      vertex -59.6086 -38.3936 120
+      vertex -59.5312 -38.454 127
+      vertex -59.6086 -38.3936 127
+    endloop
+  endfacet
+  facet normal -0.615209 -0.788364 -0
+    outer loop
+      vertex -59.5312 -38.454 127
+      vertex -59.6086 -38.3936 120
+      vertex -59.5312 -38.454 120
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8024 -40.0981 127
+      vertex -58.8024 -39.9019 127
+      vertex -58.8 -40 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8096 -40.196 127
+      vertex -58.8024 -39.9019 127
+      vertex -58.8024 -40.0981 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8096 -40.196 127
+      vertex -58.8096 -39.804 127
+      vertex -58.8024 -39.9019 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8216 -40.2935 127
+      vertex -58.8096 -39.804 127
+      vertex -58.8096 -40.196 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8216 -40.2935 127
+      vertex -58.8216 -39.7065 127
+      vertex -58.8096 -39.804 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8384 -40.3902 127
+      vertex -58.8216 -39.7065 127
+      vertex -58.8216 -40.2935 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8384 -40.3902 127
+      vertex -58.8384 -39.6098 127
+      vertex -58.8216 -39.7065 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8599 -40.486 127
+      vertex -58.8384 -39.6098 127
+      vertex -58.8384 -40.3902 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8599 -40.486 127
+      vertex -58.8599 -39.514 127
+      vertex -58.8384 -39.6098 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8861 -40.5806 127
+      vertex -58.8599 -39.514 127
+      vertex -58.8599 -40.486 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8861 -40.5806 127
+      vertex -58.8861 -39.4194 127
+      vertex -58.8599 -39.514 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9169 -40.6738 127
+      vertex -58.8861 -39.4194 127
+      vertex -58.8861 -40.5806 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9169 -40.6738 127
+      vertex -58.9169 -39.3262 127
+      vertex -58.8861 -39.4194 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9522 -40.7654 127
+      vertex -58.9169 -39.3262 127
+      vertex -58.9169 -40.6738 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9522 -40.7654 127
+      vertex -58.9522 -39.2346 127
+      vertex -58.9169 -39.3262 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.992 -40.8551 127
+      vertex -58.9522 -39.2346 127
+      vertex -58.9522 -40.7654 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.992 -40.8551 127
+      vertex -58.992 -39.1449 127
+      vertex -58.9522 -39.2346 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0362 -40.9428 127
+      vertex -58.992 -39.1449 127
+      vertex -58.992 -40.8551 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0362 -40.9428 127
+      vertex -59.0362 -39.0572 127
+      vertex -58.992 -39.1449 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0845 -41.0282 127
+      vertex -59.0362 -39.0572 127
+      vertex -59.0362 -40.9428 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0845 -41.0282 127
+      vertex -59.0845 -38.9718 127
+      vertex -59.0362 -39.0572 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1371 -41.1111 127
+      vertex -59.0845 -38.9718 127
+      vertex -59.0845 -41.0282 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1371 -41.1111 127
+      vertex -59.1371 -38.8889 127
+      vertex -59.0845 -38.9718 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1936 -41.1914 127
+      vertex -59.1371 -38.8889 127
+      vertex -59.1371 -41.1111 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1936 -41.1914 127
+      vertex -59.1936 -38.8086 127
+      vertex -59.1371 -38.8889 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.254 -41.2688 127
+      vertex -59.1936 -38.8086 127
+      vertex -59.1936 -41.1914 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.254 -41.2688 127
+      vertex -59.254 -38.7312 127
+      vertex -59.1936 -38.8086 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3181 -41.3431 127
+      vertex -59.254 -38.7312 127
+      vertex -59.254 -41.2688 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3181 -41.3431 127
+      vertex -59.3181 -38.6569 127
+      vertex -59.254 -38.7312 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3858 -41.4142 127
+      vertex -59.3181 -38.6569 127
+      vertex -59.3181 -41.3431 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3858 -41.4142 127
+      vertex -59.3858 -38.5858 127
+      vertex -59.3181 -38.6569 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.4569 -41.4819 127
+      vertex -59.3858 -38.5858 127
+      vertex -59.3858 -41.4142 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.4569 -41.4819 127
+      vertex -59.4569 -38.5181 127
+      vertex -59.3858 -38.5858 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.5312 -41.546 127
+      vertex -59.4569 -38.5181 127
+      vertex -59.4569 -41.4819 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.5312 -41.546 127
+      vertex -59.5312 -38.454 127
+      vertex -59.4569 -38.5181 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6086 -41.6064 127
+      vertex -59.5312 -38.454 127
+      vertex -59.5312 -41.546 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6086 -41.6064 127
+      vertex -59.6086 -38.3936 127
+      vertex -59.5312 -38.454 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6889 -41.6629 127
+      vertex -59.6086 -38.3936 127
+      vertex -59.6086 -41.6064 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6889 -41.6629 127
+      vertex -59.6889 -38.3371 127
+      vertex -59.6086 -38.3936 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.8 -41.7314 127
+      vertex -59.6889 -41.6629 127
+      vertex -59.7718 -41.7155 127
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -59.6889 -41.6629 127
+      vertex -59.8 -41.7314 127
+      vertex -59.6889 -38.3371 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.8 -38.2686 127
+      vertex -59.6889 -38.3371 127
+      vertex -59.8 -41.7314 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6889 -38.3371 127
+      vertex -59.8 -38.2686 127
+      vertex -59.7718 -38.2845 127
+    endloop
+  endfacet
+  facet normal -0.491141 0.87108 0
+    outer loop
+      vertex -59.7718 -41.7155 120
+      vertex -59.8 -41.7314 127
+      vertex -59.7718 -41.7155 127
+    endloop
+  endfacet
+  facet normal -0.491141 0.87108 0
+    outer loop
+      vertex -59.8 -41.7314 127
+      vertex -59.7718 -41.7155 120
+      vertex -59.8 -41.7314 120
+    endloop
+  endfacet
+  facet normal -0.615209 0.788364 0
+    outer loop
+      vertex -59.5312 -41.546 120
+      vertex -59.6086 -41.6064 127
+      vertex -59.5312 -41.546 127
+    endloop
+  endfacet
+  facet normal -0.615209 0.788364 0
+    outer loop
+      vertex -59.6086 -41.6064 127
+      vertex -59.5312 -41.546 120
+      vertex -59.6086 -41.6064 120
+    endloop
+  endfacet
+  facet normal -0.914064 0.405571 0
+    outer loop
+      vertex -58.992 -40.8551 120
+      vertex -58.9522 -40.7654 127
+      vertex -58.9522 -40.7654 120
+    endloop
+  endfacet
+  facet normal -0.914064 0.405571 0
+    outer loop
+      vertex -58.9522 -40.7654 127
+      vertex -58.992 -40.8551 120
+      vertex -58.992 -40.8551 127
+    endloop
+  endfacet
+  facet normal -0.933109 0.359593 0
+    outer loop
+      vertex -58.9522 -40.7654 120
+      vertex -58.9169 -40.6738 127
+      vertex -58.9169 -40.6738 120
+    endloop
+  endfacet
+  facet normal -0.933109 0.359593 0
+    outer loop
+      vertex -58.9169 -40.6738 127
+      vertex -58.9522 -40.7654 120
+      vertex -58.9522 -40.7654 127
+    endloop
+  endfacet
+  facet normal -0.997307 -0.0733463 0
+    outer loop
+      vertex -58.8024 40.0981 120
+      vertex -58.8096 40.196 127
+      vertex -58.8096 40.196 120
+    endloop
+  endfacet
+  facet normal -0.997307 -0.0733463 0
+    outer loop
+      vertex -58.8096 40.196 127
+      vertex -58.8024 40.0981 120
+      vertex -58.8024 40.0981 127
+    endloop
+  endfacet
+  facet normal -0.999701 -0.0244575 0
+    outer loop
+      vertex -58.8 40 120
+      vertex -58.8024 40.0981 127
+      vertex -58.8024 40.0981 120
+    endloop
+  endfacet
+  facet normal -0.999701 -0.0244575 0
+    outer loop
+      vertex -58.8024 40.0981 127
+      vertex -58.8 40 120
+      vertex -58.8 40 127
+    endloop
+  endfacet
+  facet normal -0.992511 -0.122155 0
+    outer loop
+      vertex -58.8096 40.196 120
+      vertex -58.8216 40.2935 127
+      vertex -58.8216 40.2935 120
+    endloop
+  endfacet
+  facet normal -0.992511 -0.122155 0
+    outer loop
+      vertex -58.8216 40.2935 127
+      vertex -58.8096 40.196 120
+      vertex -58.8096 40.196 127
+    endloop
+  endfacet
+  facet normal -0.757167 -0.653222 0
+    outer loop
+      vertex -59.254 41.2688 120
+      vertex -59.3181 41.3431 127
+      vertex -59.3181 41.3431 120
+    endloop
+  endfacet
+  facet normal -0.757167 -0.653222 0
+    outer loop
+      vertex -59.3181 41.3431 127
+      vertex -59.254 41.2688 120
+      vertex -59.254 41.2688 127
+    endloop
+  endfacet
+  facet normal -0.653222 -0.757167 0
+    outer loop
+      vertex -59.5312 41.546 120
+      vertex -59.4569 41.4819 127
+      vertex -59.5312 41.546 127
+    endloop
+  endfacet
+  facet normal -0.653222 -0.757167 -0
+    outer loop
+      vertex -59.4569 41.4819 127
+      vertex -59.5312 41.546 120
+      vertex -59.4569 41.4819 120
+    endloop
+  endfacet
+  facet normal -0.788364 0.615209 0
+    outer loop
+      vertex -59.254 38.7312 120
+      vertex -59.1936 38.8086 127
+      vertex -59.1936 38.8086 120
+    endloop
+  endfacet
+  facet normal -0.788364 0.615209 0
+    outer loop
+      vertex -59.1936 38.8086 127
+      vertex -59.254 38.7312 120
+      vertex -59.254 38.7312 127
+    endloop
+  endfacet
+  facet normal -0.788364 -0.615209 0
+    outer loop
+      vertex -59.1936 41.1914 120
+      vertex -59.254 41.2688 127
+      vertex -59.254 41.2688 120
+    endloop
+  endfacet
+  facet normal -0.788364 -0.615209 0
+    outer loop
+      vertex -59.254 41.2688 127
+      vertex -59.1936 41.1914 120
+      vertex -59.1936 41.1914 127
+    endloop
+  endfacet
+  facet normal -0.724211 0.689579 0
+    outer loop
+      vertex -59.3858 38.5858 120
+      vertex -59.3181 38.6569 127
+      vertex -59.3181 38.6569 120
+    endloop
+  endfacet
+  facet normal -0.724211 0.689579 0
+    outer loop
+      vertex -59.3181 38.6569 127
+      vertex -59.3858 38.5858 120
+      vertex -59.3858 38.5858 127
+    endloop
+  endfacet
+  facet normal -0.97573 0.218979 0
+    outer loop
+      vertex -58.8599 39.514 120
+      vertex -58.8384 39.6098 127
+      vertex -58.8384 39.6098 120
+    endloop
+  endfacet
+  facet normal -0.97573 0.218979 0
+    outer loop
+      vertex -58.8384 39.6098 127
+      vertex -58.8599 39.514 120
+      vertex -58.8599 39.514 127
+    endloop
+  endfacet
+  facet normal -0.997307 0.0733463 0
+    outer loop
+      vertex -58.8096 39.804 120
+      vertex -58.8024 39.9019 127
+      vertex -58.8024 39.9019 120
+    endloop
+  endfacet
+  facet normal -0.997307 0.0733463 0
+    outer loop
+      vertex -58.8024 39.9019 127
+      vertex -58.8096 39.804 120
+      vertex -58.8096 39.804 127
+    endloop
+  endfacet
+  facet normal -0.949495 -0.313782 0
+    outer loop
+      vertex -58.8861 40.5806 120
+      vertex -58.9169 40.6738 127
+      vertex -58.9169 40.6738 120
+    endloop
+  endfacet
+  facet normal -0.949495 -0.313782 0
+    outer loop
+      vertex -58.9169 40.6738 127
+      vertex -58.8861 40.5806 120
+      vertex -58.8861 40.5806 127
+    endloop
+  endfacet
+  facet normal -0.892997 0.450062 0
+    outer loop
+      vertex -59.0362 39.0572 120
+      vertex -58.992 39.1449 127
+      vertex -58.992 39.1449 120
+    endloop
+  endfacet
+  facet normal -0.892997 0.450062 0
+    outer loop
+      vertex -58.992 39.1449 127
+      vertex -59.0362 39.0572 120
+      vertex -59.0362 39.0572 127
+    endloop
+  endfacet
+  facet normal -0.87043 -0.492292 0
+    outer loop
+      vertex -59.0362 40.9428 120
+      vertex -59.0845 41.0282 127
+      vertex -59.0845 41.0282 120
+    endloop
+  endfacet
+  facet normal -0.87043 -0.492292 0
+    outer loop
+      vertex -59.0845 41.0282 127
+      vertex -59.0362 40.9428 120
+      vertex -59.0362 40.9428 127
+    endloop
+  endfacet
+  facet normal -0.575443 -0.817842 0
+    outer loop
+      vertex -59.6889 41.6629 120
+      vertex -59.6086 41.6064 127
+      vertex -59.6889 41.6629 127
+    endloop
+  endfacet
+  facet normal -0.575443 -0.817842 -0
+    outer loop
+      vertex -59.6086 41.6064 127
+      vertex -59.6889 41.6629 120
+      vertex -59.6086 41.6064 120
+    endloop
+  endfacet
+  facet normal -0.844374 0.535755 0
+    outer loop
+      vertex -59.1371 38.8889 120
+      vertex -59.0845 38.9718 127
+      vertex -59.0845 38.9718 120
+    endloop
+  endfacet
+  facet normal -0.844374 0.535755 0
+    outer loop
+      vertex -59.0845 38.9718 127
+      vertex -59.1371 38.8889 120
+      vertex -59.1371 38.8889 127
+    endloop
+  endfacet
+  facet normal -0.844374 -0.535755 0
+    outer loop
+      vertex -59.0845 41.0282 120
+      vertex -59.1371 41.1111 127
+      vertex -59.1371 41.1111 120
+    endloop
+  endfacet
+  facet normal -0.844374 -0.535755 0
+    outer loop
+      vertex -59.1371 41.1111 127
+      vertex -59.0845 41.0282 120
+      vertex -59.0845 41.0282 127
+    endloop
+  endfacet
+  facet normal -0.892997 -0.450062 0
+    outer loop
+      vertex -58.992 40.8551 120
+      vertex -59.0362 40.9428 127
+      vertex -59.0362 40.9428 120
+    endloop
+  endfacet
+  facet normal -0.892997 -0.450062 0
+    outer loop
+      vertex -59.0362 40.9428 127
+      vertex -58.992 40.8551 120
+      vertex -58.992 40.8551 127
+    endloop
+  endfacet
+  facet normal -0.985242 0.171169 0
+    outer loop
+      vertex -58.8384 39.6098 120
+      vertex -58.8216 39.7065 127
+      vertex -58.8216 39.7065 120
+    endloop
+  endfacet
+  facet normal -0.985242 0.171169 0
+    outer loop
+      vertex -58.8216 39.7065 127
+      vertex -58.8384 39.6098 120
+      vertex -58.8384 39.6098 127
+    endloop
+  endfacet
+  facet normal -0.535755 0.844374 0
+    outer loop
+      vertex -59.6889 38.3371 120
+      vertex -59.7718 38.2845 127
+      vertex -59.6889 38.3371 127
+    endloop
+  endfacet
+  facet normal -0.535755 0.844374 0
+    outer loop
+      vertex -59.7718 38.2845 127
+      vertex -59.6889 38.3371 120
+      vertex -59.7718 38.2845 120
+    endloop
+  endfacet
+  facet normal -0.963722 0.266908 0
+    outer loop
+      vertex -58.8861 39.4194 120
+      vertex -58.8599 39.514 127
+      vertex -58.8599 39.514 120
+    endloop
+  endfacet
+  facet normal -0.963722 0.266908 0
+    outer loop
+      vertex -58.8599 39.514 127
+      vertex -58.8861 39.4194 120
+      vertex -58.8861 39.4194 127
+    endloop
+  endfacet
+  facet normal -0.992511 0.122155 0
+    outer loop
+      vertex -58.8216 39.7065 120
+      vertex -58.8096 39.804 127
+      vertex -58.8096 39.804 120
+    endloop
+  endfacet
+  facet normal -0.992511 0.122155 0
+    outer loop
+      vertex -58.8096 39.804 127
+      vertex -58.8216 39.7065 120
+      vertex -58.8216 39.7065 127
+    endloop
+  endfacet
+  facet normal -0.933109 -0.359593 0
+    outer loop
+      vertex -58.9169 40.6738 120
+      vertex -58.9522 40.7654 127
+      vertex -58.9522 40.7654 120
+    endloop
+  endfacet
+  facet normal -0.933109 -0.359593 0
+    outer loop
+      vertex -58.9522 40.7654 127
+      vertex -58.9169 40.6738 120
+      vertex -58.9169 40.6738 127
+    endloop
+  endfacet
+  facet normal -0.757167 0.653222 0
+    outer loop
+      vertex -59.3181 38.6569 120
+      vertex -59.254 38.7312 127
+      vertex -59.254 38.7312 120
+    endloop
+  endfacet
+  facet normal -0.757167 0.653222 0
+    outer loop
+      vertex -59.254 38.7312 127
+      vertex -59.3181 38.6569 120
+      vertex -59.3181 38.6569 127
+    endloop
+  endfacet
+  facet normal -0.87043 0.492292 0
+    outer loop
+      vertex -59.0845 38.9718 120
+      vertex -59.0362 39.0572 127
+      vertex -59.0362 39.0572 120
+    endloop
+  endfacet
+  facet normal -0.87043 0.492292 0
+    outer loop
+      vertex -59.0362 39.0572 127
+      vertex -59.0845 38.9718 120
+      vertex -59.0845 38.9718 127
+    endloop
+  endfacet
+  facet normal -0.575443 0.817842 0
+    outer loop
+      vertex -59.6086 38.3936 120
+      vertex -59.6889 38.3371 127
+      vertex -59.6086 38.3936 127
+    endloop
+  endfacet
+  facet normal -0.575443 0.817842 0
+    outer loop
+      vertex -59.6889 38.3371 127
+      vertex -59.6086 38.3936 120
+      vertex -59.6889 38.3371 120
+    endloop
+  endfacet
+  facet normal -0.949495 0.313782 0
+    outer loop
+      vertex -58.9169 39.3262 120
+      vertex -58.8861 39.4194 127
+      vertex -58.8861 39.4194 120
+    endloop
+  endfacet
+  facet normal -0.949495 0.313782 0
+    outer loop
+      vertex -58.8861 39.4194 127
+      vertex -58.9169 39.3262 120
+      vertex -58.9169 39.3262 127
+    endloop
+  endfacet
+  facet normal -0.689579 0.724211 0
+    outer loop
+      vertex -59.3858 38.5858 120
+      vertex -59.4569 38.5181 127
+      vertex -59.3858 38.5858 127
+    endloop
+  endfacet
+  facet normal -0.689579 0.724211 0
+    outer loop
+      vertex -59.4569 38.5181 127
+      vertex -59.3858 38.5858 120
+      vertex -59.4569 38.5181 120
+    endloop
+  endfacet
+  facet normal -0.491141 -0.87108 0
+    outer loop
+      vertex -59.8 41.7314 120
+      vertex -59.7718 41.7155 127
+      vertex -59.8 41.7314 127
+    endloop
+  endfacet
+  facet normal -0.491141 -0.87108 -0
+    outer loop
+      vertex -59.7718 41.7155 127
+      vertex -59.8 41.7314 120
+      vertex -59.7718 41.7155 120
+    endloop
+  endfacet
+  facet normal -0.689579 -0.724211 0
+    outer loop
+      vertex -59.4569 41.4819 120
+      vertex -59.3858 41.4142 127
+      vertex -59.4569 41.4819 127
+    endloop
+  endfacet
+  facet normal -0.689579 -0.724211 -0
+    outer loop
+      vertex -59.3858 41.4142 127
+      vertex -59.4569 41.4819 120
+      vertex -59.3858 41.4142 120
+    endloop
+  endfacet
+  facet normal -0.817842 -0.575443 0
+    outer loop
+      vertex -59.1371 41.1111 120
+      vertex -59.1936 41.1914 127
+      vertex -59.1936 41.1914 120
+    endloop
+  endfacet
+  facet normal -0.817842 -0.575443 0
+    outer loop
+      vertex -59.1936 41.1914 127
+      vertex -59.1371 41.1111 120
+      vertex -59.1371 41.1111 127
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8024 40.0981 120
+      vertex -58.8024 39.9019 120
+      vertex -58.8 40 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8096 40.196 120
+      vertex -58.8024 39.9019 120
+      vertex -58.8024 40.0981 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8096 40.196 120
+      vertex -58.8096 39.804 120
+      vertex -58.8024 39.9019 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8216 40.2935 120
+      vertex -58.8096 39.804 120
+      vertex -58.8096 40.196 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8216 40.2935 120
+      vertex -58.8216 39.7065 120
+      vertex -58.8096 39.804 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8384 40.3902 120
+      vertex -58.8216 39.7065 120
+      vertex -58.8216 40.2935 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8384 40.3902 120
+      vertex -58.8384 39.6098 120
+      vertex -58.8216 39.7065 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8599 40.486 120
+      vertex -58.8384 39.6098 120
+      vertex -58.8384 40.3902 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8599 40.486 120
+      vertex -58.8599 39.514 120
+      vertex -58.8384 39.6098 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8861 40.5806 120
+      vertex -58.8599 39.514 120
+      vertex -58.8599 40.486 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8861 40.5806 120
+      vertex -58.8861 39.4194 120
+      vertex -58.8599 39.514 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9169 40.6738 120
+      vertex -58.8861 39.4194 120
+      vertex -58.8861 40.5806 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9169 40.6738 120
+      vertex -58.9169 39.3262 120
+      vertex -58.8861 39.4194 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9522 40.7654 120
+      vertex -58.9169 39.3262 120
+      vertex -58.9169 40.6738 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9522 40.7654 120
+      vertex -58.9522 39.2346 120
+      vertex -58.9169 39.3262 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.992 40.8551 120
+      vertex -58.9522 39.2346 120
+      vertex -58.9522 40.7654 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.992 40.8551 120
+      vertex -58.992 39.1449 120
+      vertex -58.9522 39.2346 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0362 40.9428 120
+      vertex -58.992 39.1449 120
+      vertex -58.992 40.8551 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0362 40.9428 120
+      vertex -59.0362 39.0572 120
+      vertex -58.992 39.1449 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0845 41.0282 120
+      vertex -59.0362 39.0572 120
+      vertex -59.0362 40.9428 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0845 41.0282 120
+      vertex -59.0845 38.9718 120
+      vertex -59.0362 39.0572 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1371 41.1111 120
+      vertex -59.0845 38.9718 120
+      vertex -59.0845 41.0282 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1371 41.1111 120
+      vertex -59.1371 38.8889 120
+      vertex -59.0845 38.9718 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1936 41.1914 120
+      vertex -59.1371 38.8889 120
+      vertex -59.1371 41.1111 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1936 41.1914 120
+      vertex -59.1936 38.8086 120
+      vertex -59.1371 38.8889 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.254 41.2688 120
+      vertex -59.1936 38.8086 120
+      vertex -59.1936 41.1914 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.254 41.2688 120
+      vertex -59.254 38.7312 120
+      vertex -59.1936 38.8086 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3181 41.3431 120
+      vertex -59.254 38.7312 120
+      vertex -59.254 41.2688 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3181 41.3431 120
+      vertex -59.3181 38.6569 120
+      vertex -59.254 38.7312 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3858 41.4142 120
+      vertex -59.3181 38.6569 120
+      vertex -59.3181 41.3431 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3858 41.4142 120
+      vertex -59.3858 38.5858 120
+      vertex -59.3181 38.6569 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.4569 41.4819 120
+      vertex -59.3858 38.5858 120
+      vertex -59.3858 41.4142 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.4569 41.4819 120
+      vertex -59.4569 38.5181 120
+      vertex -59.3858 38.5858 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.5312 41.546 120
+      vertex -59.4569 38.5181 120
+      vertex -59.4569 41.4819 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.5312 41.546 120
+      vertex -59.5312 38.454 120
+      vertex -59.4569 38.5181 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6086 41.6064 120
+      vertex -59.5312 38.454 120
+      vertex -59.5312 41.546 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6086 41.6064 120
+      vertex -59.6086 38.3936 120
+      vertex -59.5312 38.454 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 41.6629 120
+      vertex -59.6086 38.3936 120
+      vertex -59.6086 41.6064 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 41.6629 120
+      vertex -59.6889 38.3371 120
+      vertex -59.6086 38.3936 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.8 41.7314 120
+      vertex -59.6889 41.6629 120
+      vertex -59.7718 41.7155 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 41.6629 120
+      vertex -59.8 41.7314 120
+      vertex -59.6889 38.3371 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.8 38.2686 120
+      vertex -59.6889 38.3371 120
+      vertex -59.8 41.7314 120
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 38.3371 120
+      vertex -59.8 38.2686 120
+      vertex -59.7718 38.2845 120
+    endloop
+  endfacet
+  facet normal -0.653222 0.757167 0
+    outer loop
+      vertex -59.4569 38.5181 120
+      vertex -59.5312 38.454 127
+      vertex -59.4569 38.5181 127
+    endloop
+  endfacet
+  facet normal -0.653222 0.757167 0
+    outer loop
+      vertex -59.5312 38.454 127
+      vertex -59.4569 38.5181 120
+      vertex -59.5312 38.454 120
+    endloop
+  endfacet
+  facet normal -0.985242 -0.171169 0
+    outer loop
+      vertex -58.8216 40.2935 120
+      vertex -58.8384 40.3902 127
+      vertex -58.8384 40.3902 120
+    endloop
+  endfacet
+  facet normal -0.985242 -0.171169 0
+    outer loop
+      vertex -58.8384 40.3902 127
+      vertex -58.8216 40.2935 120
+      vertex -58.8216 40.2935 127
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244575 0
+    outer loop
+      vertex -58.8024 39.9019 120
+      vertex -58.8 40 127
+      vertex -58.8 40 120
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244575 0
+    outer loop
+      vertex -58.8 40 127
+      vertex -58.8024 39.9019 120
+      vertex -58.8024 39.9019 127
+    endloop
+  endfacet
+  facet normal -0.914064 -0.405571 0
+    outer loop
+      vertex -58.9522 40.7654 120
+      vertex -58.992 40.8551 127
+      vertex -58.992 40.8551 120
+    endloop
+  endfacet
+  facet normal -0.914064 -0.405571 0
+    outer loop
+      vertex -58.992 40.8551 127
+      vertex -58.9522 40.7654 120
+      vertex -58.9522 40.7654 127
+    endloop
+  endfacet
+  facet normal -0.97573 -0.218979 0
+    outer loop
+      vertex -58.8384 40.3902 120
+      vertex -58.8599 40.486 127
+      vertex -58.8599 40.486 120
+    endloop
+  endfacet
+  facet normal -0.97573 -0.218979 0
+    outer loop
+      vertex -58.8599 40.486 127
+      vertex -58.8384 40.3902 120
+      vertex -58.8384 40.3902 127
+    endloop
+  endfacet
+  facet normal -0.724211 -0.689579 0
+    outer loop
+      vertex -59.3181 41.3431 120
+      vertex -59.3858 41.4142 127
+      vertex -59.3858 41.4142 120
+    endloop
+  endfacet
+  facet normal -0.724211 -0.689579 0
+    outer loop
+      vertex -59.3858 41.4142 127
+      vertex -59.3181 41.3431 120
+      vertex -59.3181 41.3431 127
+    endloop
+  endfacet
+  facet normal -0.963722 -0.266908 0
+    outer loop
+      vertex -58.8599 40.486 120
+      vertex -58.8861 40.5806 127
+      vertex -58.8861 40.5806 120
+    endloop
+  endfacet
+  facet normal -0.963722 -0.266908 0
+    outer loop
+      vertex -58.8861 40.5806 127
+      vertex -58.8599 40.486 120
+      vertex -58.8599 40.486 127
+    endloop
+  endfacet
+  facet normal -0.535755 -0.844374 0
+    outer loop
+      vertex -59.7718 41.7155 120
+      vertex -59.6889 41.6629 127
+      vertex -59.7718 41.7155 127
+    endloop
+  endfacet
+  facet normal -0.535755 -0.844374 -0
+    outer loop
+      vertex -59.6889 41.6629 127
+      vertex -59.7718 41.7155 120
+      vertex -59.6889 41.6629 120
+    endloop
+  endfacet
+  facet normal -0.817842 0.575443 0
+    outer loop
+      vertex -59.1936 38.8086 120
+      vertex -59.1371 38.8889 127
+      vertex -59.1371 38.8889 120
+    endloop
+  endfacet
+  facet normal -0.817842 0.575443 0
+    outer loop
+      vertex -59.1371 38.8889 127
+      vertex -59.1936 38.8086 120
+      vertex -59.1936 38.8086 127
+    endloop
+  endfacet
+  facet normal -0.615209 -0.788364 0
+    outer loop
+      vertex -59.6086 41.6064 120
+      vertex -59.5312 41.546 127
+      vertex -59.6086 41.6064 127
+    endloop
+  endfacet
+  facet normal -0.615209 -0.788364 -0
+    outer loop
+      vertex -59.5312 41.546 127
+      vertex -59.6086 41.6064 120
+      vertex -59.5312 41.546 120
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8024 39.9019 127
+      vertex -58.8024 40.0981 127
+      vertex -58.8 40 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8096 39.804 127
+      vertex -58.8024 40.0981 127
+      vertex -58.8024 39.9019 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8096 39.804 127
+      vertex -58.8096 40.196 127
+      vertex -58.8024 40.0981 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8216 39.7065 127
+      vertex -58.8096 40.196 127
+      vertex -58.8096 39.804 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8216 39.7065 127
+      vertex -58.8216 40.2935 127
+      vertex -58.8096 40.196 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8384 39.6098 127
+      vertex -58.8216 40.2935 127
+      vertex -58.8216 39.7065 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8384 39.6098 127
+      vertex -58.8384 40.3902 127
+      vertex -58.8216 40.2935 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8599 39.514 127
+      vertex -58.8384 40.3902 127
+      vertex -58.8384 39.6098 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8599 39.514 127
+      vertex -58.8599 40.486 127
+      vertex -58.8384 40.3902 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8861 39.4194 127
+      vertex -58.8599 40.486 127
+      vertex -58.8599 39.514 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8861 39.4194 127
+      vertex -58.8861 40.5806 127
+      vertex -58.8599 40.486 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9169 39.3262 127
+      vertex -58.8861 40.5806 127
+      vertex -58.8861 39.4194 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9169 39.3262 127
+      vertex -58.9169 40.6738 127
+      vertex -58.8861 40.5806 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9522 39.2346 127
+      vertex -58.9169 40.6738 127
+      vertex -58.9169 39.3262 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9522 39.2346 127
+      vertex -58.9522 40.7654 127
+      vertex -58.9169 40.6738 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.992 39.1449 127
+      vertex -58.9522 40.7654 127
+      vertex -58.9522 39.2346 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.992 39.1449 127
+      vertex -58.992 40.8551 127
+      vertex -58.9522 40.7654 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0362 39.0572 127
+      vertex -58.992 40.8551 127
+      vertex -58.992 39.1449 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0362 39.0572 127
+      vertex -59.0362 40.9428 127
+      vertex -58.992 40.8551 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0845 38.9718 127
+      vertex -59.0362 40.9428 127
+      vertex -59.0362 39.0572 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0845 38.9718 127
+      vertex -59.0845 41.0282 127
+      vertex -59.0362 40.9428 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1371 38.8889 127
+      vertex -59.0845 41.0282 127
+      vertex -59.0845 38.9718 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1371 38.8889 127
+      vertex -59.1371 41.1111 127
+      vertex -59.0845 41.0282 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1936 38.8086 127
+      vertex -59.1371 41.1111 127
+      vertex -59.1371 38.8889 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1936 38.8086 127
+      vertex -59.1936 41.1914 127
+      vertex -59.1371 41.1111 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.254 38.7312 127
+      vertex -59.1936 41.1914 127
+      vertex -59.1936 38.8086 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.254 38.7312 127
+      vertex -59.254 41.2688 127
+      vertex -59.1936 41.1914 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3181 38.6569 127
+      vertex -59.254 41.2688 127
+      vertex -59.254 38.7312 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3181 38.6569 127
+      vertex -59.3181 41.3431 127
+      vertex -59.254 41.2688 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3858 38.5858 127
+      vertex -59.3181 41.3431 127
+      vertex -59.3181 38.6569 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3858 38.5858 127
+      vertex -59.3858 41.4142 127
+      vertex -59.3181 41.3431 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.4569 38.5181 127
+      vertex -59.3858 41.4142 127
+      vertex -59.3858 38.5858 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.4569 38.5181 127
+      vertex -59.4569 41.4819 127
+      vertex -59.3858 41.4142 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.5312 38.454 127
+      vertex -59.4569 41.4819 127
+      vertex -59.4569 38.5181 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.5312 38.454 127
+      vertex -59.5312 41.546 127
+      vertex -59.4569 41.4819 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6086 38.3936 127
+      vertex -59.5312 41.546 127
+      vertex -59.5312 38.454 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6086 38.3936 127
+      vertex -59.6086 41.6064 127
+      vertex -59.5312 41.546 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6889 38.3371 127
+      vertex -59.6086 41.6064 127
+      vertex -59.6086 38.3936 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6889 38.3371 127
+      vertex -59.6889 41.6629 127
+      vertex -59.6086 41.6064 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.8 38.2686 127
+      vertex -59.6889 38.3371 127
+      vertex -59.7718 38.2845 127
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -59.6889 38.3371 127
+      vertex -59.8 38.2686 127
+      vertex -59.6889 41.6629 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.8 41.7314 127
+      vertex -59.6889 41.6629 127
+      vertex -59.8 38.2686 127
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6889 41.6629 127
+      vertex -59.8 41.7314 127
+      vertex -59.7718 41.7155 127
+    endloop
+  endfacet
+  facet normal -0.491141 0.87108 0
+    outer loop
+      vertex -59.7718 38.2845 120
+      vertex -59.8 38.2686 127
+      vertex -59.7718 38.2845 127
+    endloop
+  endfacet
+  facet normal -0.491141 0.87108 0
+    outer loop
+      vertex -59.8 38.2686 127
+      vertex -59.7718 38.2845 120
+      vertex -59.8 38.2686 120
+    endloop
+  endfacet
+  facet normal -0.615209 0.788364 0
+    outer loop
+      vertex -59.5312 38.454 120
+      vertex -59.6086 38.3936 127
+      vertex -59.5312 38.454 127
+    endloop
+  endfacet
+  facet normal -0.615209 0.788364 0
+    outer loop
+      vertex -59.6086 38.3936 127
+      vertex -59.5312 38.454 120
+      vertex -59.6086 38.3936 120
+    endloop
+  endfacet
+  facet normal -0.914064 0.405571 0
+    outer loop
+      vertex -58.992 39.1449 120
+      vertex -58.9522 39.2346 127
+      vertex -58.9522 39.2346 120
+    endloop
+  endfacet
+  facet normal -0.914064 0.405571 0
+    outer loop
+      vertex -58.9522 39.2346 127
+      vertex -58.992 39.1449 120
+      vertex -58.992 39.1449 127
+    endloop
+  endfacet
+  facet normal -0.933109 0.359593 0
+    outer loop
+      vertex -58.9522 39.2346 120
+      vertex -58.9169 39.3262 127
+      vertex -58.9169 39.3262 120
+    endloop
+  endfacet
+  facet normal -0.933109 0.359593 0
+    outer loop
+      vertex -58.9169 39.3262 127
+      vertex -58.9522 39.2346 120
+      vertex -58.9522 39.2346 127
+    endloop
+  endfacet
+  facet normal -0.997307 -0.0733463 0
+    outer loop
+      vertex -58.8024 -39.9019 180
+      vertex -58.8096 -39.804 187
+      vertex -58.8096 -39.804 180
+    endloop
+  endfacet
+  facet normal -0.997307 -0.0733463 0
+    outer loop
+      vertex -58.8096 -39.804 187
+      vertex -58.8024 -39.9019 180
+      vertex -58.8024 -39.9019 187
+    endloop
+  endfacet
+  facet normal -0.999701 -0.0244575 0
+    outer loop
+      vertex -58.8 -40 180
+      vertex -58.8024 -39.9019 187
+      vertex -58.8024 -39.9019 180
+    endloop
+  endfacet
+  facet normal -0.999701 -0.0244575 0
+    outer loop
+      vertex -58.8024 -39.9019 187
+      vertex -58.8 -40 180
+      vertex -58.8 -40 187
+    endloop
+  endfacet
+  facet normal -0.992511 -0.122155 0
+    outer loop
+      vertex -58.8096 -39.804 180
+      vertex -58.8216 -39.7065 187
+      vertex -58.8216 -39.7065 180
+    endloop
+  endfacet
+  facet normal -0.992511 -0.122155 0
+    outer loop
+      vertex -58.8216 -39.7065 187
+      vertex -58.8096 -39.804 180
+      vertex -58.8096 -39.804 187
+    endloop
+  endfacet
+  facet normal -0.757167 -0.653222 0
+    outer loop
+      vertex -59.254 -38.7312 180
+      vertex -59.3181 -38.6569 187
+      vertex -59.3181 -38.6569 180
+    endloop
+  endfacet
+  facet normal -0.757167 -0.653222 0
+    outer loop
+      vertex -59.3181 -38.6569 187
+      vertex -59.254 -38.7312 180
+      vertex -59.254 -38.7312 187
+    endloop
+  endfacet
+  facet normal -0.653222 -0.757167 0
+    outer loop
+      vertex -59.5312 -38.454 180
+      vertex -59.4569 -38.5181 187
+      vertex -59.5312 -38.454 187
+    endloop
+  endfacet
+  facet normal -0.653222 -0.757167 -0
+    outer loop
+      vertex -59.4569 -38.5181 187
+      vertex -59.5312 -38.454 180
+      vertex -59.4569 -38.5181 180
+    endloop
+  endfacet
+  facet normal -0.788364 0.615209 0
+    outer loop
+      vertex -59.254 -41.2688 180
+      vertex -59.1936 -41.1914 187
+      vertex -59.1936 -41.1914 180
+    endloop
+  endfacet
+  facet normal -0.788364 0.615209 0
+    outer loop
+      vertex -59.1936 -41.1914 187
+      vertex -59.254 -41.2688 180
+      vertex -59.254 -41.2688 187
+    endloop
+  endfacet
+  facet normal -0.788364 -0.615209 0
+    outer loop
+      vertex -59.1936 -38.8086 180
+      vertex -59.254 -38.7312 187
+      vertex -59.254 -38.7312 180
+    endloop
+  endfacet
+  facet normal -0.788364 -0.615209 0
+    outer loop
+      vertex -59.254 -38.7312 187
+      vertex -59.1936 -38.8086 180
+      vertex -59.1936 -38.8086 187
+    endloop
+  endfacet
+  facet normal -0.724211 0.689579 0
+    outer loop
+      vertex -59.3858 -41.4142 180
+      vertex -59.3181 -41.3431 187
+      vertex -59.3181 -41.3431 180
+    endloop
+  endfacet
+  facet normal -0.724211 0.689579 0
+    outer loop
+      vertex -59.3181 -41.3431 187
+      vertex -59.3858 -41.4142 180
+      vertex -59.3858 -41.4142 187
+    endloop
+  endfacet
+  facet normal -0.97573 0.218979 0
+    outer loop
+      vertex -58.8599 -40.486 180
+      vertex -58.8384 -40.3902 187
+      vertex -58.8384 -40.3902 180
+    endloop
+  endfacet
+  facet normal -0.97573 0.218979 0
+    outer loop
+      vertex -58.8384 -40.3902 187
+      vertex -58.8599 -40.486 180
+      vertex -58.8599 -40.486 187
+    endloop
+  endfacet
+  facet normal -0.997307 0.0733463 0
+    outer loop
+      vertex -58.8096 -40.196 180
+      vertex -58.8024 -40.0981 187
+      vertex -58.8024 -40.0981 180
+    endloop
+  endfacet
+  facet normal -0.997307 0.0733463 0
+    outer loop
+      vertex -58.8024 -40.0981 187
+      vertex -58.8096 -40.196 180
+      vertex -58.8096 -40.196 187
+    endloop
+  endfacet
+  facet normal -0.949495 -0.313782 0
+    outer loop
+      vertex -58.8861 -39.4194 180
+      vertex -58.9169 -39.3262 187
+      vertex -58.9169 -39.3262 180
+    endloop
+  endfacet
+  facet normal -0.949495 -0.313782 0
+    outer loop
+      vertex -58.9169 -39.3262 187
+      vertex -58.8861 -39.4194 180
+      vertex -58.8861 -39.4194 187
+    endloop
+  endfacet
+  facet normal -0.892997 0.450062 0
+    outer loop
+      vertex -59.0362 -40.9428 180
+      vertex -58.992 -40.8551 187
+      vertex -58.992 -40.8551 180
+    endloop
+  endfacet
+  facet normal -0.892997 0.450062 0
+    outer loop
+      vertex -58.992 -40.8551 187
+      vertex -59.0362 -40.9428 180
+      vertex -59.0362 -40.9428 187
+    endloop
+  endfacet
+  facet normal -0.87043 -0.492292 0
+    outer loop
+      vertex -59.0362 -39.0572 180
+      vertex -59.0845 -38.9718 187
+      vertex -59.0845 -38.9718 180
+    endloop
+  endfacet
+  facet normal -0.87043 -0.492292 0
+    outer loop
+      vertex -59.0845 -38.9718 187
+      vertex -59.0362 -39.0572 180
+      vertex -59.0362 -39.0572 187
+    endloop
+  endfacet
+  facet normal -0.575443 -0.817842 0
+    outer loop
+      vertex -59.6889 -38.3371 180
+      vertex -59.6086 -38.3936 187
+      vertex -59.6889 -38.3371 187
+    endloop
+  endfacet
+  facet normal -0.575443 -0.817842 -0
+    outer loop
+      vertex -59.6086 -38.3936 187
+      vertex -59.6889 -38.3371 180
+      vertex -59.6086 -38.3936 180
+    endloop
+  endfacet
+  facet normal -0.844374 0.535755 0
+    outer loop
+      vertex -59.1371 -41.1111 180
+      vertex -59.0845 -41.0282 187
+      vertex -59.0845 -41.0282 180
+    endloop
+  endfacet
+  facet normal -0.844374 0.535755 0
+    outer loop
+      vertex -59.0845 -41.0282 187
+      vertex -59.1371 -41.1111 180
+      vertex -59.1371 -41.1111 187
+    endloop
+  endfacet
+  facet normal -0.844374 -0.535755 0
+    outer loop
+      vertex -59.0845 -38.9718 180
+      vertex -59.1371 -38.8889 187
+      vertex -59.1371 -38.8889 180
+    endloop
+  endfacet
+  facet normal -0.844374 -0.535755 0
+    outer loop
+      vertex -59.1371 -38.8889 187
+      vertex -59.0845 -38.9718 180
+      vertex -59.0845 -38.9718 187
+    endloop
+  endfacet
+  facet normal -0.892997 -0.450062 0
+    outer loop
+      vertex -58.992 -39.1449 180
+      vertex -59.0362 -39.0572 187
+      vertex -59.0362 -39.0572 180
+    endloop
+  endfacet
+  facet normal -0.892997 -0.450062 0
+    outer loop
+      vertex -59.0362 -39.0572 187
+      vertex -58.992 -39.1449 180
+      vertex -58.992 -39.1449 187
+    endloop
+  endfacet
+  facet normal -0.535755 0.844374 0
+    outer loop
+      vertex -59.6889 -41.6629 180
+      vertex -59.7718 -41.7155 187
+      vertex -59.6889 -41.6629 187
+    endloop
+  endfacet
+  facet normal -0.535755 0.844374 0
+    outer loop
+      vertex -59.7718 -41.7155 187
+      vertex -59.6889 -41.6629 180
+      vertex -59.7718 -41.7155 180
+    endloop
+  endfacet
+  facet normal -0.963722 0.266908 0
+    outer loop
+      vertex -58.8861 -40.5806 180
+      vertex -58.8599 -40.486 187
+      vertex -58.8599 -40.486 180
+    endloop
+  endfacet
+  facet normal -0.963722 0.266908 0
+    outer loop
+      vertex -58.8599 -40.486 187
+      vertex -58.8861 -40.5806 180
+      vertex -58.8861 -40.5806 187
+    endloop
+  endfacet
+  facet normal -0.992511 0.122155 0
+    outer loop
+      vertex -58.8216 -40.2935 180
+      vertex -58.8096 -40.196 187
+      vertex -58.8096 -40.196 180
+    endloop
+  endfacet
+  facet normal -0.992511 0.122155 0
+    outer loop
+      vertex -58.8096 -40.196 187
+      vertex -58.8216 -40.2935 180
+      vertex -58.8216 -40.2935 187
+    endloop
+  endfacet
+  facet normal -0.933109 -0.359593 0
+    outer loop
+      vertex -58.9169 -39.3262 180
+      vertex -58.9522 -39.2346 187
+      vertex -58.9522 -39.2346 180
+    endloop
+  endfacet
+  facet normal -0.933109 -0.359593 0
+    outer loop
+      vertex -58.9522 -39.2346 187
+      vertex -58.9169 -39.3262 180
+      vertex -58.9169 -39.3262 187
+    endloop
+  endfacet
+  facet normal -0.757167 0.653222 0
+    outer loop
+      vertex -59.3181 -41.3431 180
+      vertex -59.254 -41.2688 187
+      vertex -59.254 -41.2688 180
+    endloop
+  endfacet
+  facet normal -0.757167 0.653222 0
+    outer loop
+      vertex -59.254 -41.2688 187
+      vertex -59.3181 -41.3431 180
+      vertex -59.3181 -41.3431 187
+    endloop
+  endfacet
+  facet normal -0.87043 0.492292 0
+    outer loop
+      vertex -59.0845 -41.0282 180
+      vertex -59.0362 -40.9428 187
+      vertex -59.0362 -40.9428 180
+    endloop
+  endfacet
+  facet normal -0.87043 0.492292 0
+    outer loop
+      vertex -59.0362 -40.9428 187
+      vertex -59.0845 -41.0282 180
+      vertex -59.0845 -41.0282 187
+    endloop
+  endfacet
+  facet normal -0.575443 0.817842 0
+    outer loop
+      vertex -59.6086 -41.6064 180
+      vertex -59.6889 -41.6629 187
+      vertex -59.6086 -41.6064 187
+    endloop
+  endfacet
+  facet normal -0.575443 0.817842 0
+    outer loop
+      vertex -59.6889 -41.6629 187
+      vertex -59.6086 -41.6064 180
+      vertex -59.6889 -41.6629 180
+    endloop
+  endfacet
+  facet normal -0.949495 0.313782 0
+    outer loop
+      vertex -58.9169 -40.6738 180
+      vertex -58.8861 -40.5806 187
+      vertex -58.8861 -40.5806 180
+    endloop
+  endfacet
+  facet normal -0.949495 0.313782 0
+    outer loop
+      vertex -58.8861 -40.5806 187
+      vertex -58.9169 -40.6738 180
+      vertex -58.9169 -40.6738 187
+    endloop
+  endfacet
+  facet normal -0.689579 0.724211 0
+    outer loop
+      vertex -59.3858 -41.4142 180
+      vertex -59.4569 -41.4819 187
+      vertex -59.3858 -41.4142 187
+    endloop
+  endfacet
+  facet normal -0.689579 0.724211 0
+    outer loop
+      vertex -59.4569 -41.4819 187
+      vertex -59.3858 -41.4142 180
+      vertex -59.4569 -41.4819 180
+    endloop
+  endfacet
+  facet normal -0.491141 -0.87108 0
+    outer loop
+      vertex -59.8 -38.2686 180
+      vertex -59.7718 -38.2845 187
+      vertex -59.8 -38.2686 187
+    endloop
+  endfacet
+  facet normal -0.491141 -0.87108 -0
+    outer loop
+      vertex -59.7718 -38.2845 187
+      vertex -59.8 -38.2686 180
+      vertex -59.7718 -38.2845 180
+    endloop
+  endfacet
+  facet normal -0.689579 -0.724211 0
+    outer loop
+      vertex -59.4569 -38.5181 180
+      vertex -59.3858 -38.5858 187
+      vertex -59.4569 -38.5181 187
+    endloop
+  endfacet
+  facet normal -0.689579 -0.724211 -0
+    outer loop
+      vertex -59.3858 -38.5858 187
+      vertex -59.4569 -38.5181 180
+      vertex -59.3858 -38.5858 180
+    endloop
+  endfacet
+  facet normal -0.817842 -0.575443 0
+    outer loop
+      vertex -59.1371 -38.8889 180
+      vertex -59.1936 -38.8086 187
+      vertex -59.1936 -38.8086 180
+    endloop
+  endfacet
+  facet normal -0.817842 -0.575443 0
+    outer loop
+      vertex -59.1936 -38.8086 187
+      vertex -59.1371 -38.8889 180
+      vertex -59.1371 -38.8889 187
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8024 -39.9019 180
+      vertex -58.8024 -40.0981 180
+      vertex -58.8 -40 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8096 -39.804 180
+      vertex -58.8024 -40.0981 180
+      vertex -58.8024 -39.9019 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8096 -39.804 180
+      vertex -58.8096 -40.196 180
+      vertex -58.8024 -40.0981 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8216 -39.7065 180
+      vertex -58.8096 -40.196 180
+      vertex -58.8096 -39.804 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8216 -39.7065 180
+      vertex -58.8216 -40.2935 180
+      vertex -58.8096 -40.196 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8384 -39.6098 180
+      vertex -58.8216 -40.2935 180
+      vertex -58.8216 -39.7065 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8384 -39.6098 180
+      vertex -58.8384 -40.3902 180
+      vertex -58.8216 -40.2935 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8599 -39.514 180
+      vertex -58.8384 -40.3902 180
+      vertex -58.8384 -39.6098 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8599 -39.514 180
+      vertex -58.8599 -40.486 180
+      vertex -58.8384 -40.3902 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8861 -39.4194 180
+      vertex -58.8599 -40.486 180
+      vertex -58.8599 -39.514 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8861 -39.4194 180
+      vertex -58.8861 -40.5806 180
+      vertex -58.8599 -40.486 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9169 -39.3262 180
+      vertex -58.8861 -40.5806 180
+      vertex -58.8861 -39.4194 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9169 -39.3262 180
+      vertex -58.9169 -40.6738 180
+      vertex -58.8861 -40.5806 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9522 -39.2346 180
+      vertex -58.9169 -40.6738 180
+      vertex -58.9169 -39.3262 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9522 -39.2346 180
+      vertex -58.9522 -40.7654 180
+      vertex -58.9169 -40.6738 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.992 -39.1449 180
+      vertex -58.9522 -40.7654 180
+      vertex -58.9522 -39.2346 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.992 -39.1449 180
+      vertex -58.992 -40.8551 180
+      vertex -58.9522 -40.7654 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0362 -39.0572 180
+      vertex -58.992 -40.8551 180
+      vertex -58.992 -39.1449 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0362 -39.0572 180
+      vertex -59.0362 -40.9428 180
+      vertex -58.992 -40.8551 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0845 -38.9718 180
+      vertex -59.0362 -40.9428 180
+      vertex -59.0362 -39.0572 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0845 -38.9718 180
+      vertex -59.0845 -41.0282 180
+      vertex -59.0362 -40.9428 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1371 -38.8889 180
+      vertex -59.0845 -41.0282 180
+      vertex -59.0845 -38.9718 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1371 -38.8889 180
+      vertex -59.1371 -41.1111 180
+      vertex -59.0845 -41.0282 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1936 -38.8086 180
+      vertex -59.1371 -41.1111 180
+      vertex -59.1371 -38.8889 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1936 -38.8086 180
+      vertex -59.1936 -41.1914 180
+      vertex -59.1371 -41.1111 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.254 -38.7312 180
+      vertex -59.1936 -41.1914 180
+      vertex -59.1936 -38.8086 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.254 -38.7312 180
+      vertex -59.254 -41.2688 180
+      vertex -59.1936 -41.1914 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3181 -38.6569 180
+      vertex -59.254 -41.2688 180
+      vertex -59.254 -38.7312 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3181 -38.6569 180
+      vertex -59.3181 -41.3431 180
+      vertex -59.254 -41.2688 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3858 -38.5858 180
+      vertex -59.3181 -41.3431 180
+      vertex -59.3181 -38.6569 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3858 -38.5858 180
+      vertex -59.3858 -41.4142 180
+      vertex -59.3181 -41.3431 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.4569 -38.5181 180
+      vertex -59.3858 -41.4142 180
+      vertex -59.3858 -38.5858 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.4569 -38.5181 180
+      vertex -59.4569 -41.4819 180
+      vertex -59.3858 -41.4142 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.5312 -38.454 180
+      vertex -59.4569 -41.4819 180
+      vertex -59.4569 -38.5181 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.5312 -38.454 180
+      vertex -59.5312 -41.546 180
+      vertex -59.4569 -41.4819 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6086 -38.3936 180
+      vertex -59.5312 -41.546 180
+      vertex -59.5312 -38.454 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6086 -38.3936 180
+      vertex -59.6086 -41.6064 180
+      vertex -59.5312 -41.546 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 -38.3371 180
+      vertex -59.6086 -41.6064 180
+      vertex -59.6086 -38.3936 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 -38.3371 180
+      vertex -59.6889 -41.6629 180
+      vertex -59.6086 -41.6064 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.8 -38.2686 180
+      vertex -59.6889 -38.3371 180
+      vertex -59.7718 -38.2845 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 -38.3371 180
+      vertex -59.8 -38.2686 180
+      vertex -59.6889 -41.6629 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.8 -41.7314 180
+      vertex -59.6889 -41.6629 180
+      vertex -59.8 -38.2686 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 -41.6629 180
+      vertex -59.8 -41.7314 180
+      vertex -59.7718 -41.7155 180
+    endloop
+  endfacet
+  facet normal -0.653222 0.757167 0
+    outer loop
+      vertex -59.4569 -41.4819 180
+      vertex -59.5312 -41.546 187
+      vertex -59.4569 -41.4819 187
+    endloop
+  endfacet
+  facet normal -0.653222 0.757167 0
+    outer loop
+      vertex -59.5312 -41.546 187
+      vertex -59.4569 -41.4819 180
+      vertex -59.5312 -41.546 180
+    endloop
+  endfacet
+  facet normal -0.985242 -0.171169 0
+    outer loop
+      vertex -58.8216 -39.7065 180
+      vertex -58.8384 -39.6098 187
+      vertex -58.8384 -39.6098 180
+    endloop
+  endfacet
+  facet normal -0.985242 -0.171169 0
+    outer loop
+      vertex -58.8384 -39.6098 187
+      vertex -58.8216 -39.7065 180
+      vertex -58.8216 -39.7065 187
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244575 0
+    outer loop
+      vertex -58.8024 -40.0981 180
+      vertex -58.8 -40 187
+      vertex -58.8 -40 180
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244575 0
+    outer loop
+      vertex -58.8 -40 187
+      vertex -58.8024 -40.0981 180
+      vertex -58.8024 -40.0981 187
+    endloop
+  endfacet
+  facet normal -0.914064 -0.405571 0
+    outer loop
+      vertex -58.9522 -39.2346 180
+      vertex -58.992 -39.1449 187
+      vertex -58.992 -39.1449 180
+    endloop
+  endfacet
+  facet normal -0.914064 -0.405571 0
+    outer loop
+      vertex -58.992 -39.1449 187
+      vertex -58.9522 -39.2346 180
+      vertex -58.9522 -39.2346 187
+    endloop
+  endfacet
+  facet normal -0.97573 -0.218979 0
+    outer loop
+      vertex -58.8384 -39.6098 180
+      vertex -58.8599 -39.514 187
+      vertex -58.8599 -39.514 180
+    endloop
+  endfacet
+  facet normal -0.97573 -0.218979 0
+    outer loop
+      vertex -58.8599 -39.514 187
+      vertex -58.8384 -39.6098 180
+      vertex -58.8384 -39.6098 187
+    endloop
+  endfacet
+  facet normal -0.724211 -0.689579 0
+    outer loop
+      vertex -59.3181 -38.6569 180
+      vertex -59.3858 -38.5858 187
+      vertex -59.3858 -38.5858 180
+    endloop
+  endfacet
+  facet normal -0.724211 -0.689579 0
+    outer loop
+      vertex -59.3858 -38.5858 187
+      vertex -59.3181 -38.6569 180
+      vertex -59.3181 -38.6569 187
+    endloop
+  endfacet
+  facet normal -0.963722 -0.266908 0
+    outer loop
+      vertex -58.8599 -39.514 180
+      vertex -58.8861 -39.4194 187
+      vertex -58.8861 -39.4194 180
+    endloop
+  endfacet
+  facet normal -0.963722 -0.266908 0
+    outer loop
+      vertex -58.8861 -39.4194 187
+      vertex -58.8599 -39.514 180
+      vertex -58.8599 -39.514 187
+    endloop
+  endfacet
+  facet normal -0.535755 -0.844374 0
+    outer loop
+      vertex -59.7718 -38.2845 180
+      vertex -59.6889 -38.3371 187
+      vertex -59.7718 -38.2845 187
+    endloop
+  endfacet
+  facet normal -0.535755 -0.844374 -0
+    outer loop
+      vertex -59.6889 -38.3371 187
+      vertex -59.7718 -38.2845 180
+      vertex -59.6889 -38.3371 180
+    endloop
+  endfacet
+  facet normal -0.817842 0.575443 0
+    outer loop
+      vertex -59.1936 -41.1914 180
+      vertex -59.1371 -41.1111 187
+      vertex -59.1371 -41.1111 180
+    endloop
+  endfacet
+  facet normal -0.817842 0.575443 0
+    outer loop
+      vertex -59.1371 -41.1111 187
+      vertex -59.1936 -41.1914 180
+      vertex -59.1936 -41.1914 187
+    endloop
+  endfacet
+  facet normal -0.615209 -0.788364 0
+    outer loop
+      vertex -59.6086 -38.3936 180
+      vertex -59.5312 -38.454 187
+      vertex -59.6086 -38.3936 187
+    endloop
+  endfacet
+  facet normal -0.615209 -0.788364 -0
+    outer loop
+      vertex -59.5312 -38.454 187
+      vertex -59.6086 -38.3936 180
+      vertex -59.5312 -38.454 180
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8024 -40.0981 187
+      vertex -58.8024 -39.9019 187
+      vertex -58.8 -40 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8096 -40.196 187
+      vertex -58.8024 -39.9019 187
+      vertex -58.8024 -40.0981 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8096 -40.196 187
+      vertex -58.8096 -39.804 187
+      vertex -58.8024 -39.9019 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8216 -40.2935 187
+      vertex -58.8096 -39.804 187
+      vertex -58.8096 -40.196 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8216 -40.2935 187
+      vertex -58.8216 -39.7065 187
+      vertex -58.8096 -39.804 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8384 -40.3902 187
+      vertex -58.8216 -39.7065 187
+      vertex -58.8216 -40.2935 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8384 -40.3902 187
+      vertex -58.8384 -39.6098 187
+      vertex -58.8216 -39.7065 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8599 -40.486 187
+      vertex -58.8384 -39.6098 187
+      vertex -58.8384 -40.3902 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8599 -40.486 187
+      vertex -58.8599 -39.514 187
+      vertex -58.8384 -39.6098 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8861 -40.5806 187
+      vertex -58.8599 -39.514 187
+      vertex -58.8599 -40.486 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8861 -40.5806 187
+      vertex -58.8861 -39.4194 187
+      vertex -58.8599 -39.514 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9169 -40.6738 187
+      vertex -58.8861 -39.4194 187
+      vertex -58.8861 -40.5806 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9169 -40.6738 187
+      vertex -58.9169 -39.3262 187
+      vertex -58.8861 -39.4194 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9522 -40.7654 187
+      vertex -58.9169 -39.3262 187
+      vertex -58.9169 -40.6738 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9522 -40.7654 187
+      vertex -58.9522 -39.2346 187
+      vertex -58.9169 -39.3262 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.992 -40.8551 187
+      vertex -58.9522 -39.2346 187
+      vertex -58.9522 -40.7654 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.992 -40.8551 187
+      vertex -58.992 -39.1449 187
+      vertex -58.9522 -39.2346 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0362 -40.9428 187
+      vertex -58.992 -39.1449 187
+      vertex -58.992 -40.8551 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0362 -40.9428 187
+      vertex -59.0362 -39.0572 187
+      vertex -58.992 -39.1449 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0845 -41.0282 187
+      vertex -59.0362 -39.0572 187
+      vertex -59.0362 -40.9428 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0845 -41.0282 187
+      vertex -59.0845 -38.9718 187
+      vertex -59.0362 -39.0572 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1371 -41.1111 187
+      vertex -59.0845 -38.9718 187
+      vertex -59.0845 -41.0282 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1371 -41.1111 187
+      vertex -59.1371 -38.8889 187
+      vertex -59.0845 -38.9718 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1936 -41.1914 187
+      vertex -59.1371 -38.8889 187
+      vertex -59.1371 -41.1111 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1936 -41.1914 187
+      vertex -59.1936 -38.8086 187
+      vertex -59.1371 -38.8889 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.254 -41.2688 187
+      vertex -59.1936 -38.8086 187
+      vertex -59.1936 -41.1914 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.254 -41.2688 187
+      vertex -59.254 -38.7312 187
+      vertex -59.1936 -38.8086 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3181 -41.3431 187
+      vertex -59.254 -38.7312 187
+      vertex -59.254 -41.2688 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3181 -41.3431 187
+      vertex -59.3181 -38.6569 187
+      vertex -59.254 -38.7312 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3858 -41.4142 187
+      vertex -59.3181 -38.6569 187
+      vertex -59.3181 -41.3431 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3858 -41.4142 187
+      vertex -59.3858 -38.5858 187
+      vertex -59.3181 -38.6569 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.4569 -41.4819 187
+      vertex -59.3858 -38.5858 187
+      vertex -59.3858 -41.4142 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.4569 -41.4819 187
+      vertex -59.4569 -38.5181 187
+      vertex -59.3858 -38.5858 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.5312 -41.546 187
+      vertex -59.4569 -38.5181 187
+      vertex -59.4569 -41.4819 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.5312 -41.546 187
+      vertex -59.5312 -38.454 187
+      vertex -59.4569 -38.5181 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6086 -41.6064 187
+      vertex -59.5312 -38.454 187
+      vertex -59.5312 -41.546 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6086 -41.6064 187
+      vertex -59.6086 -38.3936 187
+      vertex -59.5312 -38.454 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6889 -41.6629 187
+      vertex -59.6086 -38.3936 187
+      vertex -59.6086 -41.6064 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6889 -41.6629 187
+      vertex -59.6889 -38.3371 187
+      vertex -59.6086 -38.3936 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.8 -41.7314 187
+      vertex -59.6889 -41.6629 187
+      vertex -59.7718 -41.7155 187
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -59.6889 -41.6629 187
+      vertex -59.8 -41.7314 187
+      vertex -59.6889 -38.3371 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.8 -38.2686 187
+      vertex -59.6889 -38.3371 187
+      vertex -59.8 -41.7314 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6889 -38.3371 187
+      vertex -59.8 -38.2686 187
+      vertex -59.7718 -38.2845 187
+    endloop
+  endfacet
+  facet normal -0.491141 0.87108 0
+    outer loop
+      vertex -59.7718 -41.7155 180
+      vertex -59.8 -41.7314 187
+      vertex -59.7718 -41.7155 187
+    endloop
+  endfacet
+  facet normal -0.491141 0.87108 0
+    outer loop
+      vertex -59.8 -41.7314 187
+      vertex -59.7718 -41.7155 180
+      vertex -59.8 -41.7314 180
+    endloop
+  endfacet
+  facet normal -0.615209 0.788364 0
+    outer loop
+      vertex -59.5312 -41.546 180
+      vertex -59.6086 -41.6064 187
+      vertex -59.5312 -41.546 187
+    endloop
+  endfacet
+  facet normal -0.615209 0.788364 0
+    outer loop
+      vertex -59.6086 -41.6064 187
+      vertex -59.5312 -41.546 180
+      vertex -59.6086 -41.6064 180
+    endloop
+  endfacet
+  facet normal -0.985242 0.171169 0
+    outer loop
+      vertex -58.8384 -40.3902 180
+      vertex -58.8216 -40.2935 187
+      vertex -58.8216 -40.2935 180
+    endloop
+  endfacet
+  facet normal -0.985242 0.171169 0
+    outer loop
+      vertex -58.8216 -40.2935 187
+      vertex -58.8384 -40.3902 180
+      vertex -58.8384 -40.3902 187
+    endloop
+  endfacet
+  facet normal -0.914064 0.405571 0
+    outer loop
+      vertex -58.992 -40.8551 180
+      vertex -58.9522 -40.7654 187
+      vertex -58.9522 -40.7654 180
+    endloop
+  endfacet
+  facet normal -0.914064 0.405571 0
+    outer loop
+      vertex -58.9522 -40.7654 187
+      vertex -58.992 -40.8551 180
+      vertex -58.992 -40.8551 187
+    endloop
+  endfacet
+  facet normal -0.933109 0.359593 0
+    outer loop
+      vertex -58.9522 -40.7654 180
+      vertex -58.9169 -40.6738 187
+      vertex -58.9169 -40.6738 180
+    endloop
+  endfacet
+  facet normal -0.933109 0.359593 0
+    outer loop
+      vertex -58.9169 -40.6738 187
+      vertex -58.9522 -40.7654 180
+      vertex -58.9522 -40.7654 187
+    endloop
+  endfacet
+  facet normal -0.997307 -0.0733463 0
+    outer loop
+      vertex -58.8024 40.0981 180
+      vertex -58.8096 40.196 187
+      vertex -58.8096 40.196 180
+    endloop
+  endfacet
+  facet normal -0.997307 -0.0733463 0
+    outer loop
+      vertex -58.8096 40.196 187
+      vertex -58.8024 40.0981 180
+      vertex -58.8024 40.0981 187
+    endloop
+  endfacet
+  facet normal -0.999701 -0.0244575 0
+    outer loop
+      vertex -58.8 40 180
+      vertex -58.8024 40.0981 187
+      vertex -58.8024 40.0981 180
+    endloop
+  endfacet
+  facet normal -0.999701 -0.0244575 0
+    outer loop
+      vertex -58.8024 40.0981 187
+      vertex -58.8 40 180
+      vertex -58.8 40 187
+    endloop
+  endfacet
+  facet normal -0.992511 -0.122155 0
+    outer loop
+      vertex -58.8096 40.196 180
+      vertex -58.8216 40.2935 187
+      vertex -58.8216 40.2935 180
+    endloop
+  endfacet
+  facet normal -0.992511 -0.122155 0
+    outer loop
+      vertex -58.8216 40.2935 187
+      vertex -58.8096 40.196 180
+      vertex -58.8096 40.196 187
+    endloop
+  endfacet
+  facet normal -0.757167 -0.653222 0
+    outer loop
+      vertex -59.254 41.2688 180
+      vertex -59.3181 41.3431 187
+      vertex -59.3181 41.3431 180
+    endloop
+  endfacet
+  facet normal -0.757167 -0.653222 0
+    outer loop
+      vertex -59.3181 41.3431 187
+      vertex -59.254 41.2688 180
+      vertex -59.254 41.2688 187
+    endloop
+  endfacet
+  facet normal -0.653222 -0.757167 0
+    outer loop
+      vertex -59.5312 41.546 180
+      vertex -59.4569 41.4819 187
+      vertex -59.5312 41.546 187
+    endloop
+  endfacet
+  facet normal -0.653222 -0.757167 -0
+    outer loop
+      vertex -59.4569 41.4819 187
+      vertex -59.5312 41.546 180
+      vertex -59.4569 41.4819 180
+    endloop
+  endfacet
+  facet normal -0.788364 0.615209 0
+    outer loop
+      vertex -59.254 38.7312 180
+      vertex -59.1936 38.8086 187
+      vertex -59.1936 38.8086 180
+    endloop
+  endfacet
+  facet normal -0.788364 0.615209 0
+    outer loop
+      vertex -59.1936 38.8086 187
+      vertex -59.254 38.7312 180
+      vertex -59.254 38.7312 187
+    endloop
+  endfacet
+  facet normal -0.788364 -0.615209 0
+    outer loop
+      vertex -59.1936 41.1914 180
+      vertex -59.254 41.2688 187
+      vertex -59.254 41.2688 180
+    endloop
+  endfacet
+  facet normal -0.788364 -0.615209 0
+    outer loop
+      vertex -59.254 41.2688 187
+      vertex -59.1936 41.1914 180
+      vertex -59.1936 41.1914 187
+    endloop
+  endfacet
+  facet normal -0.724211 0.689579 0
+    outer loop
+      vertex -59.3858 38.5858 180
+      vertex -59.3181 38.6569 187
+      vertex -59.3181 38.6569 180
+    endloop
+  endfacet
+  facet normal -0.724211 0.689579 0
+    outer loop
+      vertex -59.3181 38.6569 187
+      vertex -59.3858 38.5858 180
+      vertex -59.3858 38.5858 187
+    endloop
+  endfacet
+  facet normal -0.97573 0.218979 0
+    outer loop
+      vertex -58.8599 39.514 180
+      vertex -58.8384 39.6098 187
+      vertex -58.8384 39.6098 180
+    endloop
+  endfacet
+  facet normal -0.97573 0.218979 0
+    outer loop
+      vertex -58.8384 39.6098 187
+      vertex -58.8599 39.514 180
+      vertex -58.8599 39.514 187
+    endloop
+  endfacet
+  facet normal -0.997307 0.0733463 0
+    outer loop
+      vertex -58.8096 39.804 180
+      vertex -58.8024 39.9019 187
+      vertex -58.8024 39.9019 180
+    endloop
+  endfacet
+  facet normal -0.997307 0.0733463 0
+    outer loop
+      vertex -58.8024 39.9019 187
+      vertex -58.8096 39.804 180
+      vertex -58.8096 39.804 187
+    endloop
+  endfacet
+  facet normal -0.949495 -0.313782 0
+    outer loop
+      vertex -58.8861 40.5806 180
+      vertex -58.9169 40.6738 187
+      vertex -58.9169 40.6738 180
+    endloop
+  endfacet
+  facet normal -0.949495 -0.313782 0
+    outer loop
+      vertex -58.9169 40.6738 187
+      vertex -58.8861 40.5806 180
+      vertex -58.8861 40.5806 187
+    endloop
+  endfacet
+  facet normal -0.892997 0.450062 0
+    outer loop
+      vertex -59.0362 39.0572 180
+      vertex -58.992 39.1449 187
+      vertex -58.992 39.1449 180
+    endloop
+  endfacet
+  facet normal -0.892997 0.450062 0
+    outer loop
+      vertex -58.992 39.1449 187
+      vertex -59.0362 39.0572 180
+      vertex -59.0362 39.0572 187
+    endloop
+  endfacet
+  facet normal -0.87043 -0.492292 0
+    outer loop
+      vertex -59.0362 40.9428 180
+      vertex -59.0845 41.0282 187
+      vertex -59.0845 41.0282 180
+    endloop
+  endfacet
+  facet normal -0.87043 -0.492292 0
+    outer loop
+      vertex -59.0845 41.0282 187
+      vertex -59.0362 40.9428 180
+      vertex -59.0362 40.9428 187
+    endloop
+  endfacet
+  facet normal -0.575443 -0.817842 0
+    outer loop
+      vertex -59.6889 41.6629 180
+      vertex -59.6086 41.6064 187
+      vertex -59.6889 41.6629 187
+    endloop
+  endfacet
+  facet normal -0.575443 -0.817842 -0
+    outer loop
+      vertex -59.6086 41.6064 187
+      vertex -59.6889 41.6629 180
+      vertex -59.6086 41.6064 180
+    endloop
+  endfacet
+  facet normal -0.844374 0.535755 0
+    outer loop
+      vertex -59.1371 38.8889 180
+      vertex -59.0845 38.9718 187
+      vertex -59.0845 38.9718 180
+    endloop
+  endfacet
+  facet normal -0.844374 0.535755 0
+    outer loop
+      vertex -59.0845 38.9718 187
+      vertex -59.1371 38.8889 180
+      vertex -59.1371 38.8889 187
+    endloop
+  endfacet
+  facet normal -0.844374 -0.535755 0
+    outer loop
+      vertex -59.0845 41.0282 180
+      vertex -59.1371 41.1111 187
+      vertex -59.1371 41.1111 180
+    endloop
+  endfacet
+  facet normal -0.844374 -0.535755 0
+    outer loop
+      vertex -59.1371 41.1111 187
+      vertex -59.0845 41.0282 180
+      vertex -59.0845 41.0282 187
+    endloop
+  endfacet
+  facet normal -0.892997 -0.450062 0
+    outer loop
+      vertex -58.992 40.8551 180
+      vertex -59.0362 40.9428 187
+      vertex -59.0362 40.9428 180
+    endloop
+  endfacet
+  facet normal -0.892997 -0.450062 0
+    outer loop
+      vertex -59.0362 40.9428 187
+      vertex -58.992 40.8551 180
+      vertex -58.992 40.8551 187
+    endloop
+  endfacet
+  facet normal -0.535755 0.844374 0
+    outer loop
+      vertex -59.6889 38.3371 180
+      vertex -59.7718 38.2845 187
+      vertex -59.6889 38.3371 187
+    endloop
+  endfacet
+  facet normal -0.535755 0.844374 0
+    outer loop
+      vertex -59.7718 38.2845 187
+      vertex -59.6889 38.3371 180
+      vertex -59.7718 38.2845 180
+    endloop
+  endfacet
+  facet normal -0.963722 0.266908 0
+    outer loop
+      vertex -58.8861 39.4194 180
+      vertex -58.8599 39.514 187
+      vertex -58.8599 39.514 180
+    endloop
+  endfacet
+  facet normal -0.963722 0.266908 0
+    outer loop
+      vertex -58.8599 39.514 187
+      vertex -58.8861 39.4194 180
+      vertex -58.8861 39.4194 187
+    endloop
+  endfacet
+  facet normal -0.992511 0.122155 0
+    outer loop
+      vertex -58.8216 39.7065 180
+      vertex -58.8096 39.804 187
+      vertex -58.8096 39.804 180
+    endloop
+  endfacet
+  facet normal -0.992511 0.122155 0
+    outer loop
+      vertex -58.8096 39.804 187
+      vertex -58.8216 39.7065 180
+      vertex -58.8216 39.7065 187
+    endloop
+  endfacet
+  facet normal -0.933109 -0.359593 0
+    outer loop
+      vertex -58.9169 40.6738 180
+      vertex -58.9522 40.7654 187
+      vertex -58.9522 40.7654 180
+    endloop
+  endfacet
+  facet normal -0.933109 -0.359593 0
+    outer loop
+      vertex -58.9522 40.7654 187
+      vertex -58.9169 40.6738 180
+      vertex -58.9169 40.6738 187
+    endloop
+  endfacet
+  facet normal -0.757167 0.653222 0
+    outer loop
+      vertex -59.3181 38.6569 180
+      vertex -59.254 38.7312 187
+      vertex -59.254 38.7312 180
+    endloop
+  endfacet
+  facet normal -0.757167 0.653222 0
+    outer loop
+      vertex -59.254 38.7312 187
+      vertex -59.3181 38.6569 180
+      vertex -59.3181 38.6569 187
+    endloop
+  endfacet
+  facet normal -0.87043 0.492292 0
+    outer loop
+      vertex -59.0845 38.9718 180
+      vertex -59.0362 39.0572 187
+      vertex -59.0362 39.0572 180
+    endloop
+  endfacet
+  facet normal -0.87043 0.492292 0
+    outer loop
+      vertex -59.0362 39.0572 187
+      vertex -59.0845 38.9718 180
+      vertex -59.0845 38.9718 187
+    endloop
+  endfacet
+  facet normal -0.575443 0.817842 0
+    outer loop
+      vertex -59.6086 38.3936 180
+      vertex -59.6889 38.3371 187
+      vertex -59.6086 38.3936 187
+    endloop
+  endfacet
+  facet normal -0.575443 0.817842 0
+    outer loop
+      vertex -59.6889 38.3371 187
+      vertex -59.6086 38.3936 180
+      vertex -59.6889 38.3371 180
+    endloop
+  endfacet
+  facet normal -0.949495 0.313782 0
+    outer loop
+      vertex -58.9169 39.3262 180
+      vertex -58.8861 39.4194 187
+      vertex -58.8861 39.4194 180
+    endloop
+  endfacet
+  facet normal -0.949495 0.313782 0
+    outer loop
+      vertex -58.8861 39.4194 187
+      vertex -58.9169 39.3262 180
+      vertex -58.9169 39.3262 187
+    endloop
+  endfacet
+  facet normal -0.689579 0.724211 0
+    outer loop
+      vertex -59.3858 38.5858 180
+      vertex -59.4569 38.5181 187
+      vertex -59.3858 38.5858 187
+    endloop
+  endfacet
+  facet normal -0.689579 0.724211 0
+    outer loop
+      vertex -59.4569 38.5181 187
+      vertex -59.3858 38.5858 180
+      vertex -59.4569 38.5181 180
+    endloop
+  endfacet
+  facet normal -0.491141 -0.87108 0
+    outer loop
+      vertex -59.8 41.7314 180
+      vertex -59.7718 41.7155 187
+      vertex -59.8 41.7314 187
+    endloop
+  endfacet
+  facet normal -0.491141 -0.87108 -0
+    outer loop
+      vertex -59.7718 41.7155 187
+      vertex -59.8 41.7314 180
+      vertex -59.7718 41.7155 180
+    endloop
+  endfacet
+  facet normal -0.689579 -0.724211 0
+    outer loop
+      vertex -59.4569 41.4819 180
+      vertex -59.3858 41.4142 187
+      vertex -59.4569 41.4819 187
+    endloop
+  endfacet
+  facet normal -0.689579 -0.724211 -0
+    outer loop
+      vertex -59.3858 41.4142 187
+      vertex -59.4569 41.4819 180
+      vertex -59.3858 41.4142 180
+    endloop
+  endfacet
+  facet normal -0.817842 -0.575443 0
+    outer loop
+      vertex -59.1371 41.1111 180
+      vertex -59.1936 41.1914 187
+      vertex -59.1936 41.1914 180
+    endloop
+  endfacet
+  facet normal -0.817842 -0.575443 0
+    outer loop
+      vertex -59.1936 41.1914 187
+      vertex -59.1371 41.1111 180
+      vertex -59.1371 41.1111 187
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8024 40.0981 180
+      vertex -58.8024 39.9019 180
+      vertex -58.8 40 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8096 40.196 180
+      vertex -58.8024 39.9019 180
+      vertex -58.8024 40.0981 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8096 40.196 180
+      vertex -58.8096 39.804 180
+      vertex -58.8024 39.9019 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8216 40.2935 180
+      vertex -58.8096 39.804 180
+      vertex -58.8096 40.196 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8216 40.2935 180
+      vertex -58.8216 39.7065 180
+      vertex -58.8096 39.804 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8384 40.3902 180
+      vertex -58.8216 39.7065 180
+      vertex -58.8216 40.2935 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8384 40.3902 180
+      vertex -58.8384 39.6098 180
+      vertex -58.8216 39.7065 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8599 40.486 180
+      vertex -58.8384 39.6098 180
+      vertex -58.8384 40.3902 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8599 40.486 180
+      vertex -58.8599 39.514 180
+      vertex -58.8384 39.6098 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8861 40.5806 180
+      vertex -58.8599 39.514 180
+      vertex -58.8599 40.486 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.8861 40.5806 180
+      vertex -58.8861 39.4194 180
+      vertex -58.8599 39.514 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9169 40.6738 180
+      vertex -58.8861 39.4194 180
+      vertex -58.8861 40.5806 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9169 40.6738 180
+      vertex -58.9169 39.3262 180
+      vertex -58.8861 39.4194 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9522 40.7654 180
+      vertex -58.9169 39.3262 180
+      vertex -58.9169 40.6738 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9522 40.7654 180
+      vertex -58.9522 39.2346 180
+      vertex -58.9169 39.3262 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.992 40.8551 180
+      vertex -58.9522 39.2346 180
+      vertex -58.9522 40.7654 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.992 40.8551 180
+      vertex -58.992 39.1449 180
+      vertex -58.9522 39.2346 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0362 40.9428 180
+      vertex -58.992 39.1449 180
+      vertex -58.992 40.8551 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0362 40.9428 180
+      vertex -59.0362 39.0572 180
+      vertex -58.992 39.1449 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0845 41.0282 180
+      vertex -59.0362 39.0572 180
+      vertex -59.0362 40.9428 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.0845 41.0282 180
+      vertex -59.0845 38.9718 180
+      vertex -59.0362 39.0572 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1371 41.1111 180
+      vertex -59.0845 38.9718 180
+      vertex -59.0845 41.0282 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1371 41.1111 180
+      vertex -59.1371 38.8889 180
+      vertex -59.0845 38.9718 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1936 41.1914 180
+      vertex -59.1371 38.8889 180
+      vertex -59.1371 41.1111 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1936 41.1914 180
+      vertex -59.1936 38.8086 180
+      vertex -59.1371 38.8889 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.254 41.2688 180
+      vertex -59.1936 38.8086 180
+      vertex -59.1936 41.1914 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.254 41.2688 180
+      vertex -59.254 38.7312 180
+      vertex -59.1936 38.8086 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3181 41.3431 180
+      vertex -59.254 38.7312 180
+      vertex -59.254 41.2688 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3181 41.3431 180
+      vertex -59.3181 38.6569 180
+      vertex -59.254 38.7312 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3858 41.4142 180
+      vertex -59.3181 38.6569 180
+      vertex -59.3181 41.3431 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3858 41.4142 180
+      vertex -59.3858 38.5858 180
+      vertex -59.3181 38.6569 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.4569 41.4819 180
+      vertex -59.3858 38.5858 180
+      vertex -59.3858 41.4142 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.4569 41.4819 180
+      vertex -59.4569 38.5181 180
+      vertex -59.3858 38.5858 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.5312 41.546 180
+      vertex -59.4569 38.5181 180
+      vertex -59.4569 41.4819 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.5312 41.546 180
+      vertex -59.5312 38.454 180
+      vertex -59.4569 38.5181 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6086 41.6064 180
+      vertex -59.5312 38.454 180
+      vertex -59.5312 41.546 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6086 41.6064 180
+      vertex -59.6086 38.3936 180
+      vertex -59.5312 38.454 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 41.6629 180
+      vertex -59.6086 38.3936 180
+      vertex -59.6086 41.6064 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 41.6629 180
+      vertex -59.6889 38.3371 180
+      vertex -59.6086 38.3936 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.8 41.7314 180
+      vertex -59.6889 41.6629 180
+      vertex -59.7718 41.7155 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 41.6629 180
+      vertex -59.8 41.7314 180
+      vertex -59.6889 38.3371 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.8 38.2686 180
+      vertex -59.6889 38.3371 180
+      vertex -59.8 41.7314 180
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.6889 38.3371 180
+      vertex -59.8 38.2686 180
+      vertex -59.7718 38.2845 180
+    endloop
+  endfacet
+  facet normal -0.985242 -0.171169 0
+    outer loop
+      vertex -58.8216 40.2935 180
+      vertex -58.8384 40.3902 187
+      vertex -58.8384 40.3902 180
+    endloop
+  endfacet
+  facet normal -0.985242 -0.171169 0
+    outer loop
+      vertex -58.8384 40.3902 187
+      vertex -58.8216 40.2935 180
+      vertex -58.8216 40.2935 187
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244575 0
+    outer loop
+      vertex -58.8024 39.9019 180
+      vertex -58.8 40 187
+      vertex -58.8 40 180
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244575 0
+    outer loop
+      vertex -58.8 40 187
+      vertex -58.8024 39.9019 180
+      vertex -58.8024 39.9019 187
+    endloop
+  endfacet
+  facet normal -0.914064 -0.405571 0
+    outer loop
+      vertex -58.9522 40.7654 180
+      vertex -58.992 40.8551 187
+      vertex -58.992 40.8551 180
+    endloop
+  endfacet
+  facet normal -0.914064 -0.405571 0
+    outer loop
+      vertex -58.992 40.8551 187
+      vertex -58.9522 40.7654 180
+      vertex -58.9522 40.7654 187
+    endloop
+  endfacet
+  facet normal -0.97573 -0.218979 0
+    outer loop
+      vertex -58.8384 40.3902 180
+      vertex -58.8599 40.486 187
+      vertex -58.8599 40.486 180
+    endloop
+  endfacet
+  facet normal -0.97573 -0.218979 0
+    outer loop
+      vertex -58.8599 40.486 187
+      vertex -58.8384 40.3902 180
+      vertex -58.8384 40.3902 187
+    endloop
+  endfacet
+  facet normal -0.724211 -0.689579 0
+    outer loop
+      vertex -59.3181 41.3431 180
+      vertex -59.3858 41.4142 187
+      vertex -59.3858 41.4142 180
+    endloop
+  endfacet
+  facet normal -0.724211 -0.689579 0
+    outer loop
+      vertex -59.3858 41.4142 187
+      vertex -59.3181 41.3431 180
+      vertex -59.3181 41.3431 187
+    endloop
+  endfacet
+  facet normal -0.963722 -0.266908 0
+    outer loop
+      vertex -58.8599 40.486 180
+      vertex -58.8861 40.5806 187
+      vertex -58.8861 40.5806 180
+    endloop
+  endfacet
+  facet normal -0.963722 -0.266908 0
+    outer loop
+      vertex -58.8861 40.5806 187
+      vertex -58.8599 40.486 180
+      vertex -58.8599 40.486 187
+    endloop
+  endfacet
+  facet normal -0.535755 -0.844374 0
+    outer loop
+      vertex -59.7718 41.7155 180
+      vertex -59.6889 41.6629 187
+      vertex -59.7718 41.7155 187
+    endloop
+  endfacet
+  facet normal -0.535755 -0.844374 -0
+    outer loop
+      vertex -59.6889 41.6629 187
+      vertex -59.7718 41.7155 180
+      vertex -59.6889 41.6629 180
+    endloop
+  endfacet
+  facet normal -0.817842 0.575443 0
+    outer loop
+      vertex -59.1936 38.8086 180
+      vertex -59.1371 38.8889 187
+      vertex -59.1371 38.8889 180
+    endloop
+  endfacet
+  facet normal -0.817842 0.575443 0
+    outer loop
+      vertex -59.1371 38.8889 187
+      vertex -59.1936 38.8086 180
+      vertex -59.1936 38.8086 187
+    endloop
+  endfacet
+  facet normal -0.615209 -0.788364 0
+    outer loop
+      vertex -59.6086 41.6064 180
+      vertex -59.5312 41.546 187
+      vertex -59.6086 41.6064 187
+    endloop
+  endfacet
+  facet normal -0.615209 -0.788364 -0
+    outer loop
+      vertex -59.5312 41.546 187
+      vertex -59.6086 41.6064 180
+      vertex -59.5312 41.546 180
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8024 39.9019 187
+      vertex -58.8024 40.0981 187
+      vertex -58.8 40 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8096 39.804 187
+      vertex -58.8024 40.0981 187
+      vertex -58.8024 39.9019 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8096 39.804 187
+      vertex -58.8096 40.196 187
+      vertex -58.8024 40.0981 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8216 39.7065 187
+      vertex -58.8096 40.196 187
+      vertex -58.8096 39.804 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8216 39.7065 187
+      vertex -58.8216 40.2935 187
+      vertex -58.8096 40.196 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8384 39.6098 187
+      vertex -58.8216 40.2935 187
+      vertex -58.8216 39.7065 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8384 39.6098 187
+      vertex -58.8384 40.3902 187
+      vertex -58.8216 40.2935 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8599 39.514 187
+      vertex -58.8384 40.3902 187
+      vertex -58.8384 39.6098 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8599 39.514 187
+      vertex -58.8599 40.486 187
+      vertex -58.8384 40.3902 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8861 39.4194 187
+      vertex -58.8599 40.486 187
+      vertex -58.8599 39.514 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.8861 39.4194 187
+      vertex -58.8861 40.5806 187
+      vertex -58.8599 40.486 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9169 39.3262 187
+      vertex -58.8861 40.5806 187
+      vertex -58.8861 39.4194 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9169 39.3262 187
+      vertex -58.9169 40.6738 187
+      vertex -58.8861 40.5806 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9522 39.2346 187
+      vertex -58.9169 40.6738 187
+      vertex -58.9169 39.3262 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.9522 39.2346 187
+      vertex -58.9522 40.7654 187
+      vertex -58.9169 40.6738 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.992 39.1449 187
+      vertex -58.9522 40.7654 187
+      vertex -58.9522 39.2346 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.992 39.1449 187
+      vertex -58.992 40.8551 187
+      vertex -58.9522 40.7654 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0362 39.0572 187
+      vertex -58.992 40.8551 187
+      vertex -58.992 39.1449 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0362 39.0572 187
+      vertex -59.0362 40.9428 187
+      vertex -58.992 40.8551 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0845 38.9718 187
+      vertex -59.0362 40.9428 187
+      vertex -59.0362 39.0572 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0845 38.9718 187
+      vertex -59.0845 41.0282 187
+      vertex -59.0362 40.9428 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1371 38.8889 187
+      vertex -59.0845 41.0282 187
+      vertex -59.0845 38.9718 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1371 38.8889 187
+      vertex -59.1371 41.1111 187
+      vertex -59.0845 41.0282 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1936 38.8086 187
+      vertex -59.1371 41.1111 187
+      vertex -59.1371 38.8889 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.1936 38.8086 187
+      vertex -59.1936 41.1914 187
+      vertex -59.1371 41.1111 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.254 38.7312 187
+      vertex -59.1936 41.1914 187
+      vertex -59.1936 38.8086 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.254 38.7312 187
+      vertex -59.254 41.2688 187
+      vertex -59.1936 41.1914 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3181 38.6569 187
+      vertex -59.254 41.2688 187
+      vertex -59.254 38.7312 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3181 38.6569 187
+      vertex -59.3181 41.3431 187
+      vertex -59.254 41.2688 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3858 38.5858 187
+      vertex -59.3181 41.3431 187
+      vertex -59.3181 38.6569 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.3858 38.5858 187
+      vertex -59.3858 41.4142 187
+      vertex -59.3181 41.3431 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.4569 38.5181 187
+      vertex -59.3858 41.4142 187
+      vertex -59.3858 38.5858 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.4569 38.5181 187
+      vertex -59.4569 41.4819 187
+      vertex -59.3858 41.4142 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.5312 38.454 187
+      vertex -59.4569 41.4819 187
+      vertex -59.4569 38.5181 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.5312 38.454 187
+      vertex -59.5312 41.546 187
+      vertex -59.4569 41.4819 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6086 38.3936 187
+      vertex -59.5312 41.546 187
+      vertex -59.5312 38.454 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6086 38.3936 187
+      vertex -59.6086 41.6064 187
+      vertex -59.5312 41.546 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6889 38.3371 187
+      vertex -59.6086 41.6064 187
+      vertex -59.6086 38.3936 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6889 38.3371 187
+      vertex -59.6889 41.6629 187
+      vertex -59.6086 41.6064 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.8 38.2686 187
+      vertex -59.6889 38.3371 187
+      vertex -59.7718 38.2845 187
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -59.6889 38.3371 187
+      vertex -59.8 38.2686 187
+      vertex -59.6889 41.6629 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.8 41.7314 187
+      vertex -59.6889 41.6629 187
+      vertex -59.8 38.2686 187
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.6889 41.6629 187
+      vertex -59.8 41.7314 187
+      vertex -59.7718 41.7155 187
+    endloop
+  endfacet
+  facet normal -0.491141 0.87108 0
+    outer loop
+      vertex -59.7718 38.2845 180
+      vertex -59.8 38.2686 187
+      vertex -59.7718 38.2845 187
+    endloop
+  endfacet
+  facet normal -0.491141 0.87108 0
+    outer loop
+      vertex -59.8 38.2686 187
+      vertex -59.7718 38.2845 180
+      vertex -59.8 38.2686 180
+    endloop
+  endfacet
+  facet normal -0.615209 0.788364 0
+    outer loop
+      vertex -59.5312 38.454 180
+      vertex -59.6086 38.3936 187
+      vertex -59.5312 38.454 187
+    endloop
+  endfacet
+  facet normal -0.615209 0.788364 0
+    outer loop
+      vertex -59.6086 38.3936 187
+      vertex -59.5312 38.454 180
+      vertex -59.6086 38.3936 180
+    endloop
+  endfacet
+  facet normal -0.985242 0.171169 0
+    outer loop
+      vertex -58.8384 39.6098 180
+      vertex -58.8216 39.7065 187
+      vertex -58.8216 39.7065 180
+    endloop
+  endfacet
+  facet normal -0.985242 0.171169 0
+    outer loop
+      vertex -58.8216 39.7065 187
+      vertex -58.8384 39.6098 180
+      vertex -58.8384 39.6098 187
+    endloop
+  endfacet
+  facet normal -0.653222 0.757167 0
+    outer loop
+      vertex -59.4569 38.5181 180
+      vertex -59.5312 38.454 187
+      vertex -59.4569 38.5181 187
+    endloop
+  endfacet
+  facet normal -0.653222 0.757167 0
+    outer loop
+      vertex -59.5312 38.454 187
+      vertex -59.4569 38.5181 180
+      vertex -59.5312 38.454 180
+    endloop
+  endfacet
+  facet normal -0.914064 0.405571 0
+    outer loop
+      vertex -58.992 39.1449 180
+      vertex -58.9522 39.2346 187
+      vertex -58.9522 39.2346 180
+    endloop
+  endfacet
+  facet normal -0.914064 0.405571 0
+    outer loop
+      vertex -58.9522 39.2346 187
+      vertex -58.992 39.1449 180
+      vertex -58.992 39.1449 187
+    endloop
+  endfacet
+  facet normal -0.933109 0.359593 0
+    outer loop
+      vertex -58.9522 39.2346 180
+      vertex -58.9169 39.3262 187
+      vertex -58.9169 39.3262 180
+    endloop
+  endfacet
+  facet normal -0.933109 0.359593 0
+    outer loop
+      vertex -58.9169 39.3262 187
+      vertex -58.9522 39.2346 180
+      vertex -58.9522 39.2346 187
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 -50 150
+      vertex 0 -20 190
+      vertex 0 -20 150
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 0 -20 190
+      vertex 0 -50 150
+      vertex 0 -50 190
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 -50 150
+      vertex 3 -50 190
+      vertex 0 -50 190
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 3 -50 190
+      vertex 0 -50 150
+      vertex 3 -50 150
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3 -20 150
+      vertex 0 -20 190
+      vertex 3 -20 190
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 -20 190
+      vertex 3 -20 150
+      vertex 0 -20 150
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -20 190
+      vertex 3 -50 190
+      vertex 3 -20 190
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3 -50 190
+      vertex 0 -20 190
+      vertex 0 -50 190
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -50 150
+      vertex 3 -20 150
+      vertex 3 -50 150
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 3 -20 150
+      vertex 0 -50 150
+      vertex 0 -20 150
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 3 -50 190
+      vertex 3 -20 150
+      vertex 3 -20 190
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 3 -20 150
+      vertex 3 -50 190
+      vertex 3 -50 150
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/3d_models/trap_entrance.stl
+++ b/3d_models/trap_entrance.stl
@@ -1,0 +1,6526 @@
+solid OpenSCAD_Model
+  facet normal -0.0245379 0.999699 0
+    outer loop
+      vertex 0 54.8 0
+      vertex -2.68891 54.734 20
+      vertex 0 54.8 20
+    endloop
+  endfacet
+  facet normal -0.0245379 0.999699 0
+    outer loop
+      vertex -2.68891 54.734 20
+      vertex 0 54.8 0
+      vertex -2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal 0.170987 -0.985273 0
+    outer loop
+      vertex 8.04083 -54.2069 0
+      vertex 10.6909 -53.747 20
+      vertex 8.04083 -54.2069 20
+    endloop
+  endfacet
+  facet normal 0.170987 -0.985273 0
+    outer loop
+      vertex 10.6909 -53.747 20
+      vertex 8.04083 -54.2069 0
+      vertex 10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal 0.359896 -0.932992 0
+    outer loop
+      vertex 18.4616 -51.5966 0
+      vertex 20.5267 -50.8 20
+      vertex 18.4616 -51.5966 20
+    endloop
+  endfacet
+  facet normal 0.359896 -0.932992 0
+    outer loop
+      vertex 20.5267 -50.8 20
+      vertex 18.4616 -51.5966 0
+      vertex 20.5267 -50.8 0
+    endloop
+  endfacet
+  facet normal 0.359896 0.932992 -0
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 18.4616 51.5966 20
+      vertex 20.5267 50.8 20
+    endloop
+  endfacet
+  facet normal 0.359896 0.932992 0
+    outer loop
+      vertex 18.4616 51.5966 20
+      vertex 20.5267 50.8 0
+      vertex 18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0.0245379 -0.999699 0
+    outer loop
+      vertex 0 -54.8 0
+      vertex 2.68891 -54.734 20
+      vertex 0 -54.8 20
+    endloop
+  endfacet
+  facet normal 0.0245379 -0.999699 0
+    outer loop
+      vertex 2.68891 -54.734 20
+      vertex 0 -54.8 0
+      vertex 2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal -0.0735764 -0.99729 0
+    outer loop
+      vertex -5.37134 -54.5361 0
+      vertex -2.68891 -54.734 20
+      vertex -5.37134 -54.5361 20
+    endloop
+  endfacet
+  facet normal -0.0735764 -0.99729 -0
+    outer loop
+      vertex -2.68891 -54.734 20
+      vertex -5.37134 -54.5361 0
+      vertex -2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal 0.0735764 -0.99729 0
+    outer loop
+      vertex 2.68891 -54.734 0
+      vertex 5.37134 -54.5361 20
+      vertex 2.68891 -54.734 20
+    endloop
+  endfacet
+  facet normal 0.0735764 -0.99729 0
+    outer loop
+      vertex 5.37134 -54.5361 20
+      vertex 2.68891 -54.734 0
+      vertex 5.37134 -54.5361 0
+    endloop
+  endfacet
+  facet normal 0.122392 -0.992482 0
+    outer loop
+      vertex 5.37134 -54.5361 0
+      vertex 8.04083 -54.2069 20
+      vertex 5.37134 -54.5361 20
+    endloop
+  endfacet
+  facet normal 0.122392 -0.992482 0
+    outer loop
+      vertex 8.04083 -54.2069 20
+      vertex 5.37134 -54.5361 0
+      vertex 8.04083 -54.2069 0
+    endloop
+  endfacet
+  facet normal -0.219091 0.975704 0
+    outer loop
+      vertex -10.6909 53.747 0
+      vertex -13.3153 53.1577 20
+      vertex -10.6909 53.747 20
+    endloop
+  endfacet
+  facet normal -0.219091 0.975704 0
+    outer loop
+      vertex -13.3153 53.1577 20
+      vertex -10.6909 53.747 0
+      vertex -13.3153 53.1577 0
+    endloop
+  endfacet
+  facet normal -0.0735764 0.99729 0
+    outer loop
+      vertex -2.68891 54.734 0
+      vertex -5.37134 54.5361 20
+      vertex -2.68891 54.734 20
+    endloop
+  endfacet
+  facet normal -0.0735764 0.99729 0
+    outer loop
+      vertex -5.37134 54.5361 20
+      vertex -2.68891 54.734 0
+      vertex -5.37134 54.5361 0
+    endloop
+  endfacet
+  facet normal -0.170987 -0.985273 0
+    outer loop
+      vertex -10.6909 -53.747 0
+      vertex -8.04083 -54.2069 20
+      vertex -10.6909 -53.747 20
+    endloop
+  endfacet
+  facet normal -0.170987 -0.985273 -0
+    outer loop
+      vertex -8.04083 -54.2069 20
+      vertex -10.6909 -53.747 0
+      vertex -8.04083 -54.2069 0
+    endloop
+  endfacet
+  facet normal -0.266718 0.963775 0
+    outer loop
+      vertex -13.3153 53.1577 0
+      vertex -15.9076 52.4403 20
+      vertex -13.3153 53.1577 20
+    endloop
+  endfacet
+  facet normal -0.266718 0.963775 0
+    outer loop
+      vertex -15.9076 52.4403 20
+      vertex -13.3153 53.1577 0
+      vertex -15.9076 52.4403 0
+    endloop
+  endfacet
+  facet normal 0.219091 0.975704 -0
+    outer loop
+      vertex 13.3153 53.1577 0
+      vertex 10.6909 53.747 20
+      vertex 13.3153 53.1577 20
+    endloop
+  endfacet
+  facet normal 0.219091 0.975704 0
+    outer loop
+      vertex 10.6909 53.747 20
+      vertex 13.3153 53.1577 0
+      vertex 10.6909 53.747 0
+    endloop
+  endfacet
+  facet normal 0.266718 -0.963775 0
+    outer loop
+      vertex 13.3153 -53.1577 0
+      vertex 15.9076 -52.4403 20
+      vertex 13.3153 -53.1577 20
+    endloop
+  endfacet
+  facet normal 0.266718 -0.963775 0
+    outer loop
+      vertex 15.9076 -52.4403 20
+      vertex 13.3153 -53.1577 0
+      vertex 15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal -0.0245379 -0.999699 0
+    outer loop
+      vertex -2.68891 -54.734 0
+      vertex 0 -54.8 20
+      vertex -2.68891 -54.734 20
+    endloop
+  endfacet
+  facet normal -0.0245379 -0.999699 -0
+    outer loop
+      vertex 0 -54.8 20
+      vertex -2.68891 -54.734 0
+      vertex 0 -54.8 0
+    endloop
+  endfacet
+  facet normal -0.122392 -0.992482 0
+    outer loop
+      vertex -8.04083 -54.2069 0
+      vertex -5.37134 -54.5361 20
+      vertex -8.04083 -54.2069 20
+    endloop
+  endfacet
+  facet normal -0.122392 -0.992482 -0
+    outer loop
+      vertex -5.37134 -54.5361 20
+      vertex -8.04083 -54.2069 0
+      vertex -5.37134 -54.5361 0
+    endloop
+  endfacet
+  facet normal 0.313672 -0.949531 0
+    outer loop
+      vertex 15.9076 -52.4403 0
+      vertex 18.4616 -51.5966 20
+      vertex 15.9076 -52.4403 20
+    endloop
+  endfacet
+  facet normal 0.313672 -0.949531 0
+    outer loop
+      vertex 18.4616 -51.5966 20
+      vertex 15.9076 -52.4403 0
+      vertex 18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal -0.359896 0.932992 0
+    outer loop
+      vertex -18.4616 51.5966 0
+      vertex -20.5267 50.8 20
+      vertex -18.4616 51.5966 20
+    endloop
+  endfacet
+  facet normal -0.359896 0.932992 0
+    outer loop
+      vertex -20.5267 50.8 20
+      vertex -18.4616 51.5966 0
+      vertex -20.5267 50.8 0
+    endloop
+  endfacet
+  facet normal 0.122392 0.992482 -0
+    outer loop
+      vertex 8.04083 54.2069 0
+      vertex 5.37134 54.5361 20
+      vertex 8.04083 54.2069 20
+    endloop
+  endfacet
+  facet normal 0.122392 0.992482 0
+    outer loop
+      vertex 5.37134 54.5361 20
+      vertex 8.04083 54.2069 0
+      vertex 5.37134 54.5361 0
+    endloop
+  endfacet
+  facet normal -0.170987 0.985273 0
+    outer loop
+      vertex -8.04083 54.2069 0
+      vertex -10.6909 53.747 20
+      vertex -8.04083 54.2069 20
+    endloop
+  endfacet
+  facet normal -0.170987 0.985273 0
+    outer loop
+      vertex -10.6909 53.747 20
+      vertex -8.04083 54.2069 0
+      vertex -10.6909 53.747 0
+    endloop
+  endfacet
+  facet normal -0.313672 -0.949531 0
+    outer loop
+      vertex -18.4616 -51.5966 0
+      vertex -15.9076 -52.4403 20
+      vertex -18.4616 -51.5966 20
+    endloop
+  endfacet
+  facet normal -0.313672 -0.949531 -0
+    outer loop
+      vertex -15.9076 -52.4403 20
+      vertex -18.4616 -51.5966 0
+      vertex -15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal -0.122392 0.992482 0
+    outer loop
+      vertex -5.37134 54.5361 0
+      vertex -8.04083 54.2069 20
+      vertex -5.37134 54.5361 20
+    endloop
+  endfacet
+  facet normal -0.122392 0.992482 0
+    outer loop
+      vertex -8.04083 54.2069 20
+      vertex -5.37134 54.5361 0
+      vertex -8.04083 54.2069 0
+    endloop
+  endfacet
+  facet normal 0.266718 0.963775 -0
+    outer loop
+      vertex 15.9076 52.4403 0
+      vertex 13.3153 53.1577 20
+      vertex 15.9076 52.4403 20
+    endloop
+  endfacet
+  facet normal 0.266718 0.963775 0
+    outer loop
+      vertex 13.3153 53.1577 20
+      vertex 15.9076 52.4403 0
+      vertex 13.3153 53.1577 0
+    endloop
+  endfacet
+  facet normal -0.266718 -0.963775 0
+    outer loop
+      vertex -15.9076 -52.4403 0
+      vertex -13.3153 -53.1577 20
+      vertex -15.9076 -52.4403 20
+    endloop
+  endfacet
+  facet normal -0.266718 -0.963775 -0
+    outer loop
+      vertex -13.3153 -53.1577 20
+      vertex -15.9076 -52.4403 0
+      vertex -13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal 0.0735764 0.99729 -0
+    outer loop
+      vertex 5.37134 54.5361 0
+      vertex 2.68891 54.734 20
+      vertex 5.37134 54.5361 20
+    endloop
+  endfacet
+  facet normal 0.0735764 0.99729 0
+    outer loop
+      vertex 2.68891 54.734 20
+      vertex 5.37134 54.5361 0
+      vertex 2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal -0.359896 -0.932992 0
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -18.4616 -51.5966 20
+      vertex -20.5267 -50.8 20
+    endloop
+  endfacet
+  facet normal -0.359896 -0.932992 -0
+    outer loop
+      vertex -18.4616 -51.5966 20
+      vertex -20.5267 -50.8 0
+      vertex -18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal 0.219091 -0.975704 0
+    outer loop
+      vertex 10.6909 -53.747 0
+      vertex 13.3153 -53.1577 20
+      vertex 10.6909 -53.747 20
+    endloop
+  endfacet
+  facet normal 0.219091 -0.975704 0
+    outer loop
+      vertex 13.3153 -53.1577 20
+      vertex 10.6909 -53.747 0
+      vertex 13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal 0.0245379 0.999699 -0
+    outer loop
+      vertex 2.68891 54.734 0
+      vertex 0 54.8 20
+      vertex 2.68891 54.734 20
+    endloop
+  endfacet
+  facet normal 0.0245379 0.999699 0
+    outer loop
+      vertex 0 54.8 20
+      vertex 2.68891 54.734 0
+      vertex 0 54.8 0
+    endloop
+  endfacet
+  facet normal -0.313672 0.949531 0
+    outer loop
+      vertex -15.9076 52.4403 0
+      vertex -18.4616 51.5966 20
+      vertex -15.9076 52.4403 20
+    endloop
+  endfacet
+  facet normal -0.313672 0.949531 0
+    outer loop
+      vertex -18.4616 51.5966 20
+      vertex -15.9076 52.4403 0
+      vertex -18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0.313672 0.949531 -0
+    outer loop
+      vertex 18.4616 51.5966 0
+      vertex 15.9076 52.4403 20
+      vertex 18.4616 51.5966 20
+    endloop
+  endfacet
+  facet normal 0.313672 0.949531 0
+    outer loop
+      vertex 15.9076 52.4403 20
+      vertex 18.4616 51.5966 0
+      vertex 15.9076 52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.8 0 0
+      vertex 54.8 50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.7388 -2.49264 0
+      vertex 50.8 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.5554 -4.97927 0
+      vertex 50.7388 -2.49264 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.2502 -7.45391 0
+      vertex 50.5554 -4.97927 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 49.8239 -9.91059 0
+      vertex 50.2502 -7.45391 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 49.2776 -12.3434 0
+      vertex 49.8239 -9.91059 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 48.6126 -14.7465 0
+      vertex 49.2776 -12.3434 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 47.8304 -17.114 0
+      vertex 48.6126 -14.7465 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 46.9331 -19.4403 0
+      vertex 47.8304 -17.114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 45.9227 -21.7198 0
+      vertex 46.9331 -19.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 44.8016 -23.947 0
+      vertex 45.9227 -21.7198 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 43.5726 -26.1164 0
+      vertex 44.8016 -23.947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 42.2387 -28.223 0
+      vertex 43.5726 -26.1164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 40.8029 -30.2615 0
+      vertex 42.2387 -28.223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 39.2689 -32.2272 0
+      vertex 40.8029 -30.2615 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 37.6403 -34.1152 0
+      vertex 39.2689 -32.2272 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 35.921 -35.921 0
+      vertex 37.6403 -34.1152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 34.1152 -37.6403 0
+      vertex 35.921 -35.921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 32.2272 -39.2689 0
+      vertex 34.1152 -37.6403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 30.2615 -40.8029 0
+      vertex 32.2272 -39.2689 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 28.223 -42.2387 0
+      vertex 30.2615 -40.8029 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 28.223 -42.2387 0
+      vertex 54.8 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.223 -42.2387 0
+      vertex 20.5267 -50.8 0
+      vertex 26.1164 -43.5726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.1164 -43.5726 0
+      vertex 20.5267 -50.8 0
+      vertex 23.947 -44.8016 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.947 -44.8016 0
+      vertex 20.5267 -50.8 0
+      vertex 21.7198 -45.9227 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 19.4403 -46.9331 0
+      vertex 21.7198 -45.9227 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.114 -47.8304 0
+      vertex 20.5267 -50.8 0
+      vertex 18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 17.114 -47.8304 0
+      vertex 19.4403 -46.9331 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9076 -52.4403 0
+      vertex 17.114 -47.8304 0
+      vertex 18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9076 -52.4403 0
+      vertex 14.7465 -48.6126 0
+      vertex 17.114 -47.8304 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.3153 -53.1577 0
+      vertex 14.7465 -48.6126 0
+      vertex 15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.3153 -53.1577 0
+      vertex 12.3434 -49.2776 0
+      vertex 14.7465 -48.6126 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6909 -53.747 0
+      vertex 12.3434 -49.2776 0
+      vertex 13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6909 -53.747 0
+      vertex 9.91059 -49.8239 0
+      vertex 12.3434 -49.2776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.04083 -54.2069 0
+      vertex 9.91059 -49.8239 0
+      vertex 10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.04083 -54.2069 0
+      vertex 7.45391 -50.2502 0
+      vertex 9.91059 -49.8239 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.37134 -54.5361 0
+      vertex 7.45391 -50.2502 0
+      vertex 8.04083 -54.2069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.37134 -54.5361 0
+      vertex 4.97927 -50.5554 0
+      vertex 7.45391 -50.2502 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.68891 -54.734 0
+      vertex 4.97927 -50.5554 0
+      vertex 5.37134 -54.5361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.68891 -54.734 0
+      vertex 2.49264 -50.7388 0
+      vertex 4.97927 -50.5554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -54.8 0
+      vertex 2.49264 -50.7388 0
+      vertex 2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -54.8 0
+      vertex 0 -50.8 0
+      vertex 2.49264 -50.7388 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -54.8 0
+      vertex -2.49264 -50.7388 0
+      vertex 0 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.68891 -54.734 0
+      vertex -2.49264 -50.7388 0
+      vertex 0 -54.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.68891 -54.734 0
+      vertex -4.97927 -50.5554 0
+      vertex -2.49264 -50.7388 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.37134 -54.5361 0
+      vertex -4.97927 -50.5554 0
+      vertex -2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.37134 -54.5361 0
+      vertex -7.45391 -50.2502 0
+      vertex -4.97927 -50.5554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.04083 -54.2069 0
+      vertex -7.45391 -50.2502 0
+      vertex -5.37134 -54.5361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.04083 -54.2069 0
+      vertex -9.91059 -49.8239 0
+      vertex -7.45391 -50.2502 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6909 -53.747 0
+      vertex -9.91059 -49.8239 0
+      vertex -8.04083 -54.2069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6909 -53.747 0
+      vertex -12.3434 -49.2776 0
+      vertex -9.91059 -49.8239 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.3153 -53.1577 0
+      vertex -12.3434 -49.2776 0
+      vertex -10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.3153 -53.1577 0
+      vertex -14.7465 -48.6126 0
+      vertex -12.3434 -49.2776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9076 -52.4403 0
+      vertex -14.7465 -48.6126 0
+      vertex -13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9076 -52.4403 0
+      vertex -17.114 -47.8304 0
+      vertex -14.7465 -48.6126 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.4616 -51.5966 0
+      vertex -17.114 -47.8304 0
+      vertex -15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -17.114 -47.8304 0
+      vertex -18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.114 -47.8304 0
+      vertex -20.5267 -50.8 0
+      vertex -19.4403 -46.9331 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -21.7198 -45.9227 0
+      vertex -19.4403 -46.9331 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -23.947 -44.8016 0
+      vertex -21.7198 -45.9227 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -26.1164 -43.5726 0
+      vertex -23.947 -44.8016 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -28.223 -42.2387 0
+      vertex -26.1164 -43.5726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -28.223 -42.2387 0
+      vertex -20.5267 -50.8 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -28.223 -42.2387 0
+      vertex -54.8 -50.8 0
+      vertex -30.2615 -40.8029 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -30.2615 -40.8029 0
+      vertex -54.8 -50.8 0
+      vertex -32.2272 -39.2689 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -32.2272 -39.2689 0
+      vertex -54.8 -50.8 0
+      vertex -34.1152 -37.6403 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -50.7388 -2.49264 0
+      vertex -54.8 -50.8 0
+      vertex -50.8 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -50.5554 -4.97927 0
+      vertex -54.8 -50.8 0
+      vertex -50.7388 -2.49264 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -50.2502 -7.45391 0
+      vertex -54.8 -50.8 0
+      vertex -50.5554 -4.97927 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -49.8239 -9.91059 0
+      vertex -54.8 -50.8 0
+      vertex -50.2502 -7.45391 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -49.2776 -12.3434 0
+      vertex -54.8 -50.8 0
+      vertex -49.8239 -9.91059 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -48.6126 -14.7465 0
+      vertex -54.8 -50.8 0
+      vertex -49.2776 -12.3434 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -47.8304 -17.114 0
+      vertex -54.8 -50.8 0
+      vertex -48.6126 -14.7465 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -46.9331 -19.4403 0
+      vertex -54.8 -50.8 0
+      vertex -47.8304 -17.114 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -45.9227 -21.7198 0
+      vertex -54.8 -50.8 0
+      vertex -46.9331 -19.4403 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -44.8016 -23.947 0
+      vertex -54.8 -50.8 0
+      vertex -45.9227 -21.7198 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -43.5726 -26.1164 0
+      vertex -54.8 -50.8 0
+      vertex -44.8016 -23.947 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -42.2387 -28.223 0
+      vertex -54.8 -50.8 0
+      vertex -43.5726 -26.1164 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -40.8029 -30.2615 0
+      vertex -54.8 -50.8 0
+      vertex -42.2387 -28.223 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -39.2689 -32.2272 0
+      vertex -54.8 -50.8 0
+      vertex -40.8029 -30.2615 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -37.6403 -34.1152 0
+      vertex -54.8 -50.8 0
+      vertex -39.2689 -32.2272 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -35.921 -35.921 0
+      vertex -54.8 -50.8 0
+      vertex -37.6403 -34.1152 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -34.1152 -37.6403 0
+      vertex -54.8 -50.8 0
+      vertex -35.921 -35.921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.7388 2.49264 0
+      vertex 54.8 50.8 0
+      vertex 50.8 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.5554 4.97927 0
+      vertex 54.8 50.8 0
+      vertex 50.7388 2.49264 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.2502 7.45391 0
+      vertex 54.8 50.8 0
+      vertex 50.5554 4.97927 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.8239 9.91059 0
+      vertex 54.8 50.8 0
+      vertex 50.2502 7.45391 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.2776 12.3434 0
+      vertex 54.8 50.8 0
+      vertex 49.8239 9.91059 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 48.6126 14.7465 0
+      vertex 54.8 50.8 0
+      vertex 49.2776 12.3434 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.8304 17.114 0
+      vertex 54.8 50.8 0
+      vertex 48.6126 14.7465 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 46.9331 19.4403 0
+      vertex 54.8 50.8 0
+      vertex 47.8304 17.114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 45.9227 21.7198 0
+      vertex 54.8 50.8 0
+      vertex 46.9331 19.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 44.8016 23.947 0
+      vertex 54.8 50.8 0
+      vertex 45.9227 21.7198 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 43.5726 26.1164 0
+      vertex 54.8 50.8 0
+      vertex 44.8016 23.947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 42.2387 28.223 0
+      vertex 54.8 50.8 0
+      vertex 43.5726 26.1164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40.8029 30.2615 0
+      vertex 54.8 50.8 0
+      vertex 42.2387 28.223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 39.2689 32.2272 0
+      vertex 54.8 50.8 0
+      vertex 40.8029 30.2615 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 37.6403 34.1152 0
+      vertex 54.8 50.8 0
+      vertex 39.2689 32.2272 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.921 35.921 0
+      vertex 54.8 50.8 0
+      vertex 37.6403 34.1152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34.1152 37.6403 0
+      vertex 54.8 50.8 0
+      vertex 35.921 35.921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.2272 39.2689 0
+      vertex 54.8 50.8 0
+      vertex 34.1152 37.6403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.2615 40.8029 0
+      vertex 54.8 50.8 0
+      vertex 32.2272 39.2689 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.223 42.2387 0
+      vertex 54.8 50.8 0
+      vertex 30.2615 40.8029 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 28.223 42.2387 0
+      vertex 26.1164 43.5726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 26.1164 43.5726 0
+      vertex 23.947 44.8016 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 23.947 44.8016 0
+      vertex 21.7198 45.9227 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.223 42.2387 0
+      vertex 20.5267 50.8 0
+      vertex 54.8 50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.4403 46.9331 0
+      vertex 20.5267 50.8 0
+      vertex 21.7198 45.9227 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.114 47.8304 0
+      vertex 20.5267 50.8 0
+      vertex 19.4403 46.9331 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 17.114 47.8304 0
+      vertex 18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.114 47.8304 0
+      vertex 15.9076 52.4403 0
+      vertex 18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7465 48.6126 0
+      vertex 15.9076 52.4403 0
+      vertex 17.114 47.8304 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7465 48.6126 0
+      vertex 13.3153 53.1577 0
+      vertex 15.9076 52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.3434 49.2776 0
+      vertex 13.3153 53.1577 0
+      vertex 14.7465 48.6126 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.3434 49.2776 0
+      vertex 10.6909 53.747 0
+      vertex 13.3153 53.1577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.91059 49.8239 0
+      vertex 10.6909 53.747 0
+      vertex 12.3434 49.2776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.91059 49.8239 0
+      vertex 8.04083 54.2069 0
+      vertex 10.6909 53.747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.45391 50.2502 0
+      vertex 8.04083 54.2069 0
+      vertex 9.91059 49.8239 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.45391 50.2502 0
+      vertex 5.37134 54.5361 0
+      vertex 8.04083 54.2069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.97927 50.5554 0
+      vertex 5.37134 54.5361 0
+      vertex 7.45391 50.2502 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.97927 50.5554 0
+      vertex 2.68891 54.734 0
+      vertex 5.37134 54.5361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.49264 50.7388 0
+      vertex 2.68891 54.734 0
+      vertex 4.97927 50.5554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 50.8 0
+      vertex 2.68891 54.734 0
+      vertex 2.49264 50.7388 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 50.8 0
+      vertex 0 54.8 0
+      vertex 2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.49264 50.7388 0
+      vertex 0 54.8 0
+      vertex 0 50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.49264 50.7388 0
+      vertex -2.68891 54.734 0
+      vertex 0 54.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.97927 50.5554 0
+      vertex -2.68891 54.734 0
+      vertex -2.49264 50.7388 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.97927 50.5554 0
+      vertex -5.37134 54.5361 0
+      vertex -2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.45391 50.2502 0
+      vertex -5.37134 54.5361 0
+      vertex -4.97927 50.5554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.45391 50.2502 0
+      vertex -8.04083 54.2069 0
+      vertex -5.37134 54.5361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.91059 49.8239 0
+      vertex -8.04083 54.2069 0
+      vertex -7.45391 50.2502 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.91059 49.8239 0
+      vertex -10.6909 53.747 0
+      vertex -8.04083 54.2069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3434 49.2776 0
+      vertex -10.6909 53.747 0
+      vertex -9.91059 49.8239 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3434 49.2776 0
+      vertex -13.3153 53.1577 0
+      vertex -10.6909 53.747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7465 48.6126 0
+      vertex -13.3153 53.1577 0
+      vertex -12.3434 49.2776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7465 48.6126 0
+      vertex -15.9076 52.4403 0
+      vertex -13.3153 53.1577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.114 47.8304 0
+      vertex -15.9076 52.4403 0
+      vertex -14.7465 48.6126 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.114 47.8304 0
+      vertex -18.4616 51.5966 0
+      vertex -15.9076 52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 50.8 0
+      vertex -17.114 47.8304 0
+      vertex -19.4403 46.9331 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.114 47.8304 0
+      vertex -20.5267 50.8 0
+      vertex -18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.7198 45.9227 0
+      vertex -20.5267 50.8 0
+      vertex -19.4403 46.9331 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.947 44.8016 0
+      vertex -20.5267 50.8 0
+      vertex -21.7198 45.9227 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1164 43.5726 0
+      vertex -20.5267 50.8 0
+      vertex -23.947 44.8016 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.223 42.2387 0
+      vertex -20.5267 50.8 0
+      vertex -26.1164 43.5726 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -28.223 42.2387 0
+      vertex -30.2615 40.8029 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -30.2615 40.8029 0
+      vertex -32.2272 39.2689 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -32.2272 39.2689 0
+      vertex -34.1152 37.6403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -34.1152 37.6403 0
+      vertex -35.921 35.921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -50.8 0 0
+      vertex -54.8 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.8 0 0
+      vertex -54.8 50.8 0
+      vertex -50.7388 2.49264 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.223 42.2387 0
+      vertex -54.8 50.8 0
+      vertex -20.5267 50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -37.6403 34.1152 0
+      vertex -54.8 50.8 0
+      vertex -35.921 35.921 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -39.2689 32.2272 0
+      vertex -54.8 50.8 0
+      vertex -37.6403 34.1152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -40.8029 30.2615 0
+      vertex -54.8 50.8 0
+      vertex -39.2689 32.2272 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -42.2387 28.223 0
+      vertex -54.8 50.8 0
+      vertex -40.8029 30.2615 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -43.5726 26.1164 0
+      vertex -54.8 50.8 0
+      vertex -42.2387 28.223 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.8016 23.947 0
+      vertex -54.8 50.8 0
+      vertex -43.5726 26.1164 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -45.9227 21.7198 0
+      vertex -54.8 50.8 0
+      vertex -44.8016 23.947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -46.9331 19.4403 0
+      vertex -54.8 50.8 0
+      vertex -45.9227 21.7198 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -47.8304 17.114 0
+      vertex -54.8 50.8 0
+      vertex -46.9331 19.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -48.6126 14.7465 0
+      vertex -54.8 50.8 0
+      vertex -47.8304 17.114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -49.2776 12.3434 0
+      vertex -54.8 50.8 0
+      vertex -48.6126 14.7465 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -49.8239 9.91059 0
+      vertex -54.8 50.8 0
+      vertex -49.2776 12.3434 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.2502 7.45391 0
+      vertex -54.8 50.8 0
+      vertex -49.8239 9.91059 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.5554 4.97927 0
+      vertex -54.8 50.8 0
+      vertex -50.2502 7.45391 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.7388 2.49264 0
+      vertex -54.8 50.8 0
+      vertex -50.5554 4.97927 0
+    endloop
+  endfacet
+  facet normal -0.219091 -0.975704 0
+    outer loop
+      vertex -13.3153 -53.1577 0
+      vertex -10.6909 -53.747 20
+      vertex -13.3153 -53.1577 20
+    endloop
+  endfacet
+  facet normal -0.219091 -0.975704 -0
+    outer loop
+      vertex -10.6909 -53.747 20
+      vertex -13.3153 -53.1577 0
+      vertex -10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal 0.170987 0.985273 -0
+    outer loop
+      vertex 10.6909 53.747 0
+      vertex 8.04083 54.2069 20
+      vertex 10.6909 53.747 20
+    endloop
+  endfacet
+  facet normal 0.170987 0.985273 0
+    outer loop
+      vertex 8.04083 54.2069 20
+      vertex 10.6909 53.747 0
+      vertex 8.04083 54.2069 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 54.8 50.8 0
+      vertex 54.8 50.8 20
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 54.8 -10.4701 20
+      vertex 54.8 50.8 0
+      vertex 54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 54.8 -10.4701 20
+      vertex 54.8 -50.8 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 54.8 -10.4701 20
+      vertex 54.8 -50.8 0
+      vertex 54.8 50.8 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -23.8576 50.4426 20
+      vertex -23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -26.3039 49.2112 20
+      vertex -23.8576 50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -28.6869 47.8613 20
+      vertex -26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -31.0008 46.396 20
+      vertex -28.6869 47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -33.24 44.819 20
+      vertex -31.0008 46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -35.3991 43.134 20
+      vertex -33.24 44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -37.473 41.3451 20
+      vertex -35.3991 43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -39.4566 39.4566 20
+      vertex -37.473 41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -41.3451 37.473 20
+      vertex -39.4566 39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -43.134 35.3991 20
+      vertex -41.3451 37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -44.819 33.24 20
+      vertex -43.134 35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -46.396 31.0008 20
+      vertex -44.819 33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -47.8613 28.6869 20
+      vertex -46.396 31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -49.2112 26.3039 20
+      vertex -47.8613 28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -50.4426 23.8576 20
+      vertex -49.2112 26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -51.5525 21.3537 20
+      vertex -50.4426 23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -52.5382 18.7985 20
+      vertex -51.5525 21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -53.3973 16.1979 20
+      vertex -52.5382 18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -54.1277 13.5583 20
+      vertex -53.3973 16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -54.7278 10.886 20
+      vertex -54.1277 13.5583 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.7278 10.886 20
+      vertex -54.8 50.8 20
+      vertex -54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 54.7278 10.886 20
+      vertex 54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 54.1277 13.5583 20
+      vertex 54.7278 10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 53.3973 16.1979 20
+      vertex 54.1277 13.5583 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 52.5382 18.7985 20
+      vertex 53.3973 16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 51.5525 21.3537 20
+      vertex 52.5382 18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 50.4426 23.8576 20
+      vertex 51.5525 21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 49.2112 26.3039 20
+      vertex 50.4426 23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 47.8613 28.6869 20
+      vertex 49.2112 26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 46.396 31.0008 20
+      vertex 47.8613 28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 44.819 33.24 20
+      vertex 46.396 31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 43.134 35.3991 20
+      vertex 44.819 33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 41.3451 37.473 20
+      vertex 43.134 35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 39.4566 39.4566 20
+      vertex 41.3451 37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 37.473 41.3451 20
+      vertex 39.4566 39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 35.3991 43.134 20
+      vertex 37.473 41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 33.24 44.819 20
+      vertex 35.3991 43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 31.0008 46.396 20
+      vertex 33.24 44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 28.6869 47.8613 20
+      vertex 31.0008 46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 26.3039 49.2112 20
+      vertex 28.6869 47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 23.8576 50.4426 20
+      vertex 26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 23.8576 50.4426 20
+      vertex 54.8 50.8 20
+      vertex 23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.8576 -50.4426 20
+      vertex -54.8 -50.8 20
+      vertex -23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.3039 -49.2112 20
+      vertex -54.8 -50.8 20
+      vertex -23.8576 -50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.6869 -47.8613 20
+      vertex -54.8 -50.8 20
+      vertex -26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.0008 -46.396 20
+      vertex -54.8 -50.8 20
+      vertex -28.6869 -47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.24 -44.819 20
+      vertex -54.8 -50.8 20
+      vertex -31.0008 -46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.3991 -43.134 20
+      vertex -54.8 -50.8 20
+      vertex -33.24 -44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.473 -41.3451 20
+      vertex -54.8 -50.8 20
+      vertex -35.3991 -43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -39.4566 -39.4566 20
+      vertex -54.8 -50.8 20
+      vertex -37.473 -41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.3451 -37.473 20
+      vertex -54.8 -50.8 20
+      vertex -39.4566 -39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.134 -35.3991 20
+      vertex -54.8 -50.8 20
+      vertex -41.3451 -37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.819 -33.24 20
+      vertex -54.8 -50.8 20
+      vertex -43.134 -35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.396 -31.0008 20
+      vertex -54.8 -50.8 20
+      vertex -44.819 -33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.8613 -28.6869 20
+      vertex -54.8 -50.8 20
+      vertex -46.396 -31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.2112 -26.3039 20
+      vertex -54.8 -50.8 20
+      vertex -47.8613 -28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.4426 -23.8576 20
+      vertex -54.8 -50.8 20
+      vertex -49.2112 -26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -51.5525 -21.3537 20
+      vertex -54.8 -50.8 20
+      vertex -50.4426 -23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -52.5382 -18.7985 20
+      vertex -54.8 -50.8 20
+      vertex -51.5525 -21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -53.3973 -16.1979 20
+      vertex -54.8 -50.8 20
+      vertex -52.5382 -18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.1277 -13.5583 20
+      vertex -54.8 -50.8 20
+      vertex -53.3973 -16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.7278 -10.886 20
+      vertex -54.8 -50.8 20
+      vertex -54.1277 -13.5583 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -50.8 20
+      vertex -54.7278 -10.886 20
+      vertex -54.8 -10.4701 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 54.7278 -10.886 20
+      vertex 54.8 -50.8 20
+      vertex 54.8 -10.4701 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 54.1277 -13.5583 20
+      vertex 54.8 -50.8 20
+      vertex 54.7278 -10.886 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 53.3973 -16.1979 20
+      vertex 54.8 -50.8 20
+      vertex 54.1277 -13.5583 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 52.5382 -18.7985 20
+      vertex 54.8 -50.8 20
+      vertex 53.3973 -16.1979 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 51.5525 -21.3537 20
+      vertex 54.8 -50.8 20
+      vertex 52.5382 -18.7985 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 50.4426 -23.8576 20
+      vertex 54.8 -50.8 20
+      vertex 51.5525 -21.3537 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 49.2112 -26.3039 20
+      vertex 54.8 -50.8 20
+      vertex 50.4426 -23.8576 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 47.8613 -28.6869 20
+      vertex 54.8 -50.8 20
+      vertex 49.2112 -26.3039 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 46.396 -31.0008 20
+      vertex 54.8 -50.8 20
+      vertex 47.8613 -28.6869 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 44.819 -33.24 20
+      vertex 54.8 -50.8 20
+      vertex 46.396 -31.0008 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 43.134 -35.3991 20
+      vertex 54.8 -50.8 20
+      vertex 44.819 -33.24 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 41.3451 -37.473 20
+      vertex 54.8 -50.8 20
+      vertex 43.134 -35.3991 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 39.4566 -39.4566 20
+      vertex 54.8 -50.8 20
+      vertex 41.3451 -37.473 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 37.473 -41.3451 20
+      vertex 54.8 -50.8 20
+      vertex 39.4566 -39.4566 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35.3991 -43.134 20
+      vertex 54.8 -50.8 20
+      vertex 37.473 -41.3451 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 33.24 -44.819 20
+      vertex 54.8 -50.8 20
+      vertex 35.3991 -43.134 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 31.0008 -46.396 20
+      vertex 54.8 -50.8 20
+      vertex 33.24 -44.819 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 28.6869 -47.8613 20
+      vertex 54.8 -50.8 20
+      vertex 31.0008 -46.396 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.3039 -49.2112 20
+      vertex 54.8 -50.8 20
+      vertex 28.6869 -47.8613 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.8576 -50.4426 20
+      vertex 54.8 -50.8 20
+      vertex 26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 -50.8 20
+      vertex 23.8576 -50.4426 20
+      vertex 23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.8239 9.91059 20
+      vertex 54.8 10.4701 20
+      vertex 54.7278 10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 50.8 0 20
+      vertex 54.8 -10.4701 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.8239 9.91059 20
+      vertex 54.7278 10.886 20
+      vertex 54.1277 13.5583 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 50.7388 -2.49264 20
+      vertex 54.8 -10.4701 20
+      vertex 50.8 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.2776 12.3434 20
+      vertex 54.1277 13.5583 20
+      vertex 53.3973 16.1979 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 50.5554 -4.97927 20
+      vertex 54.8 -10.4701 20
+      vertex 50.7388 -2.49264 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.6126 14.7465 20
+      vertex 53.3973 16.1979 20
+      vertex 52.5382 18.7985 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 50.2502 -7.45391 20
+      vertex 54.8 -10.4701 20
+      vertex 50.5554 -4.97927 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 47.8304 17.114 20
+      vertex 52.5382 18.7985 20
+      vertex 51.5525 21.3537 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 49.8239 -9.91059 20
+      vertex 54.8 -10.4701 20
+      vertex 50.2502 -7.45391 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 -10.4701 20
+      vertex 49.8239 -9.91059 20
+      vertex 54.7278 -10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 50.7388 2.49264 20
+      vertex 50.8 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 50.5554 4.97927 20
+      vertex 50.7388 2.49264 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 46.9331 19.4403 20
+      vertex 51.5525 21.3537 20
+      vertex 50.4426 23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 50.2502 7.45391 20
+      vertex 50.5554 4.97927 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 49.8239 9.91059 20
+      vertex 50.2502 7.45391 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.1277 13.5583 20
+      vertex 49.2776 12.3434 20
+      vertex 49.8239 9.91059 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.9227 21.7198 20
+      vertex 50.4426 23.8576 20
+      vertex 49.2112 26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 53.3973 16.1979 20
+      vertex 48.6126 14.7465 20
+      vertex 49.2776 12.3434 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 44.8016 23.947 20
+      vertex 49.2112 26.3039 20
+      vertex 47.8613 28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 52.5382 18.7985 20
+      vertex 47.8304 17.114 20
+      vertex 48.6126 14.7465 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.5525 21.3537 20
+      vertex 46.9331 19.4403 20
+      vertex 47.8304 17.114 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.5726 26.1164 20
+      vertex 47.8613 28.6869 20
+      vertex 46.396 31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 50.4426 23.8576 20
+      vertex 45.9227 21.7198 20
+      vertex 46.9331 19.4403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.2387 28.223 20
+      vertex 46.396 31.0008 20
+      vertex 44.819 33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.2112 26.3039 20
+      vertex 44.8016 23.947 20
+      vertex 45.9227 21.7198 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 47.8613 28.6869 20
+      vertex 43.5726 26.1164 20
+      vertex 44.8016 23.947 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.8029 30.2615 20
+      vertex 44.819 33.24 20
+      vertex 43.134 35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 46.396 31.0008 20
+      vertex 42.2387 28.223 20
+      vertex 43.5726 26.1164 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.2689 32.2272 20
+      vertex 43.134 35.3991 20
+      vertex 41.3451 37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 44.819 33.24 20
+      vertex 40.8029 30.2615 20
+      vertex 42.2387 28.223 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 37.6403 34.1152 20
+      vertex 41.3451 37.473 20
+      vertex 39.4566 39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.134 35.3991 20
+      vertex 39.2689 32.2272 20
+      vertex 40.8029 30.2615 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.3451 37.473 20
+      vertex 37.6403 34.1152 20
+      vertex 39.2689 32.2272 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.921 35.921 20
+      vertex 39.4566 39.4566 20
+      vertex 37.473 41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.4566 39.4566 20
+      vertex 35.921 35.921 20
+      vertex 37.6403 34.1152 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.1152 37.6403 20
+      vertex 37.473 41.3451 20
+      vertex 35.3991 43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 37.473 41.3451 20
+      vertex 34.1152 37.6403 20
+      vertex 35.921 35.921 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 32.2272 39.2689 20
+      vertex 35.3991 43.134 20
+      vertex 33.24 44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.3991 43.134 20
+      vertex 32.2272 39.2689 20
+      vertex 34.1152 37.6403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.2615 40.8029 20
+      vertex 33.24 44.819 20
+      vertex 31.0008 46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.24 44.819 20
+      vertex 30.2615 40.8029 20
+      vertex 32.2272 39.2689 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.223 42.2387 20
+      vertex 31.0008 46.396 20
+      vertex 28.6869 47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.0008 46.396 20
+      vertex 28.223 42.2387 20
+      vertex 30.2615 40.8029 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.1164 43.5726 20
+      vertex 28.6869 47.8613 20
+      vertex 26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.6869 47.8613 20
+      vertex 26.1164 43.5726 20
+      vertex 28.223 42.2387 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.3039 49.2112 20
+      vertex 23.947 44.8016 20
+      vertex 26.1164 43.5726 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.8576 50.4426 20
+      vertex 23.947 44.8016 20
+      vertex 26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.7198 45.9227 20
+      vertex 23.8576 50.4426 20
+      vertex 23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.8576 50.4426 20
+      vertex 21.7198 45.9227 20
+      vertex 23.947 44.8016 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.5267 50.8 20
+      vertex 21.7198 45.9227 20
+      vertex 23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5267 50.8 20
+      vertex 19.4403 46.9331 20
+      vertex 21.7198 45.9227 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.114 47.8304 20
+      vertex 20.5267 50.8 20
+      vertex 18.4616 51.5966 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5267 50.8 20
+      vertex 17.114 47.8304 20
+      vertex 19.4403 46.9331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.9076 52.4403 20
+      vertex 17.114 47.8304 20
+      vertex 18.4616 51.5966 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.9076 52.4403 20
+      vertex 14.7465 48.6126 20
+      vertex 17.114 47.8304 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.3153 53.1577 20
+      vertex 14.7465 48.6126 20
+      vertex 15.9076 52.4403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.3153 53.1577 20
+      vertex 12.3434 49.2776 20
+      vertex 14.7465 48.6126 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6909 53.747 20
+      vertex 12.3434 49.2776 20
+      vertex 13.3153 53.1577 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6909 53.747 20
+      vertex 9.91059 49.8239 20
+      vertex 12.3434 49.2776 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.04083 54.2069 20
+      vertex 9.91059 49.8239 20
+      vertex 10.6909 53.747 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.04083 54.2069 20
+      vertex 7.45391 50.2502 20
+      vertex 9.91059 49.8239 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.37134 54.5361 20
+      vertex 7.45391 50.2502 20
+      vertex 8.04083 54.2069 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.37134 54.5361 20
+      vertex 4.97927 50.5554 20
+      vertex 7.45391 50.2502 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.68891 54.734 20
+      vertex 4.97927 50.5554 20
+      vertex 5.37134 54.5361 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.68891 54.734 20
+      vertex 2.49264 50.7388 20
+      vertex 4.97927 50.5554 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 54.8 20
+      vertex 2.49264 50.7388 20
+      vertex 2.68891 54.734 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 54.8 20
+      vertex 0 50.8 20
+      vertex 2.49264 50.7388 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 54.8 20
+      vertex -2.49264 50.7388 20
+      vertex 0 50.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.68891 54.734 20
+      vertex -2.49264 50.7388 20
+      vertex 0 54.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.68891 54.734 20
+      vertex -4.97927 50.5554 20
+      vertex -2.49264 50.7388 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.37134 54.5361 20
+      vertex -4.97927 50.5554 20
+      vertex -2.68891 54.734 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.37134 54.5361 20
+      vertex -7.45391 50.2502 20
+      vertex -4.97927 50.5554 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8.04083 54.2069 20
+      vertex -7.45391 50.2502 20
+      vertex -5.37134 54.5361 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.04083 54.2069 20
+      vertex -9.91059 49.8239 20
+      vertex -7.45391 50.2502 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.6909 53.747 20
+      vertex -9.91059 49.8239 20
+      vertex -8.04083 54.2069 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.6909 53.747 20
+      vertex -12.3434 49.2776 20
+      vertex -9.91059 49.8239 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.3153 53.1577 20
+      vertex -12.3434 49.2776 20
+      vertex -10.6909 53.747 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.3153 53.1577 20
+      vertex -14.7465 48.6126 20
+      vertex -12.3434 49.2776 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.9076 52.4403 20
+      vertex -14.7465 48.6126 20
+      vertex -13.3153 53.1577 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.9076 52.4403 20
+      vertex -17.114 47.8304 20
+      vertex -14.7465 48.6126 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.4616 51.5966 20
+      vertex -17.114 47.8304 20
+      vertex -15.9076 52.4403 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.5267 50.8 20
+      vertex -17.114 47.8304 20
+      vertex -18.4616 51.5966 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.114 47.8304 20
+      vertex -20.5267 50.8 20
+      vertex -19.4403 46.9331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5267 50.8 20
+      vertex -21.7198 45.9227 20
+      vertex -19.4403 46.9331 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.0513 50.8 20
+      vertex -21.7198 45.9227 20
+      vertex -20.5267 50.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.8576 50.4426 20
+      vertex -21.7198 45.9227 20
+      vertex -23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.8576 50.4426 20
+      vertex -23.947 44.8016 20
+      vertex -21.7198 45.9227 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.3039 49.2112 20
+      vertex -23.947 44.8016 20
+      vertex -23.8576 50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.947 44.8016 20
+      vertex -26.3039 49.2112 20
+      vertex -26.1164 43.5726 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.6869 47.8613 20
+      vertex -26.1164 43.5726 20
+      vertex -26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1164 43.5726 20
+      vertex -28.6869 47.8613 20
+      vertex -28.223 42.2387 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.0008 46.396 20
+      vertex -28.223 42.2387 20
+      vertex -28.6869 47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.223 42.2387 20
+      vertex -31.0008 46.396 20
+      vertex -30.2615 40.8029 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -33.24 44.819 20
+      vertex -30.2615 40.8029 20
+      vertex -31.0008 46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.2615 40.8029 20
+      vertex -33.24 44.819 20
+      vertex -32.2272 39.2689 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.3991 43.134 20
+      vertex -32.2272 39.2689 20
+      vertex -33.24 44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -32.2272 39.2689 20
+      vertex -35.3991 43.134 20
+      vertex -34.1152 37.6403 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -37.473 41.3451 20
+      vertex -34.1152 37.6403 20
+      vertex -35.3991 43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.1152 37.6403 20
+      vertex -37.473 41.3451 20
+      vertex -35.921 35.921 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -39.4566 39.4566 20
+      vertex -35.921 35.921 20
+      vertex -37.473 41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.921 35.921 20
+      vertex -39.4566 39.4566 20
+      vertex -37.6403 34.1152 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -41.3451 37.473 20
+      vertex -37.6403 34.1152 20
+      vertex -39.4566 39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.6403 34.1152 20
+      vertex -41.3451 37.473 20
+      vertex -39.2689 32.2272 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -43.134 35.3991 20
+      vertex -39.2689 32.2272 20
+      vertex -41.3451 37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -39.2689 32.2272 20
+      vertex -43.134 35.3991 20
+      vertex -40.8029 30.2615 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -44.819 33.24 20
+      vertex -40.8029 30.2615 20
+      vertex -43.134 35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -40.8029 30.2615 20
+      vertex -44.819 33.24 20
+      vertex -42.2387 28.223 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -46.396 31.0008 20
+      vertex -42.2387 28.223 20
+      vertex -44.819 33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -42.2387 28.223 20
+      vertex -46.396 31.0008 20
+      vertex -43.5726 26.1164 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -47.8613 28.6869 20
+      vertex -43.5726 26.1164 20
+      vertex -46.396 31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.5726 26.1164 20
+      vertex -47.8613 28.6869 20
+      vertex -44.8016 23.947 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -49.2112 26.3039 20
+      vertex -44.8016 23.947 20
+      vertex -47.8613 28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.8016 23.947 20
+      vertex -49.2112 26.3039 20
+      vertex -45.9227 21.7198 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -50.4426 23.8576 20
+      vertex -45.9227 21.7198 20
+      vertex -49.2112 26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -45.9227 21.7198 20
+      vertex -50.4426 23.8576 20
+      vertex -46.9331 19.4403 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -51.5525 21.3537 20
+      vertex -46.9331 19.4403 20
+      vertex -50.4426 23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.9331 19.4403 20
+      vertex -51.5525 21.3537 20
+      vertex -47.8304 17.114 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -52.5382 18.7985 20
+      vertex -47.8304 17.114 20
+      vertex -51.5525 21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.8304 17.114 20
+      vertex -52.5382 18.7985 20
+      vertex -48.6126 14.7465 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -53.3973 16.1979 20
+      vertex -48.6126 14.7465 20
+      vertex -52.5382 18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.6126 14.7465 20
+      vertex -53.3973 16.1979 20
+      vertex -49.2776 12.3434 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -54.1277 13.5583 20
+      vertex -49.2776 12.3434 20
+      vertex -53.3973 16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.2776 12.3434 20
+      vertex -54.1277 13.5583 20
+      vertex -49.8239 9.91059 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -54.7278 10.886 20
+      vertex -49.8239 9.91059 20
+      vertex -54.1277 13.5583 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.7278 -10.886 20
+      vertex 49.8239 -9.91059 20
+      vertex 54.1277 -13.5583 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 49.2776 -12.3434 20
+      vertex 54.1277 -13.5583 20
+      vertex 49.8239 -9.91059 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.1277 -13.5583 20
+      vertex 49.2776 -12.3434 20
+      vertex 53.3973 -16.1979 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 48.6126 -14.7465 20
+      vertex 53.3973 -16.1979 20
+      vertex 49.2776 -12.3434 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 53.3973 -16.1979 20
+      vertex 48.6126 -14.7465 20
+      vertex 52.5382 -18.7985 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 47.8304 -17.114 20
+      vertex 52.5382 -18.7985 20
+      vertex 48.6126 -14.7465 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 52.5382 -18.7985 20
+      vertex 47.8304 -17.114 20
+      vertex 51.5525 -21.3537 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 46.9331 -19.4403 20
+      vertex 51.5525 -21.3537 20
+      vertex 47.8304 -17.114 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.5525 -21.3537 20
+      vertex 46.9331 -19.4403 20
+      vertex 50.4426 -23.8576 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 45.9227 -21.7198 20
+      vertex 50.4426 -23.8576 20
+      vertex 46.9331 -19.4403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 50.4426 -23.8576 20
+      vertex 45.9227 -21.7198 20
+      vertex 49.2112 -26.3039 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 44.8016 -23.947 20
+      vertex 49.2112 -26.3039 20
+      vertex 45.9227 -21.7198 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.2112 -26.3039 20
+      vertex 44.8016 -23.947 20
+      vertex 47.8613 -28.6869 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 43.5726 -26.1164 20
+      vertex 47.8613 -28.6869 20
+      vertex 44.8016 -23.947 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 47.8613 -28.6869 20
+      vertex 43.5726 -26.1164 20
+      vertex 46.396 -31.0008 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.2387 -28.223 20
+      vertex 46.396 -31.0008 20
+      vertex 43.5726 -26.1164 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 46.396 -31.0008 20
+      vertex 42.2387 -28.223 20
+      vertex 44.819 -33.24 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 40.8029 -30.2615 20
+      vertex 44.819 -33.24 20
+      vertex 42.2387 -28.223 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 44.819 -33.24 20
+      vertex 40.8029 -30.2615 20
+      vertex 43.134 -35.3991 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 39.2689 -32.2272 20
+      vertex 43.134 -35.3991 20
+      vertex 40.8029 -30.2615 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.134 -35.3991 20
+      vertex 39.2689 -32.2272 20
+      vertex 41.3451 -37.473 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 37.6403 -34.1152 20
+      vertex 41.3451 -37.473 20
+      vertex 39.2689 -32.2272 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.3451 -37.473 20
+      vertex 37.6403 -34.1152 20
+      vertex 39.4566 -39.4566 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35.921 -35.921 20
+      vertex 39.4566 -39.4566 20
+      vertex 37.6403 -34.1152 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.4566 -39.4566 20
+      vertex 35.921 -35.921 20
+      vertex 37.473 -41.3451 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 34.1152 -37.6403 20
+      vertex 37.473 -41.3451 20
+      vertex 35.921 -35.921 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 37.473 -41.3451 20
+      vertex 34.1152 -37.6403 20
+      vertex 35.3991 -43.134 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 32.2272 -39.2689 20
+      vertex 35.3991 -43.134 20
+      vertex 34.1152 -37.6403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.3991 -43.134 20
+      vertex 32.2272 -39.2689 20
+      vertex 33.24 -44.819 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 30.2615 -40.8029 20
+      vertex 33.24 -44.819 20
+      vertex 32.2272 -39.2689 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.24 -44.819 20
+      vertex 30.2615 -40.8029 20
+      vertex 31.0008 -46.396 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 28.223 -42.2387 20
+      vertex 31.0008 -46.396 20
+      vertex 30.2615 -40.8029 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.0008 -46.396 20
+      vertex 28.223 -42.2387 20
+      vertex 28.6869 -47.8613 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.1164 -43.5726 20
+      vertex 28.6869 -47.8613 20
+      vertex 28.223 -42.2387 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.6869 -47.8613 20
+      vertex 26.1164 -43.5726 20
+      vertex 26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.947 -44.8016 20
+      vertex 26.3039 -49.2112 20
+      vertex 26.1164 -43.5726 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.947 -44.8016 20
+      vertex 23.8576 -50.4426 20
+      vertex 26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.7198 -45.9227 20
+      vertex 23.8576 -50.4426 20
+      vertex 23.947 -44.8016 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.8576 -50.4426 20
+      vertex 21.7198 -45.9227 20
+      vertex 23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 21.7198 -45.9227 20
+      vertex 20.5267 -50.8 20
+      vertex 23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.4403 -46.9331 20
+      vertex 20.5267 -50.8 20
+      vertex 21.7198 -45.9227 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.114 -47.8304 20
+      vertex 20.5267 -50.8 20
+      vertex 19.4403 -46.9331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.5267 -50.8 20
+      vertex 17.114 -47.8304 20
+      vertex 18.4616 -51.5966 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.114 -47.8304 20
+      vertex 15.9076 -52.4403 20
+      vertex 18.4616 -51.5966 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.7465 -48.6126 20
+      vertex 15.9076 -52.4403 20
+      vertex 17.114 -47.8304 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.7465 -48.6126 20
+      vertex 13.3153 -53.1577 20
+      vertex 15.9076 -52.4403 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.3434 -49.2776 20
+      vertex 13.3153 -53.1577 20
+      vertex 14.7465 -48.6126 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.3434 -49.2776 20
+      vertex 10.6909 -53.747 20
+      vertex 13.3153 -53.1577 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.91059 -49.8239 20
+      vertex 10.6909 -53.747 20
+      vertex 12.3434 -49.2776 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.91059 -49.8239 20
+      vertex 8.04083 -54.2069 20
+      vertex 10.6909 -53.747 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.45391 -50.2502 20
+      vertex 8.04083 -54.2069 20
+      vertex 9.91059 -49.8239 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.45391 -50.2502 20
+      vertex 5.37134 -54.5361 20
+      vertex 8.04083 -54.2069 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.97927 -50.5554 20
+      vertex 5.37134 -54.5361 20
+      vertex 7.45391 -50.2502 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.97927 -50.5554 20
+      vertex 2.68891 -54.734 20
+      vertex 5.37134 -54.5361 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.49264 -50.7388 20
+      vertex 2.68891 -54.734 20
+      vertex 4.97927 -50.5554 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -50.8 20
+      vertex 2.68891 -54.734 20
+      vertex 2.49264 -50.7388 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -50.8 20
+      vertex 0 -54.8 20
+      vertex 2.68891 -54.734 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.49264 -50.7388 20
+      vertex 0 -54.8 20
+      vertex 0 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.49264 -50.7388 20
+      vertex -2.68891 -54.734 20
+      vertex 0 -54.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.97927 -50.5554 20
+      vertex -2.68891 -54.734 20
+      vertex -2.49264 -50.7388 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.97927 -50.5554 20
+      vertex -5.37134 -54.5361 20
+      vertex -2.68891 -54.734 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.45391 -50.2502 20
+      vertex -5.37134 -54.5361 20
+      vertex -4.97927 -50.5554 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.45391 -50.2502 20
+      vertex -8.04083 -54.2069 20
+      vertex -5.37134 -54.5361 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.91059 -49.8239 20
+      vertex -8.04083 -54.2069 20
+      vertex -7.45391 -50.2502 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.91059 -49.8239 20
+      vertex -10.6909 -53.747 20
+      vertex -8.04083 -54.2069 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3434 -49.2776 20
+      vertex -10.6909 -53.747 20
+      vertex -9.91059 -49.8239 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.3434 -49.2776 20
+      vertex -13.3153 -53.1577 20
+      vertex -10.6909 -53.747 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.7465 -48.6126 20
+      vertex -13.3153 -53.1577 20
+      vertex -12.3434 -49.2776 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.7465 -48.6126 20
+      vertex -15.9076 -52.4403 20
+      vertex -13.3153 -53.1577 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.114 -47.8304 20
+      vertex -15.9076 -52.4403 20
+      vertex -14.7465 -48.6126 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.114 -47.8304 20
+      vertex -18.4616 -51.5966 20
+      vertex -15.9076 -52.4403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5267 -50.8 20
+      vertex -17.114 -47.8304 20
+      vertex -19.4403 -46.9331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.114 -47.8304 20
+      vertex -20.5267 -50.8 20
+      vertex -18.4616 -51.5966 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7198 -45.9227 20
+      vertex -20.5267 -50.8 20
+      vertex -19.4403 -46.9331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7198 -45.9227 20
+      vertex -23.0513 -50.8 20
+      vertex -20.5267 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7198 -45.9227 20
+      vertex -23.8576 -50.4426 20
+      vertex -23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.947 -44.8016 20
+      vertex -23.8576 -50.4426 20
+      vertex -21.7198 -45.9227 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.3039 -49.2112 20
+      vertex -23.947 -44.8016 20
+      vertex -26.1164 -43.5726 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.947 -44.8016 20
+      vertex -26.3039 -49.2112 20
+      vertex -23.8576 -50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.6869 -47.8613 20
+      vertex -26.1164 -43.5726 20
+      vertex -28.223 -42.2387 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1164 -43.5726 20
+      vertex -28.6869 -47.8613 20
+      vertex -26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.0008 -46.396 20
+      vertex -28.223 -42.2387 20
+      vertex -30.2615 -40.8029 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.223 -42.2387 20
+      vertex -31.0008 -46.396 20
+      vertex -28.6869 -47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.24 -44.819 20
+      vertex -30.2615 -40.8029 20
+      vertex -32.2272 -39.2689 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.2615 -40.8029 20
+      vertex -33.24 -44.819 20
+      vertex -31.0008 -46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.3991 -43.134 20
+      vertex -32.2272 -39.2689 20
+      vertex -34.1152 -37.6403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -32.2272 -39.2689 20
+      vertex -35.3991 -43.134 20
+      vertex -33.24 -44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.473 -41.3451 20
+      vertex -34.1152 -37.6403 20
+      vertex -35.921 -35.921 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.1152 -37.6403 20
+      vertex -37.473 -41.3451 20
+      vertex -35.3991 -43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -39.4566 -39.4566 20
+      vertex -35.921 -35.921 20
+      vertex -37.6403 -34.1152 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.3451 -37.473 20
+      vertex -37.6403 -34.1152 20
+      vertex -39.2689 -32.2272 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.921 -35.921 20
+      vertex -39.4566 -39.4566 20
+      vertex -37.473 -41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.134 -35.3991 20
+      vertex -39.2689 -32.2272 20
+      vertex -40.8029 -30.2615 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.6403 -34.1152 20
+      vertex -41.3451 -37.473 20
+      vertex -39.4566 -39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.819 -33.24 20
+      vertex -40.8029 -30.2615 20
+      vertex -42.2387 -28.223 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -39.2689 -32.2272 20
+      vertex -43.134 -35.3991 20
+      vertex -41.3451 -37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.396 -31.0008 20
+      vertex -42.2387 -28.223 20
+      vertex -43.5726 -26.1164 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.8613 -28.6869 20
+      vertex -43.5726 -26.1164 20
+      vertex -44.8016 -23.947 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -40.8029 -30.2615 20
+      vertex -44.819 -33.24 20
+      vertex -43.134 -35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.2112 -26.3039 20
+      vertex -44.8016 -23.947 20
+      vertex -45.9227 -21.7198 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -42.2387 -28.223 20
+      vertex -46.396 -31.0008 20
+      vertex -44.819 -33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.4426 -23.8576 20
+      vertex -45.9227 -21.7198 20
+      vertex -46.9331 -19.4403 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -51.5525 -21.3537 20
+      vertex -46.9331 -19.4403 20
+      vertex -47.8304 -17.114 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.5726 -26.1164 20
+      vertex -47.8613 -28.6869 20
+      vertex -46.396 -31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -52.5382 -18.7985 20
+      vertex -47.8304 -17.114 20
+      vertex -48.6126 -14.7465 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.8016 -23.947 20
+      vertex -49.2112 -26.3039 20
+      vertex -47.8613 -28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -53.3973 -16.1979 20
+      vertex -48.6126 -14.7465 20
+      vertex -49.2776 -12.3434 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.1277 -13.5583 20
+      vertex -49.2776 -12.3434 20
+      vertex -49.8239 -9.91059 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -49.8239 -9.91059 20
+      vertex -50.2502 -7.45391 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -45.9227 -21.7198 20
+      vertex -50.4426 -23.8576 20
+      vertex -49.2112 -26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -50.2502 -7.45391 20
+      vertex -50.5554 -4.97927 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -50.5554 -4.97927 20
+      vertex -50.7388 -2.49264 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -50.7388 -2.49264 20
+      vertex -50.8 0 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -54.8 10.4701 20
+      vertex -49.8239 9.91059 20
+      vertex -54.7278 10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.9331 -19.4403 20
+      vertex -51.5525 -21.3537 20
+      vertex -50.4426 -23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.8239 9.91059 20
+      vertex -54.8 10.4701 20
+      vertex -50.2502 7.45391 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.8304 -17.114 20
+      vertex -52.5382 -18.7985 20
+      vertex -51.5525 -21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.2502 7.45391 20
+      vertex -54.8 10.4701 20
+      vertex -50.5554 4.97927 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.6126 -14.7465 20
+      vertex -53.3973 -16.1979 20
+      vertex -52.5382 -18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.5554 4.97927 20
+      vertex -54.8 10.4701 20
+      vertex -50.7388 2.49264 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.2776 -12.3434 20
+      vertex -54.1277 -13.5583 20
+      vertex -53.3973 -16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.7388 2.49264 20
+      vertex -54.8 10.4701 20
+      vertex -50.8 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -50.8 0 20
+      vertex -54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.8239 -9.91059 20
+      vertex -54.8 -10.4701 20
+      vertex -54.7278 -10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.8239 -9.91059 20
+      vertex -54.7278 -10.886 20
+      vertex -54.1277 -13.5583 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -54.8 10.4701 20
+      vertex -54.8 50.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -54.8 -10.4701 20
+      vertex -54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -54.8 -10.4701 20
+      vertex -54.8 50.8 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -54.8 -50.8 0
+      vertex -54.8 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -20.5267 50.8 0
+      vertex -23.0513 50.8 20
+      vertex -20.5267 50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -23.0513 50.8 20
+      vertex -20.5267 50.8 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -23.0513 50.8 20
+      vertex -54.8 50.8 0
+      vertex -54.8 50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 54.8 50.8 0
+      vertex 23.0513 50.8 20
+      vertex 54.8 50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 23.0513 50.8 20
+      vertex 54.8 50.8 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 23.0513 50.8 20
+      vertex 20.5267 50.8 0
+      vertex 20.5267 50.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -23.0513 -50.8 20
+      vertex -54.8 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -23.0513 -50.8 20
+      vertex -54.8 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -23.0513 -50.8 20
+      vertex -20.5267 -50.8 0
+      vertex -20.5267 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 23.0513 -50.8 20
+      vertex 20.5267 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 23.0513 -50.8 20
+      vertex 20.5267 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 23.0513 -50.8 20
+      vertex 54.8 -50.8 0
+      vertex 54.8 -50.8 20
+    endloop
+  endfacet
+  facet normal -0.997291 -0.0735547 0
+    outer loop
+      vertex 50.7388 2.49264 0
+      vertex 50.5554 4.97927 20
+      vertex 50.5554 4.97927 0
+    endloop
+  endfacet
+  facet normal -0.997291 -0.0735547 0
+    outer loop
+      vertex 50.5554 4.97927 20
+      vertex 50.7388 2.49264 0
+      vertex 50.7388 2.49264 20
+    endloop
+  endfacet
+  facet normal -0.999699 -0.0245449 0
+    outer loop
+      vertex 50.8 0 0
+      vertex 50.7388 2.49264 20
+      vertex 50.7388 2.49264 0
+    endloop
+  endfacet
+  facet normal -0.999699 -0.0245449 0
+    outer loop
+      vertex 50.7388 2.49264 20
+      vertex 50.8 0 0
+      vertex 50.8 0 20
+    endloop
+  endfacet
+  facet normal -0.99248 -0.122404 0
+    outer loop
+      vertex 50.5554 4.97927 0
+      vertex 50.2502 7.45391 20
+      vertex 50.2502 7.45391 0
+    endloop
+  endfacet
+  facet normal -0.99248 -0.122404 0
+    outer loop
+      vertex 50.2502 7.45391 20
+      vertex 50.5554 4.97927 0
+      vertex 50.5554 4.97927 20
+    endloop
+  endfacet
+  facet normal 0.170972 0.985276 -0
+    outer loop
+      vertex -7.45391 -50.2502 0
+      vertex -9.91059 -49.8239 20
+      vertex -7.45391 -50.2502 20
+    endloop
+  endfacet
+  facet normal 0.170972 0.985276 0
+    outer loop
+      vertex -9.91059 -49.8239 20
+      vertex -7.45391 -50.2502 0
+      vertex -9.91059 -49.8239 0
+    endloop
+  endfacet
+  facet normal 0.359877 0.933 -0
+    outer loop
+      vertex -17.114 -47.8304 0
+      vertex -19.4403 -46.9331 20
+      vertex -17.114 -47.8304 20
+    endloop
+  endfacet
+  facet normal 0.359877 0.933 0
+    outer loop
+      vertex -19.4403 -46.9331 20
+      vertex -17.114 -47.8304 0
+      vertex -19.4403 -46.9331 0
+    endloop
+  endfacet
+  facet normal -0.893221 0.449618 0
+    outer loop
+      vertex 44.8016 -23.947 0
+      vertex 45.9227 -21.7198 20
+      vertex 45.9227 -21.7198 0
+    endloop
+  endfacet
+  facet normal -0.893221 0.449618 0
+    outer loop
+      vertex 45.9227 -21.7198 20
+      vertex 44.8016 -23.947 0
+      vertex 44.8016 -23.947 20
+    endloop
+  endfacet
+  facet normal 0.0245449 0.999699 -0
+    outer loop
+      vertex 0 -50.8 0
+      vertex -2.49264 -50.7388 20
+      vertex 0 -50.8 20
+    endloop
+  endfacet
+  facet normal 0.0245449 0.999699 0
+    outer loop
+      vertex -2.49264 -50.7388 20
+      vertex 0 -50.8 0
+      vertex -2.49264 -50.7388 0
+    endloop
+  endfacet
+  facet normal 0.933 -0.359877 0
+    outer loop
+      vertex -47.8304 17.114 20
+      vertex -46.9331 19.4403 0
+      vertex -46.9331 19.4403 20
+    endloop
+  endfacet
+  facet normal 0.933 -0.359877 0
+    outer loop
+      vertex -46.9331 19.4403 0
+      vertex -47.8304 17.114 20
+      vertex -47.8304 17.114 0
+    endloop
+  endfacet
+  facet normal 0.359877 -0.933 0
+    outer loop
+      vertex -19.4403 46.9331 0
+      vertex -17.114 47.8304 20
+      vertex -19.4403 46.9331 20
+    endloop
+  endfacet
+  facet normal 0.359877 -0.933 0
+    outer loop
+      vertex -17.114 47.8304 20
+      vertex -19.4403 46.9331 0
+      vertex -17.114 47.8304 0
+    endloop
+  endfacet
+  facet normal 0.170972 -0.985276 0
+    outer loop
+      vertex -9.91059 49.8239 0
+      vertex -7.45391 50.2502 20
+      vertex -9.91059 49.8239 20
+    endloop
+  endfacet
+  facet normal 0.170972 -0.985276 0
+    outer loop
+      vertex -7.45391 50.2502 20
+      vertex -9.91059 49.8239 0
+      vertex -7.45391 50.2502 0
+    endloop
+  endfacet
+  facet normal -0.817561 -0.575842 0
+    outer loop
+      vertex 42.2387 28.223 0
+      vertex 40.8029 30.2615 20
+      vertex 40.8029 30.2615 0
+    endloop
+  endfacet
+  facet normal -0.817561 -0.575842 0
+    outer loop
+      vertex 40.8029 30.2615 20
+      vertex 42.2387 28.223 0
+      vertex 42.2387 28.223 20
+    endloop
+  endfacet
+  facet normal 0.949518 0.313712 0
+    outer loop
+      vertex -47.8304 -17.114 20
+      vertex -48.6126 -14.7465 0
+      vertex -48.6126 -14.7465 20
+    endloop
+  endfacet
+  facet normal 0.949518 0.313712 0
+    outer loop
+      vertex -48.6126 -14.7465 0
+      vertex -47.8304 -17.114 20
+      vertex -47.8304 -17.114 0
+    endloop
+  endfacet
+  facet normal 0.575842 -0.817561 0
+    outer loop
+      vertex -30.2615 40.8029 0
+      vertex -28.223 42.2387 20
+      vertex -30.2615 40.8029 20
+    endloop
+  endfacet
+  facet normal 0.575842 -0.817561 0
+    outer loop
+      vertex -28.223 42.2387 20
+      vertex -30.2615 40.8029 0
+      vertex -28.223 42.2387 0
+    endloop
+  endfacet
+  facet normal -0.266703 0.963779 0
+    outer loop
+      vertex 14.7465 -48.6126 0
+      vertex 12.3434 -49.2776 20
+      vertex 14.7465 -48.6126 20
+    endloop
+  endfacet
+  facet normal -0.266703 0.963779 0
+    outer loop
+      vertex 12.3434 -49.2776 20
+      vertex 14.7465 -48.6126 0
+      vertex 12.3434 -49.2776 0
+    endloop
+  endfacet
+  facet normal 0.122404 -0.99248 0
+    outer loop
+      vertex -7.45391 50.2502 0
+      vertex -4.97927 50.5554 20
+      vertex -7.45391 50.2502 20
+    endloop
+  endfacet
+  facet normal 0.122404 -0.99248 0
+    outer loop
+      vertex -4.97927 50.5554 20
+      vertex -7.45391 50.2502 0
+      vertex -4.97927 50.5554 0
+    endloop
+  endfacet
+  facet normal -0.788356 0.61522 0
+    outer loop
+      vertex 39.2689 -32.2272 0
+      vertex 40.8029 -30.2615 20
+      vertex 40.8029 -30.2615 0
+    endloop
+  endfacet
+  facet normal -0.788356 0.61522 0
+    outer loop
+      vertex 40.8029 -30.2615 20
+      vertex 39.2689 -32.2272 0
+      vertex 39.2689 -32.2272 20
+    endloop
+  endfacet
+  facet normal 0.492913 0.870078 -0
+    outer loop
+      vertex -23.947 -44.8016 0
+      vertex -26.1164 -43.5726 20
+      vertex -23.947 -44.8016 20
+    endloop
+  endfacet
+  facet normal 0.492913 0.870078 0
+    outer loop
+      vertex -26.1164 -43.5726 20
+      vertex -23.947 -44.8016 0
+      vertex -26.1164 -43.5726 0
+    endloop
+  endfacet
+  facet normal 0.0735547 -0.997291 0
+    outer loop
+      vertex -4.97927 50.5554 0
+      vertex -2.49264 50.7388 20
+      vertex -4.97927 50.5554 20
+    endloop
+  endfacet
+  facet normal 0.0735547 -0.997291 0
+    outer loop
+      vertex -2.49264 50.7388 20
+      vertex -4.97927 50.5554 0
+      vertex -2.49264 50.7388 0
+    endloop
+  endfacet
+  facet normal -0.122404 -0.99248 0
+    outer loop
+      vertex 4.97927 50.5554 0
+      vertex 7.45391 50.2502 20
+      vertex 4.97927 50.5554 20
+    endloop
+  endfacet
+  facet normal -0.122404 -0.99248 -0
+    outer loop
+      vertex 7.45391 50.2502 20
+      vertex 4.97927 50.5554 0
+      vertex 7.45391 50.2502 0
+    endloop
+  endfacet
+  facet normal -0.0735547 0.997291 0
+    outer loop
+      vertex 4.97927 -50.5554 0
+      vertex 2.49264 -50.7388 20
+      vertex 4.97927 -50.5554 20
+    endloop
+  endfacet
+  facet normal -0.0735547 0.997291 0
+    outer loop
+      vertex 2.49264 -50.7388 20
+      vertex 4.97927 -50.5554 0
+      vertex 2.49264 -50.7388 0
+    endloop
+  endfacet
+  facet normal 0.757209 0.653173 0
+    outer loop
+      vertex -37.6403 -34.1152 20
+      vertex -39.2689 -32.2272 0
+      vertex -39.2689 -32.2272 20
+    endloop
+  endfacet
+  facet normal 0.757209 0.653173 0
+    outer loop
+      vertex -39.2689 -32.2272 0
+      vertex -37.6403 -34.1152 20
+      vertex -37.6403 -34.1152 0
+    endloop
+  endfacet
+  facet normal -0.575842 0.817561 0
+    outer loop
+      vertex 30.2615 -40.8029 0
+      vertex 28.223 -42.2387 20
+      vertex 30.2615 -40.8029 20
+    endloop
+  endfacet
+  facet normal -0.575842 0.817561 0
+    outer loop
+      vertex 28.223 -42.2387 20
+      vertex 30.2615 -40.8029 0
+      vertex 28.223 -42.2387 0
+    endloop
+  endfacet
+  facet normal -0.61522 -0.788356 0
+    outer loop
+      vertex 30.2615 40.8029 0
+      vertex 32.2272 39.2689 20
+      vertex 30.2615 40.8029 20
+    endloop
+  endfacet
+  facet normal -0.61522 -0.788356 -0
+    outer loop
+      vertex 32.2272 39.2689 20
+      vertex 30.2615 40.8029 0
+      vertex 32.2272 39.2689 0
+    endloop
+  endfacet
+  facet normal -0.575842 -0.817561 0
+    outer loop
+      vertex 28.223 42.2387 0
+      vertex 30.2615 40.8029 20
+      vertex 28.223 42.2387 20
+    endloop
+  endfacet
+  facet normal -0.575842 -0.817561 -0
+    outer loop
+      vertex 30.2615 40.8029 20
+      vertex 28.223 42.2387 0
+      vertex 30.2615 40.8029 0
+    endloop
+  endfacet
+  facet normal 0.997291 0.0735547 0
+    outer loop
+      vertex -50.5554 -4.97927 20
+      vertex -50.7388 -2.49264 0
+      vertex -50.7388 -2.49264 20
+    endloop
+  endfacet
+  facet normal 0.997291 0.0735547 0
+    outer loop
+      vertex -50.7388 -2.49264 0
+      vertex -50.5554 -4.97927 20
+      vertex -50.5554 -4.97927 0
+    endloop
+  endfacet
+  facet normal 0.61522 -0.788356 0
+    outer loop
+      vertex -32.2272 39.2689 0
+      vertex -30.2615 40.8029 20
+      vertex -32.2272 39.2689 20
+    endloop
+  endfacet
+  facet normal 0.61522 -0.788356 0
+    outer loop
+      vertex -30.2615 40.8029 20
+      vertex -32.2272 39.2689 0
+      vertex -30.2615 40.8029 0
+    endloop
+  endfacet
+  facet normal 0.0245449 -0.999699 0
+    outer loop
+      vertex -2.49264 50.7388 0
+      vertex 0 50.8 20
+      vertex -2.49264 50.7388 20
+    endloop
+  endfacet
+  facet normal 0.0245449 -0.999699 0
+    outer loop
+      vertex 0 50.8 20
+      vertex -2.49264 50.7388 0
+      vertex 0 50.8 0
+    endloop
+  endfacet
+  facet normal 0.534972 0.84487 -0
+    outer loop
+      vertex -26.1164 -43.5726 0
+      vertex -28.223 -42.2387 20
+      vertex -26.1164 -43.5726 20
+    endloop
+  endfacet
+  facet normal 0.534972 0.84487 0
+    outer loop
+      vertex -28.223 -42.2387 20
+      vertex -26.1164 -43.5726 0
+      vertex -28.223 -42.2387 0
+    endloop
+  endfacet
+  facet normal 0.985276 0.170972 0
+    outer loop
+      vertex -49.8239 -9.91059 20
+      vertex -50.2502 -7.45391 0
+      vertex -50.2502 -7.45391 20
+    endloop
+  endfacet
+  facet normal 0.985276 0.170972 0
+    outer loop
+      vertex -50.2502 -7.45391 0
+      vertex -49.8239 -9.91059 20
+      vertex -49.8239 -9.91059 0
+    endloop
+  endfacet
+  facet normal -0.985276 0.170972 0
+    outer loop
+      vertex 49.8239 -9.91059 0
+      vertex 50.2502 -7.45391 20
+      vertex 50.2502 -7.45391 0
+    endloop
+  endfacet
+  facet normal -0.985276 0.170972 0
+    outer loop
+      vertex 50.2502 -7.45391 20
+      vertex 49.8239 -9.91059 0
+      vertex 49.8239 -9.91059 20
+    endloop
+  endfacet
+  facet normal -0.99248 0.122404 0
+    outer loop
+      vertex 50.2502 -7.45391 0
+      vertex 50.5554 -4.97927 20
+      vertex 50.5554 -4.97927 0
+    endloop
+  endfacet
+  facet normal -0.99248 0.122404 0
+    outer loop
+      vertex 50.5554 -4.97927 20
+      vertex 50.2502 -7.45391 0
+      vertex 50.2502 -7.45391 20
+    endloop
+  endfacet
+  facet normal -0.534972 0.84487 0
+    outer loop
+      vertex 28.223 -42.2387 0
+      vertex 26.1164 -43.5726 20
+      vertex 28.223 -42.2387 20
+    endloop
+  endfacet
+  facet normal -0.534972 0.84487 0
+    outer loop
+      vertex 26.1164 -43.5726 20
+      vertex 28.223 -42.2387 0
+      vertex 26.1164 -43.5726 0
+    endloop
+  endfacet
+  facet normal -0.84487 0.534972 0
+    outer loop
+      vertex 42.2387 -28.223 0
+      vertex 43.5726 -26.1164 20
+      vertex 43.5726 -26.1164 0
+    endloop
+  endfacet
+  facet normal -0.84487 0.534972 0
+    outer loop
+      vertex 43.5726 -26.1164 20
+      vertex 42.2387 -28.223 0
+      vertex 42.2387 -28.223 20
+    endloop
+  endfacet
+  facet normal -0.359877 -0.933 0
+    outer loop
+      vertex 17.114 47.8304 0
+      vertex 19.4403 46.9331 20
+      vertex 17.114 47.8304 20
+    endloop
+  endfacet
+  facet normal -0.359877 -0.933 -0
+    outer loop
+      vertex 19.4403 46.9331 20
+      vertex 17.114 47.8304 0
+      vertex 19.4403 46.9331 0
+    endloop
+  endfacet
+  facet normal 0.999699 0.0245449 0
+    outer loop
+      vertex -50.7388 -2.49264 20
+      vertex -50.8 0 0
+      vertex -50.8 0 20
+    endloop
+  endfacet
+  facet normal 0.999699 0.0245449 0
+    outer loop
+      vertex -50.8 0 0
+      vertex -50.7388 -2.49264 20
+      vertex -50.7388 -2.49264 0
+    endloop
+  endfacet
+  facet normal -0.870078 -0.492913 0
+    outer loop
+      vertex 44.8016 23.947 0
+      vertex 43.5726 26.1164 20
+      vertex 43.5726 26.1164 0
+    endloop
+  endfacet
+  facet normal -0.870078 -0.492913 0
+    outer loop
+      vertex 43.5726 26.1164 20
+      vertex 44.8016 23.947 0
+      vertex 44.8016 23.947 20
+    endloop
+  endfacet
+  facet normal -0.893221 -0.449618 0
+    outer loop
+      vertex 45.9227 21.7198 0
+      vertex 44.8016 23.947 20
+      vertex 44.8016 23.947 0
+    endloop
+  endfacet
+  facet normal -0.893221 -0.449618 0
+    outer loop
+      vertex 44.8016 23.947 20
+      vertex 45.9227 21.7198 0
+      vertex 45.9227 21.7198 20
+    endloop
+  endfacet
+  facet normal 0.72424 -0.689548 0
+    outer loop
+      vertex -37.6403 34.1152 20
+      vertex -35.921 35.921 0
+      vertex -35.921 35.921 20
+    endloop
+  endfacet
+  facet normal 0.72424 -0.689548 0
+    outer loop
+      vertex -35.921 35.921 0
+      vertex -37.6403 34.1152 20
+      vertex -37.6403 34.1152 0
+    endloop
+  endfacet
+  facet normal -0.933 -0.359877 0
+    outer loop
+      vertex 47.8304 17.114 0
+      vertex 46.9331 19.4403 20
+      vertex 46.9331 19.4403 0
+    endloop
+  endfacet
+  facet normal -0.933 -0.359877 0
+    outer loop
+      vertex 46.9331 19.4403 20
+      vertex 47.8304 17.114 0
+      vertex 47.8304 17.114 20
+    endloop
+  endfacet
+  facet normal 0.449618 0.893221 -0
+    outer loop
+      vertex -21.7198 -45.9227 0
+      vertex -23.947 -44.8016 20
+      vertex -21.7198 -45.9227 20
+    endloop
+  endfacet
+  facet normal 0.449618 0.893221 0
+    outer loop
+      vertex -23.947 -44.8016 20
+      vertex -21.7198 -45.9227 0
+      vertex -23.947 -44.8016 0
+    endloop
+  endfacet
+  facet normal -0.492913 -0.870078 0
+    outer loop
+      vertex 23.947 44.8016 0
+      vertex 26.1164 43.5726 20
+      vertex 23.947 44.8016 20
+    endloop
+  endfacet
+  facet normal -0.492913 -0.870078 -0
+    outer loop
+      vertex 26.1164 43.5726 20
+      vertex 23.947 44.8016 0
+      vertex 26.1164 43.5726 0
+    endloop
+  endfacet
+  facet normal 0.575842 0.817561 -0
+    outer loop
+      vertex -28.223 -42.2387 0
+      vertex -30.2615 -40.8029 20
+      vertex -28.223 -42.2387 20
+    endloop
+  endfacet
+  facet normal 0.575842 0.817561 0
+    outer loop
+      vertex -30.2615 -40.8029 20
+      vertex -28.223 -42.2387 0
+      vertex -30.2615 -40.8029 0
+    endloop
+  endfacet
+  facet normal -0.0735547 -0.997291 0
+    outer loop
+      vertex 2.49264 50.7388 0
+      vertex 4.97927 50.5554 20
+      vertex 2.49264 50.7388 20
+    endloop
+  endfacet
+  facet normal -0.0735547 -0.997291 -0
+    outer loop
+      vertex 4.97927 50.5554 20
+      vertex 2.49264 50.7388 0
+      vertex 4.97927 50.5554 0
+    endloop
+  endfacet
+  facet normal -0.313712 -0.949518 0
+    outer loop
+      vertex 14.7465 48.6126 0
+      vertex 17.114 47.8304 20
+      vertex 14.7465 48.6126 20
+    endloop
+  endfacet
+  facet normal -0.313712 -0.949518 -0
+    outer loop
+      vertex 17.114 47.8304 20
+      vertex 14.7465 48.6126 0
+      vertex 17.114 47.8304 0
+    endloop
+  endfacet
+  facet normal -0.975703 0.219099 0
+    outer loop
+      vertex 49.2776 -12.3434 0
+      vertex 49.8239 -9.91059 20
+      vertex 49.8239 -9.91059 0
+    endloop
+  endfacet
+  facet normal -0.975703 0.219099 0
+    outer loop
+      vertex 49.8239 -9.91059 20
+      vertex 49.2776 -12.3434 0
+      vertex 49.2776 -12.3434 20
+    endloop
+  endfacet
+  facet normal -0.914215 0.40523 0
+    outer loop
+      vertex 45.9227 -21.7198 0
+      vertex 46.9331 -19.4403 20
+      vertex 46.9331 -19.4403 0
+    endloop
+  endfacet
+  facet normal -0.914215 0.40523 0
+    outer loop
+      vertex 46.9331 -19.4403 20
+      vertex 45.9227 -21.7198 0
+      vertex 45.9227 -21.7198 20
+    endloop
+  endfacet
+  facet normal -0.999699 0.0245449 0
+    outer loop
+      vertex 50.7388 -2.49264 0
+      vertex 50.8 0 20
+      vertex 50.8 0 0
+    endloop
+  endfacet
+  facet normal -0.999699 0.0245449 0
+    outer loop
+      vertex 50.8 0 20
+      vertex 50.7388 -2.49264 0
+      vertex 50.7388 -2.49264 20
+    endloop
+  endfacet
+  facet normal 0.757209 -0.653173 0
+    outer loop
+      vertex -39.2689 32.2272 20
+      vertex -37.6403 34.1152 0
+      vertex -37.6403 34.1152 20
+    endloop
+  endfacet
+  facet normal 0.757209 -0.653173 0
+    outer loop
+      vertex -37.6403 34.1152 0
+      vertex -39.2689 32.2272 20
+      vertex -39.2689 32.2272 0
+    endloop
+  endfacet
+  facet normal 0.266703 0.963779 -0
+    outer loop
+      vertex -12.3434 -49.2776 0
+      vertex -14.7465 -48.6126 20
+      vertex -12.3434 -49.2776 20
+    endloop
+  endfacet
+  facet normal 0.266703 0.963779 0
+    outer loop
+      vertex -14.7465 -48.6126 20
+      vertex -12.3434 -49.2776 0
+      vertex -14.7465 -48.6126 0
+    endloop
+  endfacet
+  facet normal -0.40523 0.914215 0
+    outer loop
+      vertex 21.7198 -45.9227 0
+      vertex 19.4403 -46.9331 20
+      vertex 21.7198 -45.9227 20
+    endloop
+  endfacet
+  facet normal -0.40523 0.914215 0
+    outer loop
+      vertex 19.4403 -46.9331 20
+      vertex 21.7198 -45.9227 0
+      vertex 19.4403 -46.9331 0
+    endloop
+  endfacet
+  facet normal -0.359877 0.933 0
+    outer loop
+      vertex 19.4403 -46.9331 0
+      vertex 17.114 -47.8304 20
+      vertex 19.4403 -46.9331 20
+    endloop
+  endfacet
+  facet normal -0.359877 0.933 0
+    outer loop
+      vertex 17.114 -47.8304 20
+      vertex 19.4403 -46.9331 0
+      vertex 17.114 -47.8304 0
+    endloop
+  endfacet
+  facet normal -0.997291 0.0735547 0
+    outer loop
+      vertex 50.5554 -4.97927 0
+      vertex 50.7388 -2.49264 20
+      vertex 50.7388 -2.49264 0
+    endloop
+  endfacet
+  facet normal -0.997291 0.0735547 0
+    outer loop
+      vertex 50.7388 -2.49264 20
+      vertex 50.5554 -4.97927 0
+      vertex 50.5554 -4.97927 20
+    endloop
+  endfacet
+  facet normal -0.653173 -0.757209 0
+    outer loop
+      vertex 32.2272 39.2689 0
+      vertex 34.1152 37.6403 20
+      vertex 32.2272 39.2689 20
+    endloop
+  endfacet
+  facet normal -0.653173 -0.757209 -0
+    outer loop
+      vertex 34.1152 37.6403 20
+      vertex 32.2272 39.2689 0
+      vertex 34.1152 37.6403 0
+    endloop
+  endfacet
+  facet normal -0.788356 -0.61522 0
+    outer loop
+      vertex 40.8029 30.2615 0
+      vertex 39.2689 32.2272 20
+      vertex 39.2689 32.2272 0
+    endloop
+  endfacet
+  facet normal -0.788356 -0.61522 0
+    outer loop
+      vertex 39.2689 32.2272 20
+      vertex 40.8029 30.2615 0
+      vertex 40.8029 30.2615 20
+    endloop
+  endfacet
+  facet normal -0.689548 -0.72424 0
+    outer loop
+      vertex 34.1152 37.6403 0
+      vertex 35.921 35.921 20
+      vertex 34.1152 37.6403 20
+    endloop
+  endfacet
+  facet normal -0.689548 -0.72424 -0
+    outer loop
+      vertex 35.921 35.921 20
+      vertex 34.1152 37.6403 0
+      vertex 35.921 35.921 0
+    endloop
+  endfacet
+  facet normal -0.949518 0.313712 0
+    outer loop
+      vertex 47.8304 -17.114 0
+      vertex 48.6126 -14.7465 20
+      vertex 48.6126 -14.7465 0
+    endloop
+  endfacet
+  facet normal -0.949518 0.313712 0
+    outer loop
+      vertex 48.6126 -14.7465 20
+      vertex 47.8304 -17.114 0
+      vertex 47.8304 -17.114 20
+    endloop
+  endfacet
+  facet normal 0.40523 -0.914215 0
+    outer loop
+      vertex -21.7198 45.9227 0
+      vertex -19.4403 46.9331 20
+      vertex -21.7198 45.9227 20
+    endloop
+  endfacet
+  facet normal 0.40523 -0.914215 0
+    outer loop
+      vertex -19.4403 46.9331 20
+      vertex -21.7198 45.9227 0
+      vertex -19.4403 46.9331 0
+    endloop
+  endfacet
+  facet normal -0.84487 -0.534972 0
+    outer loop
+      vertex 43.5726 26.1164 0
+      vertex 42.2387 28.223 20
+      vertex 42.2387 28.223 0
+    endloop
+  endfacet
+  facet normal -0.84487 -0.534972 0
+    outer loop
+      vertex 42.2387 28.223 20
+      vertex 43.5726 26.1164 0
+      vertex 43.5726 26.1164 20
+    endloop
+  endfacet
+  facet normal -0.963779 -0.266703 0
+    outer loop
+      vertex 49.2776 12.3434 0
+      vertex 48.6126 14.7465 20
+      vertex 48.6126 14.7465 0
+    endloop
+  endfacet
+  facet normal -0.963779 -0.266703 0
+    outer loop
+      vertex 48.6126 14.7465 20
+      vertex 49.2776 12.3434 0
+      vertex 49.2776 12.3434 20
+    endloop
+  endfacet
+  facet normal -0.949518 -0.313712 0
+    outer loop
+      vertex 48.6126 14.7465 0
+      vertex 47.8304 17.114 20
+      vertex 47.8304 17.114 0
+    endloop
+  endfacet
+  facet normal -0.949518 -0.313712 0
+    outer loop
+      vertex 47.8304 17.114 20
+      vertex 48.6126 14.7465 0
+      vertex 48.6126 14.7465 20
+    endloop
+  endfacet
+  facet normal 0.997291 -0.0735547 0
+    outer loop
+      vertex -50.7388 2.49264 20
+      vertex -50.5554 4.97927 0
+      vertex -50.5554 4.97927 20
+    endloop
+  endfacet
+  facet normal 0.997291 -0.0735547 0
+    outer loop
+      vertex -50.5554 4.97927 0
+      vertex -50.7388 2.49264 20
+      vertex -50.7388 2.49264 0
+    endloop
+  endfacet
+  facet normal 0.266703 -0.963779 0
+    outer loop
+      vertex -14.7465 48.6126 0
+      vertex -12.3434 49.2776 20
+      vertex -14.7465 48.6126 20
+    endloop
+  endfacet
+  facet normal 0.266703 -0.963779 0
+    outer loop
+      vertex -12.3434 49.2776 20
+      vertex -14.7465 48.6126 0
+      vertex -12.3434 49.2776 0
+    endloop
+  endfacet
+  facet normal -0.963779 0.266703 0
+    outer loop
+      vertex 48.6126 -14.7465 0
+      vertex 49.2776 -12.3434 20
+      vertex 49.2776 -12.3434 0
+    endloop
+  endfacet
+  facet normal -0.963779 0.266703 0
+    outer loop
+      vertex 49.2776 -12.3434 20
+      vertex 48.6126 -14.7465 0
+      vertex 48.6126 -14.7465 20
+    endloop
+  endfacet
+  facet normal -0.933 0.359877 0
+    outer loop
+      vertex 46.9331 -19.4403 0
+      vertex 47.8304 -17.114 20
+      vertex 47.8304 -17.114 0
+    endloop
+  endfacet
+  facet normal -0.933 0.359877 0
+    outer loop
+      vertex 47.8304 -17.114 20
+      vertex 46.9331 -19.4403 0
+      vertex 46.9331 -19.4403 20
+    endloop
+  endfacet
+  facet normal -0.975703 -0.219099 0
+    outer loop
+      vertex 49.8239 9.91059 0
+      vertex 49.2776 12.3434 20
+      vertex 49.2776 12.3434 0
+    endloop
+  endfacet
+  facet normal -0.975703 -0.219099 0
+    outer loop
+      vertex 49.2776 12.3434 20
+      vertex 49.8239 9.91059 0
+      vertex 49.8239 9.91059 20
+    endloop
+  endfacet
+  facet normal 0.689548 -0.72424 0
+    outer loop
+      vertex -35.921 35.921 0
+      vertex -34.1152 37.6403 20
+      vertex -35.921 35.921 20
+    endloop
+  endfacet
+  facet normal 0.689548 -0.72424 0
+    outer loop
+      vertex -34.1152 37.6403 20
+      vertex -35.921 35.921 0
+      vertex -34.1152 37.6403 0
+    endloop
+  endfacet
+  facet normal -0.40523 -0.914215 0
+    outer loop
+      vertex 19.4403 46.9331 0
+      vertex 21.7198 45.9227 20
+      vertex 19.4403 46.9331 20
+    endloop
+  endfacet
+  facet normal -0.40523 -0.914215 -0
+    outer loop
+      vertex 21.7198 45.9227 20
+      vertex 19.4403 46.9331 0
+      vertex 21.7198 45.9227 0
+    endloop
+  endfacet
+  facet normal -0.689548 0.72424 0
+    outer loop
+      vertex 35.921 -35.921 0
+      vertex 34.1152 -37.6403 20
+      vertex 35.921 -35.921 20
+    endloop
+  endfacet
+  facet normal -0.689548 0.72424 0
+    outer loop
+      vertex 34.1152 -37.6403 20
+      vertex 35.921 -35.921 0
+      vertex 34.1152 -37.6403 0
+    endloop
+  endfacet
+  facet normal -0.985276 -0.170972 0
+    outer loop
+      vertex 50.2502 7.45391 0
+      vertex 49.8239 9.91059 20
+      vertex 49.8239 9.91059 0
+    endloop
+  endfacet
+  facet normal -0.985276 -0.170972 0
+    outer loop
+      vertex 49.8239 9.91059 20
+      vertex 50.2502 7.45391 0
+      vertex 50.2502 7.45391 20
+    endloop
+  endfacet
+  facet normal -0.914215 -0.40523 0
+    outer loop
+      vertex 46.9331 19.4403 0
+      vertex 45.9227 21.7198 20
+      vertex 45.9227 21.7198 0
+    endloop
+  endfacet
+  facet normal -0.914215 -0.40523 0
+    outer loop
+      vertex 45.9227 21.7198 20
+      vertex 46.9331 19.4403 0
+      vertex 46.9331 19.4403 20
+    endloop
+  endfacet
+  facet normal -0.757209 0.653173 0
+    outer loop
+      vertex 37.6403 -34.1152 0
+      vertex 39.2689 -32.2272 20
+      vertex 39.2689 -32.2272 0
+    endloop
+  endfacet
+  facet normal -0.757209 0.653173 0
+    outer loop
+      vertex 39.2689 -32.2272 20
+      vertex 37.6403 -34.1152 0
+      vertex 37.6403 -34.1152 20
+    endloop
+  endfacet
+  facet normal -0.534972 -0.84487 0
+    outer loop
+      vertex 26.1164 43.5726 0
+      vertex 28.223 42.2387 20
+      vertex 26.1164 43.5726 20
+    endloop
+  endfacet
+  facet normal -0.534972 -0.84487 -0
+    outer loop
+      vertex 28.223 42.2387 20
+      vertex 26.1164 43.5726 0
+      vertex 28.223 42.2387 0
+    endloop
+  endfacet
+  facet normal 0.99248 0.122404 0
+    outer loop
+      vertex -50.2502 -7.45391 20
+      vertex -50.5554 -4.97927 0
+      vertex -50.5554 -4.97927 20
+    endloop
+  endfacet
+  facet normal 0.99248 0.122404 0
+    outer loop
+      vertex -50.5554 -4.97927 0
+      vertex -50.2502 -7.45391 20
+      vertex -50.2502 -7.45391 0
+    endloop
+  endfacet
+  facet normal -0.61522 0.788356 0
+    outer loop
+      vertex 32.2272 -39.2689 0
+      vertex 30.2615 -40.8029 20
+      vertex 32.2272 -39.2689 20
+    endloop
+  endfacet
+  facet normal -0.61522 0.788356 0
+    outer loop
+      vertex 30.2615 -40.8029 20
+      vertex 32.2272 -39.2689 0
+      vertex 30.2615 -40.8029 0
+    endloop
+  endfacet
+  facet normal 0.313712 -0.949518 0
+    outer loop
+      vertex -17.114 47.8304 0
+      vertex -14.7465 48.6126 20
+      vertex -17.114 47.8304 20
+    endloop
+  endfacet
+  facet normal 0.313712 -0.949518 0
+    outer loop
+      vertex -14.7465 48.6126 20
+      vertex -17.114 47.8304 0
+      vertex -14.7465 48.6126 0
+    endloop
+  endfacet
+  facet normal -0.122404 0.99248 0
+    outer loop
+      vertex 7.45391 -50.2502 0
+      vertex 4.97927 -50.5554 20
+      vertex 7.45391 -50.2502 20
+    endloop
+  endfacet
+  facet normal -0.122404 0.99248 0
+    outer loop
+      vertex 4.97927 -50.5554 20
+      vertex 7.45391 -50.2502 0
+      vertex 4.97927 -50.5554 0
+    endloop
+  endfacet
+  facet normal 0.689548 0.72424 -0
+    outer loop
+      vertex -34.1152 -37.6403 0
+      vertex -35.921 -35.921 20
+      vertex -34.1152 -37.6403 20
+    endloop
+  endfacet
+  facet normal 0.689548 0.72424 0
+    outer loop
+      vertex -35.921 -35.921 20
+      vertex -34.1152 -37.6403 0
+      vertex -35.921 -35.921 0
+    endloop
+  endfacet
+  facet normal 0.72424 0.689548 0
+    outer loop
+      vertex -35.921 -35.921 20
+      vertex -37.6403 -34.1152 0
+      vertex -37.6403 -34.1152 20
+    endloop
+  endfacet
+  facet normal 0.72424 0.689548 0
+    outer loop
+      vertex -37.6403 -34.1152 0
+      vertex -35.921 -35.921 20
+      vertex -35.921 -35.921 0
+    endloop
+  endfacet
+  facet normal 0.219099 -0.975703 0
+    outer loop
+      vertex -12.3434 49.2776 0
+      vertex -9.91059 49.8239 20
+      vertex -12.3434 49.2776 20
+    endloop
+  endfacet
+  facet normal 0.219099 -0.975703 0
+    outer loop
+      vertex -9.91059 49.8239 20
+      vertex -12.3434 49.2776 0
+      vertex -9.91059 49.8239 0
+    endloop
+  endfacet
+  facet normal 0.788356 -0.61522 0
+    outer loop
+      vertex -40.8029 30.2615 20
+      vertex -39.2689 32.2272 0
+      vertex -39.2689 32.2272 20
+    endloop
+  endfacet
+  facet normal 0.788356 -0.61522 0
+    outer loop
+      vertex -39.2689 32.2272 0
+      vertex -40.8029 30.2615 20
+      vertex -40.8029 30.2615 0
+    endloop
+  endfacet
+  facet normal 0.870078 -0.492913 0
+    outer loop
+      vertex -44.8016 23.947 20
+      vertex -43.5726 26.1164 0
+      vertex -43.5726 26.1164 20
+    endloop
+  endfacet
+  facet normal 0.870078 -0.492913 0
+    outer loop
+      vertex -43.5726 26.1164 0
+      vertex -44.8016 23.947 20
+      vertex -44.8016 23.947 0
+    endloop
+  endfacet
+  facet normal 0.985276 -0.170972 0
+    outer loop
+      vertex -50.2502 7.45391 20
+      vertex -49.8239 9.91059 0
+      vertex -49.8239 9.91059 20
+    endloop
+  endfacet
+  facet normal 0.985276 -0.170972 0
+    outer loop
+      vertex -49.8239 9.91059 0
+      vertex -50.2502 7.45391 20
+      vertex -50.2502 7.45391 0
+    endloop
+  endfacet
+  facet normal 0.99248 -0.122404 0
+    outer loop
+      vertex -50.5554 4.97927 20
+      vertex -50.2502 7.45391 0
+      vertex -50.2502 7.45391 20
+    endloop
+  endfacet
+  facet normal 0.99248 -0.122404 0
+    outer loop
+      vertex -50.2502 7.45391 0
+      vertex -50.5554 4.97927 20
+      vertex -50.5554 4.97927 0
+    endloop
+  endfacet
+  facet normal 0.653173 -0.757209 0
+    outer loop
+      vertex -34.1152 37.6403 0
+      vertex -32.2272 39.2689 20
+      vertex -34.1152 37.6403 20
+    endloop
+  endfacet
+  facet normal 0.653173 -0.757209 0
+    outer loop
+      vertex -32.2272 39.2689 20
+      vertex -34.1152 37.6403 0
+      vertex -32.2272 39.2689 0
+    endloop
+  endfacet
+  facet normal -0.653173 0.757209 0
+    outer loop
+      vertex 34.1152 -37.6403 0
+      vertex 32.2272 -39.2689 20
+      vertex 34.1152 -37.6403 20
+    endloop
+  endfacet
+  facet normal -0.653173 0.757209 0
+    outer loop
+      vertex 32.2272 -39.2689 20
+      vertex 34.1152 -37.6403 0
+      vertex 32.2272 -39.2689 0
+    endloop
+  endfacet
+  facet normal 0.219099 0.975703 -0
+    outer loop
+      vertex -9.91059 -49.8239 0
+      vertex -12.3434 -49.2776 20
+      vertex -9.91059 -49.8239 20
+    endloop
+  endfacet
+  facet normal 0.219099 0.975703 0
+    outer loop
+      vertex -12.3434 -49.2776 20
+      vertex -9.91059 -49.8239 0
+      vertex -12.3434 -49.2776 0
+    endloop
+  endfacet
+  facet normal 0.975703 -0.219099 0
+    outer loop
+      vertex -49.8239 9.91059 20
+      vertex -49.2776 12.3434 0
+      vertex -49.2776 12.3434 20
+    endloop
+  endfacet
+  facet normal 0.975703 -0.219099 0
+    outer loop
+      vertex -49.2776 12.3434 0
+      vertex -49.8239 9.91059 20
+      vertex -49.8239 9.91059 0
+    endloop
+  endfacet
+  facet normal -0.0245449 0.999699 0
+    outer loop
+      vertex 2.49264 -50.7388 0
+      vertex 0 -50.8 20
+      vertex 2.49264 -50.7388 20
+    endloop
+  endfacet
+  facet normal -0.0245449 0.999699 0
+    outer loop
+      vertex 0 -50.8 20
+      vertex 2.49264 -50.7388 0
+      vertex 0 -50.8 0
+    endloop
+  endfacet
+  facet normal 0.313712 0.949518 -0
+    outer loop
+      vertex -14.7465 -48.6126 0
+      vertex -17.114 -47.8304 20
+      vertex -14.7465 -48.6126 20
+    endloop
+  endfacet
+  facet normal 0.313712 0.949518 0
+    outer loop
+      vertex -17.114 -47.8304 20
+      vertex -14.7465 -48.6126 0
+      vertex -17.114 -47.8304 0
+    endloop
+  endfacet
+  facet normal 0.975703 0.219099 0
+    outer loop
+      vertex -49.2776 -12.3434 20
+      vertex -49.8239 -9.91059 0
+      vertex -49.8239 -9.91059 20
+    endloop
+  endfacet
+  facet normal 0.975703 0.219099 0
+    outer loop
+      vertex -49.8239 -9.91059 0
+      vertex -49.2776 -12.3434 20
+      vertex -49.2776 -12.3434 0
+    endloop
+  endfacet
+  facet normal 0.933 0.359877 0
+    outer loop
+      vertex -46.9331 -19.4403 20
+      vertex -47.8304 -17.114 0
+      vertex -47.8304 -17.114 20
+    endloop
+  endfacet
+  facet normal 0.933 0.359877 0
+    outer loop
+      vertex -47.8304 -17.114 0
+      vertex -46.9331 -19.4403 20
+      vertex -46.9331 -19.4403 0
+    endloop
+  endfacet
+  facet normal 0.84487 -0.534972 0
+    outer loop
+      vertex -43.5726 26.1164 20
+      vertex -42.2387 28.223 0
+      vertex -42.2387 28.223 20
+    endloop
+  endfacet
+  facet normal 0.84487 -0.534972 0
+    outer loop
+      vertex -42.2387 28.223 0
+      vertex -43.5726 26.1164 20
+      vertex -43.5726 26.1164 0
+    endloop
+  endfacet
+  facet normal -0.72424 -0.689548 0
+    outer loop
+      vertex 37.6403 34.1152 0
+      vertex 35.921 35.921 20
+      vertex 35.921 35.921 0
+    endloop
+  endfacet
+  facet normal -0.72424 -0.689548 0
+    outer loop
+      vertex 35.921 35.921 20
+      vertex 37.6403 34.1152 0
+      vertex 37.6403 34.1152 20
+    endloop
+  endfacet
+  facet normal -0.449618 0.893221 0
+    outer loop
+      vertex 23.947 -44.8016 0
+      vertex 21.7198 -45.9227 20
+      vertex 23.947 -44.8016 20
+    endloop
+  endfacet
+  facet normal -0.449618 0.893221 0
+    outer loop
+      vertex 21.7198 -45.9227 20
+      vertex 23.947 -44.8016 0
+      vertex 21.7198 -45.9227 0
+    endloop
+  endfacet
+  facet normal -0.757209 -0.653173 0
+    outer loop
+      vertex 39.2689 32.2272 0
+      vertex 37.6403 34.1152 20
+      vertex 37.6403 34.1152 0
+    endloop
+  endfacet
+  facet normal -0.757209 -0.653173 0
+    outer loop
+      vertex 37.6403 34.1152 20
+      vertex 39.2689 32.2272 0
+      vertex 39.2689 32.2272 20
+    endloop
+  endfacet
+  facet normal 0.949518 -0.313712 0
+    outer loop
+      vertex -48.6126 14.7465 20
+      vertex -47.8304 17.114 0
+      vertex -47.8304 17.114 20
+    endloop
+  endfacet
+  facet normal 0.949518 -0.313712 0
+    outer loop
+      vertex -47.8304 17.114 0
+      vertex -48.6126 14.7465 20
+      vertex -48.6126 14.7465 0
+    endloop
+  endfacet
+  facet normal -0.313712 0.949518 0
+    outer loop
+      vertex 17.114 -47.8304 0
+      vertex 14.7465 -48.6126 20
+      vertex 17.114 -47.8304 20
+    endloop
+  endfacet
+  facet normal -0.313712 0.949518 0
+    outer loop
+      vertex 14.7465 -48.6126 20
+      vertex 17.114 -47.8304 0
+      vertex 14.7465 -48.6126 0
+    endloop
+  endfacet
+  facet normal 0.534972 -0.84487 0
+    outer loop
+      vertex -28.223 42.2387 0
+      vertex -26.1164 43.5726 20
+      vertex -28.223 42.2387 20
+    endloop
+  endfacet
+  facet normal 0.534972 -0.84487 0
+    outer loop
+      vertex -26.1164 43.5726 20
+      vertex -28.223 42.2387 0
+      vertex -26.1164 43.5726 0
+    endloop
+  endfacet
+  facet normal 0.40523 0.914215 -0
+    outer loop
+      vertex -19.4403 -46.9331 0
+      vertex -21.7198 -45.9227 20
+      vertex -19.4403 -46.9331 20
+    endloop
+  endfacet
+  facet normal 0.40523 0.914215 0
+    outer loop
+      vertex -21.7198 -45.9227 20
+      vertex -19.4403 -46.9331 0
+      vertex -21.7198 -45.9227 0
+    endloop
+  endfacet
+  facet normal -0.219099 -0.975703 0
+    outer loop
+      vertex 9.91059 49.8239 0
+      vertex 12.3434 49.2776 20
+      vertex 9.91059 49.8239 20
+    endloop
+  endfacet
+  facet normal -0.219099 -0.975703 -0
+    outer loop
+      vertex 12.3434 49.2776 20
+      vertex 9.91059 49.8239 0
+      vertex 12.3434 49.2776 0
+    endloop
+  endfacet
+  facet normal -0.266703 -0.963779 0
+    outer loop
+      vertex 12.3434 49.2776 0
+      vertex 14.7465 48.6126 20
+      vertex 12.3434 49.2776 20
+    endloop
+  endfacet
+  facet normal -0.266703 -0.963779 -0
+    outer loop
+      vertex 14.7465 48.6126 20
+      vertex 12.3434 49.2776 0
+      vertex 14.7465 48.6126 0
+    endloop
+  endfacet
+  facet normal -0.170972 0.985276 0
+    outer loop
+      vertex 9.91059 -49.8239 0
+      vertex 7.45391 -50.2502 20
+      vertex 9.91059 -49.8239 20
+    endloop
+  endfacet
+  facet normal -0.170972 0.985276 0
+    outer loop
+      vertex 7.45391 -50.2502 20
+      vertex 9.91059 -49.8239 0
+      vertex 7.45391 -50.2502 0
+    endloop
+  endfacet
+  facet normal -0.870078 0.492913 0
+    outer loop
+      vertex 43.5726 -26.1164 0
+      vertex 44.8016 -23.947 20
+      vertex 44.8016 -23.947 0
+    endloop
+  endfacet
+  facet normal -0.870078 0.492913 0
+    outer loop
+      vertex 44.8016 -23.947 20
+      vertex 43.5726 -26.1164 0
+      vertex 43.5726 -26.1164 20
+    endloop
+  endfacet
+  facet normal 0.0735547 0.997291 -0
+    outer loop
+      vertex -2.49264 -50.7388 0
+      vertex -4.97927 -50.5554 20
+      vertex -2.49264 -50.7388 20
+    endloop
+  endfacet
+  facet normal 0.0735547 0.997291 0
+    outer loop
+      vertex -4.97927 -50.5554 20
+      vertex -2.49264 -50.7388 0
+      vertex -4.97927 -50.5554 0
+    endloop
+  endfacet
+  facet normal -0.449618 -0.893221 0
+    outer loop
+      vertex 21.7198 45.9227 0
+      vertex 23.947 44.8016 20
+      vertex 21.7198 45.9227 20
+    endloop
+  endfacet
+  facet normal -0.449618 -0.893221 -0
+    outer loop
+      vertex 23.947 44.8016 20
+      vertex 21.7198 45.9227 0
+      vertex 23.947 44.8016 0
+    endloop
+  endfacet
+  facet normal 0.999699 -0.0245449 0
+    outer loop
+      vertex -50.8 0 20
+      vertex -50.7388 2.49264 0
+      vertex -50.7388 2.49264 20
+    endloop
+  endfacet
+  facet normal 0.999699 -0.0245449 0
+    outer loop
+      vertex -50.7388 2.49264 0
+      vertex -50.8 0 20
+      vertex -50.8 0 0
+    endloop
+  endfacet
+  facet normal -0.0245449 -0.999699 0
+    outer loop
+      vertex 0 50.8 0
+      vertex 2.49264 50.7388 20
+      vertex 0 50.8 20
+    endloop
+  endfacet
+  facet normal -0.0245449 -0.999699 -0
+    outer loop
+      vertex 2.49264 50.7388 20
+      vertex 0 50.8 0
+      vertex 2.49264 50.7388 0
+    endloop
+  endfacet
+  facet normal 0.653173 0.757209 -0
+    outer loop
+      vertex -32.2272 -39.2689 0
+      vertex -34.1152 -37.6403 20
+      vertex -32.2272 -39.2689 20
+    endloop
+  endfacet
+  facet normal 0.653173 0.757209 0
+    outer loop
+      vertex -34.1152 -37.6403 20
+      vertex -32.2272 -39.2689 0
+      vertex -34.1152 -37.6403 0
+    endloop
+  endfacet
+  facet normal -0.72424 0.689548 0
+    outer loop
+      vertex 35.921 -35.921 0
+      vertex 37.6403 -34.1152 20
+      vertex 37.6403 -34.1152 0
+    endloop
+  endfacet
+  facet normal -0.72424 0.689548 0
+    outer loop
+      vertex 37.6403 -34.1152 20
+      vertex 35.921 -35.921 0
+      vertex 35.921 -35.921 20
+    endloop
+  endfacet
+  facet normal 0.870078 0.492913 0
+    outer loop
+      vertex -43.5726 -26.1164 20
+      vertex -44.8016 -23.947 0
+      vertex -44.8016 -23.947 20
+    endloop
+  endfacet
+  facet normal 0.870078 0.492913 0
+    outer loop
+      vertex -44.8016 -23.947 0
+      vertex -43.5726 -26.1164 20
+      vertex -43.5726 -26.1164 0
+    endloop
+  endfacet
+  facet normal 0.963779 -0.266703 0
+    outer loop
+      vertex -49.2776 12.3434 20
+      vertex -48.6126 14.7465 0
+      vertex -48.6126 14.7465 20
+    endloop
+  endfacet
+  facet normal 0.963779 -0.266703 0
+    outer loop
+      vertex -48.6126 14.7465 0
+      vertex -49.2776 12.3434 20
+      vertex -49.2776 12.3434 0
+    endloop
+  endfacet
+  facet normal -0.817561 0.575842 0
+    outer loop
+      vertex 40.8029 -30.2615 0
+      vertex 42.2387 -28.223 20
+      vertex 42.2387 -28.223 0
+    endloop
+  endfacet
+  facet normal -0.817561 0.575842 0
+    outer loop
+      vertex 42.2387 -28.223 20
+      vertex 40.8029 -30.2615 0
+      vertex 40.8029 -30.2615 20
+    endloop
+  endfacet
+  facet normal 0.122404 0.99248 -0
+    outer loop
+      vertex -4.97927 -50.5554 0
+      vertex -7.45391 -50.2502 20
+      vertex -4.97927 -50.5554 20
+    endloop
+  endfacet
+  facet normal 0.122404 0.99248 0
+    outer loop
+      vertex -7.45391 -50.2502 20
+      vertex -4.97927 -50.5554 0
+      vertex -7.45391 -50.2502 0
+    endloop
+  endfacet
+  facet normal 0.817561 0.575842 0
+    outer loop
+      vertex -40.8029 -30.2615 20
+      vertex -42.2387 -28.223 0
+      vertex -42.2387 -28.223 20
+    endloop
+  endfacet
+  facet normal 0.817561 0.575842 0
+    outer loop
+      vertex -42.2387 -28.223 0
+      vertex -40.8029 -30.2615 20
+      vertex -40.8029 -30.2615 0
+    endloop
+  endfacet
+  facet normal 0.788356 0.61522 0
+    outer loop
+      vertex -39.2689 -32.2272 20
+      vertex -40.8029 -30.2615 0
+      vertex -40.8029 -30.2615 20
+    endloop
+  endfacet
+  facet normal 0.788356 0.61522 0
+    outer loop
+      vertex -40.8029 -30.2615 0
+      vertex -39.2689 -32.2272 20
+      vertex -39.2689 -32.2272 0
+    endloop
+  endfacet
+  facet normal 0.817561 -0.575842 0
+    outer loop
+      vertex -42.2387 28.223 20
+      vertex -40.8029 30.2615 0
+      vertex -40.8029 30.2615 20
+    endloop
+  endfacet
+  facet normal 0.817561 -0.575842 0
+    outer loop
+      vertex -40.8029 30.2615 0
+      vertex -42.2387 28.223 20
+      vertex -42.2387 28.223 0
+    endloop
+  endfacet
+  facet normal -0.492913 0.870078 0
+    outer loop
+      vertex 26.1164 -43.5726 0
+      vertex 23.947 -44.8016 20
+      vertex 26.1164 -43.5726 20
+    endloop
+  endfacet
+  facet normal -0.492913 0.870078 0
+    outer loop
+      vertex 23.947 -44.8016 20
+      vertex 26.1164 -43.5726 0
+      vertex 23.947 -44.8016 0
+    endloop
+  endfacet
+  facet normal -0.170972 -0.985276 0
+    outer loop
+      vertex 7.45391 50.2502 0
+      vertex 9.91059 49.8239 20
+      vertex 7.45391 50.2502 20
+    endloop
+  endfacet
+  facet normal -0.170972 -0.985276 -0
+    outer loop
+      vertex 9.91059 49.8239 20
+      vertex 7.45391 50.2502 0
+      vertex 9.91059 49.8239 0
+    endloop
+  endfacet
+  facet normal 0.492913 -0.870078 0
+    outer loop
+      vertex -26.1164 43.5726 0
+      vertex -23.947 44.8016 20
+      vertex -26.1164 43.5726 20
+    endloop
+  endfacet
+  facet normal 0.492913 -0.870078 0
+    outer loop
+      vertex -23.947 44.8016 20
+      vertex -26.1164 43.5726 0
+      vertex -23.947 44.8016 0
+    endloop
+  endfacet
+  facet normal 0.893221 0.449618 0
+    outer loop
+      vertex -44.8016 -23.947 20
+      vertex -45.9227 -21.7198 0
+      vertex -45.9227 -21.7198 20
+    endloop
+  endfacet
+  facet normal 0.893221 0.449618 0
+    outer loop
+      vertex -45.9227 -21.7198 0
+      vertex -44.8016 -23.947 20
+      vertex -44.8016 -23.947 0
+    endloop
+  endfacet
+  facet normal 0.61522 0.788356 -0
+    outer loop
+      vertex -30.2615 -40.8029 0
+      vertex -32.2272 -39.2689 20
+      vertex -30.2615 -40.8029 20
+    endloop
+  endfacet
+  facet normal 0.61522 0.788356 0
+    outer loop
+      vertex -32.2272 -39.2689 20
+      vertex -30.2615 -40.8029 0
+      vertex -32.2272 -39.2689 0
+    endloop
+  endfacet
+  facet normal 0.84487 0.534972 0
+    outer loop
+      vertex -42.2387 -28.223 20
+      vertex -43.5726 -26.1164 0
+      vertex -43.5726 -26.1164 20
+    endloop
+  endfacet
+  facet normal 0.84487 0.534972 0
+    outer loop
+      vertex -43.5726 -26.1164 0
+      vertex -42.2387 -28.223 20
+      vertex -42.2387 -28.223 0
+    endloop
+  endfacet
+  facet normal -0.219099 0.975703 0
+    outer loop
+      vertex 12.3434 -49.2776 0
+      vertex 9.91059 -49.8239 20
+      vertex 12.3434 -49.2776 20
+    endloop
+  endfacet
+  facet normal -0.219099 0.975703 0
+    outer loop
+      vertex 9.91059 -49.8239 20
+      vertex 12.3434 -49.2776 0
+      vertex 9.91059 -49.8239 0
+    endloop
+  endfacet
+  facet normal 0.963779 0.266703 0
+    outer loop
+      vertex -48.6126 -14.7465 20
+      vertex -49.2776 -12.3434 0
+      vertex -49.2776 -12.3434 20
+    endloop
+  endfacet
+  facet normal 0.963779 0.266703 0
+    outer loop
+      vertex -49.2776 -12.3434 0
+      vertex -48.6126 -14.7465 20
+      vertex -48.6126 -14.7465 0
+    endloop
+  endfacet
+  facet normal 0.914215 -0.40523 0
+    outer loop
+      vertex -46.9331 19.4403 20
+      vertex -45.9227 21.7198 0
+      vertex -45.9227 21.7198 20
+    endloop
+  endfacet
+  facet normal 0.914215 -0.40523 0
+    outer loop
+      vertex -45.9227 21.7198 0
+      vertex -46.9331 19.4403 20
+      vertex -46.9331 19.4403 0
+    endloop
+  endfacet
+  facet normal 0.893221 -0.449618 0
+    outer loop
+      vertex -45.9227 21.7198 20
+      vertex -44.8016 23.947 0
+      vertex -44.8016 23.947 20
+    endloop
+  endfacet
+  facet normal 0.893221 -0.449618 0
+    outer loop
+      vertex -44.8016 23.947 0
+      vertex -45.9227 21.7198 20
+      vertex -45.9227 21.7198 0
+    endloop
+  endfacet
+  facet normal 0.449618 -0.893221 0
+    outer loop
+      vertex -23.947 44.8016 0
+      vertex -21.7198 45.9227 20
+      vertex -23.947 44.8016 20
+    endloop
+  endfacet
+  facet normal 0.449618 -0.893221 0
+    outer loop
+      vertex -21.7198 45.9227 20
+      vertex -23.947 44.8016 0
+      vertex -21.7198 45.9227 0
+    endloop
+  endfacet
+  facet normal 0.914215 0.40523 0
+    outer loop
+      vertex -45.9227 -21.7198 20
+      vertex -46.9331 -19.4403 0
+      vertex -46.9331 -19.4403 20
+    endloop
+  endfacet
+  facet normal 0.914215 0.40523 0
+    outer loop
+      vertex -46.9331 -19.4403 0
+      vertex -45.9227 -21.7198 20
+      vertex -45.9227 -21.7198 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 7.5 57.8 38
+      vertex -7.5 57.8 40
+      vertex 7.5 57.8 40
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.5 57.8 40
+      vertex 7.5 57.8 38
+      vertex -7.5 57.8 38
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 7.5 57.8 20
+      vertex -7.5 57.8 38
+      vertex 7.5 57.8 38
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.5 57.8 38
+      vertex 7.5 57.8 20
+      vertex -7.5 57.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.5 57.8 40
+      vertex 7.5 52.8 40
+      vertex 7.5 57.8 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 52.8 40
+      vertex -7.5 57.8 40
+      vertex -7.5 52.8 40
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.5 54.8 20
+      vertex 7.5 57.8 20
+      vertex 7.5 54.8 20
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.5 57.8 20
+      vertex -7.5 54.8 20
+      vertex -7.5 57.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.5 54.8 20
+      vertex 7.5 54.8 38
+      vertex -7.5 54.8 38
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 7.5 54.8 38
+      vertex -7.5 54.8 20
+      vertex 7.5 54.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 54.8 38
+      vertex -7.5 57.8 38
+      vertex -7.5 57.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 54.8 38
+      vertex -7.5 57.8 20
+      vertex -7.5 54.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 57.8 38
+      vertex -7.5 54.8 38
+      vertex -7.5 57.8 40
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 52.8 40
+      vertex -7.5 54.8 38
+      vertex -7.5 52.8 38
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 54.8 38
+      vertex -7.5 52.8 40
+      vertex -7.5 57.8 40
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 54.8 38
+      vertex 7.5 57.8 38
+      vertex 7.5 57.8 40
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 57.8 38
+      vertex 7.5 54.8 38
+      vertex 7.5 57.8 20
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 7.5 52.8 40
+      vertex 7.5 54.8 38
+      vertex 7.5 57.8 40
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 54.8 38
+      vertex 7.5 52.8 40
+      vertex 7.5 52.8 38
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 57.8 20
+      vertex 7.5 54.8 38
+      vertex 7.5 54.8 20
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.5 52.8 38
+      vertex 7.5 54.8 38
+      vertex 7.5 52.8 38
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.5 54.8 38
+      vertex -7.5 52.8 38
+      vertex -7.5 54.8 38
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.5 52.8 38
+      vertex 7.5 52.8 40
+      vertex -7.5 52.8 40
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 7.5 52.8 40
+      vertex -7.5 52.8 38
+      vertex 7.5 52.8 38
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.5 -57.8 38
+      vertex 7.5 -57.8 40
+      vertex -7.5 -57.8 40
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 7.5 -57.8 40
+      vertex -7.5 -57.8 38
+      vertex 7.5 -57.8 38
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.5 -57.8 20
+      vertex 7.5 -57.8 38
+      vertex -7.5 -57.8 38
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 7.5 -57.8 38
+      vertex -7.5 -57.8 20
+      vertex 7.5 -57.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.5 -52.8 40
+      vertex 7.5 -57.8 40
+      vertex 7.5 -52.8 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 -57.8 40
+      vertex -7.5 -52.8 40
+      vertex -7.5 -57.8 40
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.5 -57.8 20
+      vertex 7.5 -54.8 20
+      vertex 7.5 -57.8 20
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.5 -54.8 20
+      vertex -7.5 -57.8 20
+      vertex -7.5 -54.8 20
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 7.5 -54.8 20
+      vertex -7.5 -54.8 38
+      vertex 7.5 -54.8 38
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.5 -54.8 38
+      vertex 7.5 -54.8 20
+      vertex -7.5 -54.8 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 -52.8 40
+      vertex 7.5 -54.8 38
+      vertex 7.5 -52.8 38
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 7.5 -57.8 40
+      vertex 7.5 -54.8 38
+      vertex 7.5 -52.8 40
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 -57.8 38
+      vertex 7.5 -54.8 38
+      vertex 7.5 -57.8 40
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 -54.8 38
+      vertex 7.5 -57.8 38
+      vertex 7.5 -54.8 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 -54.8 20
+      vertex 7.5 -57.8 38
+      vertex 7.5 -57.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 -54.8 20
+      vertex -7.5 -57.8 20
+      vertex -7.5 -54.8 38
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 -54.8 38
+      vertex -7.5 -52.8 40
+      vertex -7.5 -52.8 38
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 -57.8 38
+      vertex -7.5 -54.8 38
+      vertex -7.5 -57.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 -57.8 40
+      vertex -7.5 -54.8 38
+      vertex -7.5 -57.8 38
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 -54.8 38
+      vertex -7.5 -57.8 40
+      vertex -7.5 -52.8 40
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.5 -54.8 38
+      vertex 7.5 -52.8 38
+      vertex 7.5 -54.8 38
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.5 -52.8 38
+      vertex -7.5 -54.8 38
+      vertex -7.5 -52.8 38
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 7.5 -52.8 38
+      vertex -7.5 -52.8 40
+      vertex 7.5 -52.8 40
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.5 -52.8 40
+      vertex 7.5 -52.8 38
+      vertex -7.5 -52.8 38
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 3 0 75
+      vertex 3 15 55
+      vertex 3 15 75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 3 15 55
+      vertex 3 0 75
+      vertex 3 0 55
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 3 -15 75
+      vertex 3 -3 55
+      vertex 3 -3 75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 3 -3 55
+      vertex 3 -15 75
+      vertex 3 -15 55
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15 0 75
+      vertex 0 -3 75
+      vertex 0 0 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -3 75
+      vertex -15 0 75
+      vertex -15 -3 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 75
+      vertex 3 0 75
+      vertex 3 15 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3 0 75
+      vertex 0 0 75
+      vertex 3 -3 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 75
+      vertex 3 15 75
+      vertex 0 15 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -3 75
+      vertex 3 -3 75
+      vertex 0 0 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3 -3 75
+      vertex 0 -3 75
+      vertex 3 -15 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3 -15 75
+      vertex 0 -3 75
+      vertex 0 -15 75
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3 0 75
+      vertex 15 -3 75
+      vertex 15 0 75
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15 -3 75
+      vertex 3 0 75
+      vertex 3 -3 75
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15 -3 55
+      vertex 0 0 55
+      vertex 0 -3 55
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 0 0 55
+      vertex -15 -3 55
+      vertex -15 0 55
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -3 55
+      vertex 3 -3 55
+      vertex 3 -15 55
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3 -3 55
+      vertex 0 -3 55
+      vertex 3 0 55
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -3 55
+      vertex 3 -15 55
+      vertex 0 -15 55
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 3 0 55
+      vertex 0 -3 55
+      vertex 0 0 55
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3 0 55
+      vertex 0 0 55
+      vertex 3 15 55
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 3 15 55
+      vertex 0 0 55
+      vertex 0 15 55
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3 -3 55
+      vertex 15 0 55
+      vertex 15 -3 55
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15 0 55
+      vertex 3 -3 55
+      vertex 3 0 55
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 55
+      vertex 0 15 75
+      vertex 0 15 55
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 0 15 75
+      vertex 0 0 55
+      vertex 0 0 75
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 -15 55
+      vertex 0 -3 75
+      vertex 0 -3 55
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 0 -3 75
+      vertex 0 -15 55
+      vertex 0 -15 75
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3 15 55
+      vertex 0 15 75
+      vertex 3 15 75
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 15 75
+      vertex 3 15 55
+      vertex 0 15 55
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 -15 55
+      vertex 3 -15 75
+      vertex 0 -15 75
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 3 -15 75
+      vertex 0 -15 55
+      vertex 3 -15 55
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 3 -3 55
+      vertex 15 -3 75
+      vertex 3 -3 75
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 15 -3 75
+      vertex 3 -3 55
+      vertex 15 -3 55
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -15 -3 55
+      vertex 0 -3 75
+      vertex -15 -3 75
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 0 -3 75
+      vertex -15 -3 55
+      vertex 0 -3 55
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 15 0 55
+      vertex 3 0 75
+      vertex 15 0 75
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3 0 75
+      vertex 15 0 55
+      vertex 3 0 55
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0 0 55
+      vertex -15 0 75
+      vertex 0 0 75
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -15 0 75
+      vertex 0 0 55
+      vertex -15 0 55
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 15 -3 75
+      vertex 15 0 55
+      vertex 15 0 75
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 15 0 55
+      vertex 15 -3 75
+      vertex 15 -3 55
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -15 -3 55
+      vertex -15 0 75
+      vertex -15 0 55
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -15 0 75
+      vertex -15 -3 55
+      vertex -15 -3 75
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/3d_models/trap_funnel_adapter.stl
+++ b/3d_models/trap_funnel_adapter.stl
@@ -1,0 +1,10194 @@
+solid OpenSCAD_Model
+  facet normal -0.16963 0.977426 0.12595
+    outer loop
+      vertex -8.04083 54.2069 0
+      vertex -9.9649 51.2958 20
+      vertex -7.66813 51.6944 20
+    endloop
+  endfacet
+  facet normal -0.169625 0.977427 0.125951
+    outer loop
+      vertex -9.9649 51.2958 20
+      vertex -8.04083 54.2069 0
+      vertex -10.6909 53.747 0
+    endloop
+  endfacet
+  facet normal -0.0241692 0.991742 0.125948
+    outer loop
+      vertex -2.33039 52.2028 20
+      vertex -2.68891 54.734 0
+      vertex -2.56428 52.1971 20
+    endloop
+  endfacet
+  facet normal 0.169625 0.977427 0.125951
+    outer loop
+      vertex 8.04083 54.2069 0
+      vertex 9.9649 51.2958 20
+      vertex 10.6909 53.747 0
+    endloop
+  endfacet
+  facet normal 0.16963 0.977426 0.12595
+    outer loop
+      vertex 9.9649 51.2958 20
+      vertex 8.04083 54.2069 0
+      vertex 7.66813 51.6944 20
+    endloop
+  endfacet
+  facet normal -0.264594 -0.9561 0.125949
+    outer loop
+      vertex -13.3153 -53.1577 0
+      vertex -15.41 -50.8 13.4972
+      vertex -15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal -0.26459 -0.956101 0.125949
+    outer loop
+      vertex -15.41 -50.8 13.4972
+      vertex -13.3153 -53.1577 0
+      vertex -12.9498 -50.8 18.6655
+    endloop
+  endfacet
+  facet normal -0.0241692 -0.991742 0.125948
+    outer loop
+      vertex -2.56428 -52.1971 20
+      vertex -2.68891 -54.734 0
+      vertex -2.33039 -52.2028 20
+    endloop
+  endfacet
+  facet normal 0.0243425 -0.991738 0.125951
+    outer loop
+      vertex 0 -54.8 0
+      vertex 2.33039 -52.2028 20
+      vertex 0 -52.26 20
+    endloop
+  endfacet
+  facet normal 0.0243425 -0.991738 0.125951
+    outer loop
+      vertex 2.33039 -52.2028 20
+      vertex 0 -54.8 0
+      vertex 2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal -0.26459 0.956101 0.125949
+    outer loop
+      vertex -13.3153 53.1577 0
+      vertex -15.41 50.8 13.4972
+      vertex -12.9498 50.8 18.6655
+    endloop
+  endfacet
+  facet normal -0.264594 0.9561 0.125949
+    outer loop
+      vertex -15.41 50.8 13.4972
+      vertex -13.3153 53.1577 0
+      vertex -15.9076 52.4403 0
+    endloop
+  endfacet
+  facet normal -0.217088 0.967992 0.125951
+    outer loop
+      vertex -10.1954 51.2558 20
+      vertex -10.6909 53.747 0
+      vertex -10.4237 51.2046 20
+    endloop
+  endfacet
+  facet normal 0.0733553 -0.989321 0.125948
+    outer loop
+      vertex 2.7976 -52.1798 20
+      vertex 2.56428 -52.1971 20
+      vertex 2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal 0.217364 0.967932 0.125934
+    outer loop
+      vertex 12.7247 50.8 19.1382
+      vertex 10.4237 51.2046 20
+      vertex 12.2254 50.8 20
+    endloop
+  endfacet
+  facet normal 0.217346 0.967934 0.12595
+    outer loop
+      vertex 10.6909 53.747 0
+      vertex 12.7247 50.8 19.1382
+      vertex 13.3153 53.1577 0
+    endloop
+  endfacet
+  facet normal 0.217369 0.96793 0.125947
+    outer loop
+      vertex 12.7247 50.8 19.1382
+      vertex 10.6909 53.747 0
+      vertex 10.4237 51.2046 20
+    endloop
+  endfacet
+  facet normal 0.169619 0.977428 0.125951
+    outer loop
+      vertex 10.6909 53.747 0
+      vertex 9.9649 51.2958 20
+      vertex 10.1954 51.2558 20
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.6747 0 0
+      vertex 54.8 50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.6139 -2.47624 0
+      vertex 50.6747 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.6136 -2.48649 0
+      vertex 50.6139 -2.47624 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.6129 -2.49671 0
+      vertex 50.6136 -2.48649 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.4307 -4.96699 0
+      vertex 50.6129 -2.49671 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.4294 -4.97716 0
+      vertex 50.4307 -4.96699 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.1262 -7.43552 0
+      vertex 50.4294 -4.97716 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 50.1244 -7.44562 0
+      vertex 50.1262 -7.43552 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 49.701 -9.88614 0
+      vertex 50.1244 -7.44562 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 49.1583 -12.3029 0
+      vertex 49.701 -9.88614 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 49.156 -12.3129 0
+      vertex 49.1583 -12.3029 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 49.1533 -12.3228 0
+      vertex 49.156 -12.3129 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 48.4926 -14.7101 0
+      vertex 49.1533 -12.3228 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 48.4894 -14.7198 0
+      vertex 48.4926 -14.7101 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 47.7124 -17.0718 0
+      vertex 48.4894 -14.7198 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 46.821 -19.3828 0
+      vertex 47.7124 -17.0718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 46.8173 -19.3924 0
+      vertex 46.821 -19.3828 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 45.8135 -21.6568 0
+      vertex 46.8173 -19.3924 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 45.8094 -21.6662 0
+      vertex 45.8135 -21.6568 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 45.8047 -21.6754 0
+      vertex 45.8094 -21.6662 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 44.6911 -23.8879 0
+      vertex 45.8047 -21.6754 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 43.4702 -26.0431 0
+      vertex 44.6911 -23.8879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 43.4651 -26.052 0
+      vertex 43.4702 -26.0431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 43.4596 -26.0606 0
+      vertex 43.4651 -26.052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 42.1344 -28.1533 0
+      vertex 43.4596 -26.0606 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 40.7082 -30.1785 0
+      vertex 42.1344 -28.1533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 40.7023 -30.1869 0
+      vertex 40.7082 -30.1785 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 39.1784 -32.1396 0
+      vertex 40.7023 -30.1869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 39.1721 -32.1477 0
+      vertex 39.1784 -32.1396 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 39.1654 -32.1554 0
+      vertex 39.1721 -32.1477 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 37.5475 -34.031 0
+      vertex 39.1654 -32.1554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 35.8395 -35.825 0
+      vertex 37.5475 -34.031 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 35.8324 -35.8324 0
+      vertex 35.8395 -35.825 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 35.825 -35.8395 0
+      vertex 35.8324 -35.8324 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 34.031 -37.5475 0
+      vertex 35.825 -35.8395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 32.1554 -39.1654 0
+      vertex 34.031 -37.5475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 32.1477 -39.1721 0
+      vertex 32.1554 -39.1654 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 32.1396 -39.1784 0
+      vertex 32.1477 -39.1721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 30.1869 -40.7023 0
+      vertex 32.1396 -39.1784 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 30.1785 -40.7082 0
+      vertex 30.1869 -40.7023 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 28.1533 -42.1344 0
+      vertex 30.1785 -40.7082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 28.1533 -42.1344 0
+      vertex 54.8 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.1533 -42.1344 0
+      vertex 20.5267 -50.8 0
+      vertex 26.0606 -43.4596 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.0606 -43.4596 0
+      vertex 20.5267 -50.8 0
+      vertex 26.052 -43.4651 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.052 -43.4651 0
+      vertex 20.5267 -50.8 0
+      vertex 26.0431 -43.4702 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.0431 -43.4702 0
+      vertex 20.5267 -50.8 0
+      vertex 23.8879 -44.6911 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.8879 -44.6911 0
+      vertex 20.5267 -50.8 0
+      vertex 21.6754 -45.8047 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.6754 -45.8047 0
+      vertex 20.5267 -50.8 0
+      vertex 21.6662 -45.8094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 21.6662 -45.8094 0
+      vertex 20.5267 -50.8 0
+      vertex 21.6568 -45.8135 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 19.3924 -46.8173 0
+      vertex 21.6568 -45.8135 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 19.3828 -46.821 0
+      vertex 19.3924 -46.8173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0718 -47.7124 0
+      vertex 20.5267 -50.8 0
+      vertex 18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 17.0718 -47.7124 0
+      vertex 19.3828 -46.821 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9076 -52.4403 0
+      vertex 17.0718 -47.7124 0
+      vertex 18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9076 -52.4403 0
+      vertex 14.7198 -48.4894 0
+      vertex 17.0718 -47.7124 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9076 -52.4403 0
+      vertex 14.7101 -48.4926 0
+      vertex 14.7198 -48.4894 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.3153 -53.1577 0
+      vertex 14.7101 -48.4926 0
+      vertex 15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.3153 -53.1577 0
+      vertex 12.3228 -49.1533 0
+      vertex 14.7101 -48.4926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.3153 -53.1577 0
+      vertex 12.3129 -49.156 0
+      vertex 12.3228 -49.1533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.3153 -53.1577 0
+      vertex 12.3029 -49.1583 0
+      vertex 12.3129 -49.156 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6909 -53.747 0
+      vertex 12.3029 -49.1583 0
+      vertex 13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6909 -53.747 0
+      vertex 9.88614 -49.701 0
+      vertex 12.3029 -49.1583 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.04083 -54.2069 0
+      vertex 9.88614 -49.701 0
+      vertex 10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.04083 -54.2069 0
+      vertex 7.44562 -50.1244 0
+      vertex 9.88614 -49.701 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.04083 -54.2069 0
+      vertex 7.43552 -50.1262 0
+      vertex 7.44562 -50.1244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.37134 -54.5361 0
+      vertex 7.43552 -50.1262 0
+      vertex 8.04083 -54.2069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.37134 -54.5361 0
+      vertex 4.97716 -50.4294 0
+      vertex 7.43552 -50.1262 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.37134 -54.5361 0
+      vertex 4.96699 -50.4307 0
+      vertex 4.97716 -50.4294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.68891 -54.734 0
+      vertex 4.96699 -50.4307 0
+      vertex 5.37134 -54.5361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.68891 -54.734 0
+      vertex 2.49671 -50.6129 0
+      vertex 4.96699 -50.4307 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.68891 -54.734 0
+      vertex 2.48649 -50.6136 0
+      vertex 2.49671 -50.6129 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.68891 -54.734 0
+      vertex 2.47624 -50.6139 0
+      vertex 2.48649 -50.6136 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -54.8 0
+      vertex 2.47624 -50.6139 0
+      vertex 2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -54.8 0
+      vertex 0 -50.6747 0
+      vertex 2.47624 -50.6139 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -54.8 0
+      vertex -2.47624 -50.6139 0
+      vertex 0 -50.6747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.68891 -54.734 0
+      vertex -2.47624 -50.6139 0
+      vertex 0 -54.8 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.47624 -50.6139 0
+      vertex -2.68891 -54.734 0
+      vertex -2.48649 -50.6136 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.48649 -50.6136 0
+      vertex -2.68891 -54.734 0
+      vertex -2.49671 -50.6129 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.68891 -54.734 0
+      vertex -4.96699 -50.4307 0
+      vertex -2.49671 -50.6129 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.37134 -54.5361 0
+      vertex -4.96699 -50.4307 0
+      vertex -2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -4.96699 -50.4307 0
+      vertex -5.37134 -54.5361 0
+      vertex -4.97716 -50.4294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.37134 -54.5361 0
+      vertex -7.43552 -50.1262 0
+      vertex -4.97716 -50.4294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.04083 -54.2069 0
+      vertex -7.43552 -50.1262 0
+      vertex -5.37134 -54.5361 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -7.43552 -50.1262 0
+      vertex -8.04083 -54.2069 0
+      vertex -7.44562 -50.1244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.04083 -54.2069 0
+      vertex -9.88614 -49.701 0
+      vertex -7.44562 -50.1244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6909 -53.747 0
+      vertex -9.88614 -49.701 0
+      vertex -8.04083 -54.2069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6909 -53.747 0
+      vertex -12.3029 -49.1583 0
+      vertex -9.88614 -49.701 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.3153 -53.1577 0
+      vertex -12.3029 -49.1583 0
+      vertex -10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.3029 -49.1583 0
+      vertex -13.3153 -53.1577 0
+      vertex -12.3129 -49.156 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.3129 -49.156 0
+      vertex -13.3153 -53.1577 0
+      vertex -12.3228 -49.1533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.3153 -53.1577 0
+      vertex -14.7101 -48.4926 0
+      vertex -12.3228 -49.1533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9076 -52.4403 0
+      vertex -14.7101 -48.4926 0
+      vertex -13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.7101 -48.4926 0
+      vertex -15.9076 -52.4403 0
+      vertex -14.7198 -48.4894 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9076 -52.4403 0
+      vertex -17.0718 -47.7124 0
+      vertex -14.7198 -48.4894 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.4616 -51.5966 0
+      vertex -17.0718 -47.7124 0
+      vertex -15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -17.0718 -47.7124 0
+      vertex -18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -17.0718 -47.7124 0
+      vertex -20.5267 -50.8 0
+      vertex -19.3828 -46.821 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.3828 -46.821 0
+      vertex -20.5267 -50.8 0
+      vertex -19.3924 -46.8173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -21.6568 -45.8135 0
+      vertex -19.3924 -46.8173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -21.6662 -45.8094 0
+      vertex -21.6568 -45.8135 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -21.6754 -45.8047 0
+      vertex -21.6662 -45.8094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -23.8879 -44.6911 0
+      vertex -21.6754 -45.8047 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -26.0431 -43.4702 0
+      vertex -23.8879 -44.6911 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -26.052 -43.4651 0
+      vertex -26.0431 -43.4702 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -26.0606 -43.4596 0
+      vertex -26.052 -43.4651 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -28.1533 -42.1344 0
+      vertex -26.0606 -43.4596 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -28.1533 -42.1344 0
+      vertex -20.5267 -50.8 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -28.1533 -42.1344 0
+      vertex -54.8 -50.8 0
+      vertex -30.1785 -40.7082 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -30.1785 -40.7082 0
+      vertex -54.8 -50.8 0
+      vertex -30.1869 -40.7023 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -30.1869 -40.7023 0
+      vertex -54.8 -50.8 0
+      vertex -32.1396 -39.1784 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -32.1396 -39.1784 0
+      vertex -54.8 -50.8 0
+      vertex -32.1477 -39.1721 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -32.1477 -39.1721 0
+      vertex -54.8 -50.8 0
+      vertex -32.1554 -39.1654 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -32.1554 -39.1654 0
+      vertex -54.8 -50.8 0
+      vertex -34.031 -37.5475 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -34.031 -37.5475 0
+      vertex -54.8 -50.8 0
+      vertex -35.825 -35.8395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -35.8395 -35.825 0
+      vertex -35.8324 -35.8324 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -39.1654 -32.1554 0
+      vertex -37.5475 -34.031 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -39.1784 -32.1396 0
+      vertex -39.1721 -32.1477 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -40.7082 -30.1785 0
+      vertex -40.7023 -30.1869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -43.4596 -26.0606 0
+      vertex -42.1344 -28.1533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -45.8047 -21.6754 0
+      vertex -44.6911 -23.8879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -45.8135 -21.6568 0
+      vertex -45.8094 -21.6662 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -46.821 -19.3828 0
+      vertex -46.8173 -19.3924 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -49.1533 -12.3228 0
+      vertex -48.4926 -14.7101 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -50.1244 -7.44562 0
+      vertex -49.701 -9.88614 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -50.4294 -4.97716 0
+      vertex -50.1262 -7.43552 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.4307 -4.96699 0
+      vertex -50.6136 -2.48649 0
+      vertex -50.6129 -2.49671 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -50.6139 -2.47624 0
+      vertex -54.8 -50.8 0
+      vertex -50.6747 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -50.6136 -2.48649 0
+      vertex -54.8 -50.8 0
+      vertex -50.6139 -2.47624 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -50.4307 -4.96699 0
+      vertex -54.8 -50.8 0
+      vertex -50.6136 -2.48649 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -50.4294 -4.97716 0
+      vertex -54.8 -50.8 0
+      vertex -50.4307 -4.96699 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -50.1244 -7.44562 0
+      vertex -54.8 -50.8 0
+      vertex -50.1262 -7.43552 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -49.1583 -12.3029 0
+      vertex -54.8 -50.8 0
+      vertex -49.701 -9.88614 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -49.156 -12.3129 0
+      vertex -54.8 -50.8 0
+      vertex -49.1583 -12.3029 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -49.1533 -12.3228 0
+      vertex -54.8 -50.8 0
+      vertex -49.156 -12.3129 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -48.4894 -14.7198 0
+      vertex -54.8 -50.8 0
+      vertex -48.4926 -14.7101 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -47.7124 -17.0718 0
+      vertex -54.8 -50.8 0
+      vertex -48.4894 -14.7198 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -46.821 -19.3828 0
+      vertex -54.8 -50.8 0
+      vertex -47.7124 -17.0718 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -45.8135 -21.6568 0
+      vertex -54.8 -50.8 0
+      vertex -46.8173 -19.3924 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -45.8047 -21.6754 0
+      vertex -54.8 -50.8 0
+      vertex -45.8094 -21.6662 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -43.4702 -26.0431 0
+      vertex -54.8 -50.8 0
+      vertex -44.6911 -23.8879 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -43.4651 -26.052 0
+      vertex -54.8 -50.8 0
+      vertex -43.4702 -26.0431 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -43.4596 -26.0606 0
+      vertex -54.8 -50.8 0
+      vertex -43.4651 -26.052 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -40.7082 -30.1785 0
+      vertex -54.8 -50.8 0
+      vertex -42.1344 -28.1533 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -39.1784 -32.1396 0
+      vertex -54.8 -50.8 0
+      vertex -40.7023 -30.1869 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -39.1654 -32.1554 0
+      vertex -54.8 -50.8 0
+      vertex -39.1721 -32.1477 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -35.8395 -35.825 0
+      vertex -54.8 -50.8 0
+      vertex -37.5475 -34.031 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -35.825 -35.8395 0
+      vertex -54.8 -50.8 0
+      vertex -35.8324 -35.8324 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.6139 2.47624 0
+      vertex 54.8 50.8 0
+      vertex 50.6747 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.6136 2.48649 0
+      vertex 54.8 50.8 0
+      vertex 50.6139 2.47624 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.6129 2.49671 0
+      vertex 54.8 50.8 0
+      vertex 50.6136 2.48649 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.4307 4.96699 0
+      vertex 54.8 50.8 0
+      vertex 50.6129 2.49671 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.4294 4.97716 0
+      vertex 54.8 50.8 0
+      vertex 50.4307 4.96699 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.1262 7.43552 0
+      vertex 54.8 50.8 0
+      vertex 50.4294 4.97716 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 50.1244 7.44562 0
+      vertex 54.8 50.8 0
+      vertex 50.1262 7.43552 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.701 9.88614 0
+      vertex 54.8 50.8 0
+      vertex 50.1244 7.44562 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.1583 12.3029 0
+      vertex 54.8 50.8 0
+      vertex 49.701 9.88614 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.156 12.3129 0
+      vertex 54.8 50.8 0
+      vertex 49.1583 12.3029 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.1533 12.3228 0
+      vertex 54.8 50.8 0
+      vertex 49.156 12.3129 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 48.4926 14.7101 0
+      vertex 54.8 50.8 0
+      vertex 49.1533 12.3228 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 48.4894 14.7198 0
+      vertex 54.8 50.8 0
+      vertex 48.4926 14.7101 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.7124 17.0718 0
+      vertex 54.8 50.8 0
+      vertex 48.4894 14.7198 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 46.821 19.3828 0
+      vertex 54.8 50.8 0
+      vertex 47.7124 17.0718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 46.8173 19.3924 0
+      vertex 54.8 50.8 0
+      vertex 46.821 19.3828 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 45.8135 21.6568 0
+      vertex 54.8 50.8 0
+      vertex 46.8173 19.3924 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 45.8094 21.6662 0
+      vertex 54.8 50.8 0
+      vertex 45.8135 21.6568 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 45.8047 21.6754 0
+      vertex 54.8 50.8 0
+      vertex 45.8094 21.6662 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 44.6911 23.8879 0
+      vertex 54.8 50.8 0
+      vertex 45.8047 21.6754 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 43.4702 26.0431 0
+      vertex 54.8 50.8 0
+      vertex 44.6911 23.8879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 43.4651 26.052 0
+      vertex 54.8 50.8 0
+      vertex 43.4702 26.0431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 43.4596 26.0606 0
+      vertex 54.8 50.8 0
+      vertex 43.4651 26.052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 42.1344 28.1533 0
+      vertex 54.8 50.8 0
+      vertex 43.4596 26.0606 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40.7082 30.1785 0
+      vertex 54.8 50.8 0
+      vertex 42.1344 28.1533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40.7023 30.1869 0
+      vertex 54.8 50.8 0
+      vertex 40.7082 30.1785 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 39.1784 32.1396 0
+      vertex 54.8 50.8 0
+      vertex 40.7023 30.1869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 39.1721 32.1477 0
+      vertex 54.8 50.8 0
+      vertex 39.1784 32.1396 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 39.1654 32.1554 0
+      vertex 54.8 50.8 0
+      vertex 39.1721 32.1477 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 37.5475 34.031 0
+      vertex 54.8 50.8 0
+      vertex 39.1654 32.1554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.8395 35.825 0
+      vertex 54.8 50.8 0
+      vertex 37.5475 34.031 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.8324 35.8324 0
+      vertex 54.8 50.8 0
+      vertex 35.8395 35.825 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.825 35.8395 0
+      vertex 54.8 50.8 0
+      vertex 35.8324 35.8324 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34.031 37.5475 0
+      vertex 54.8 50.8 0
+      vertex 35.825 35.8395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.1554 39.1654 0
+      vertex 54.8 50.8 0
+      vertex 34.031 37.5475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.1477 39.1721 0
+      vertex 54.8 50.8 0
+      vertex 32.1554 39.1654 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.1396 39.1784 0
+      vertex 54.8 50.8 0
+      vertex 32.1477 39.1721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.1869 40.7023 0
+      vertex 54.8 50.8 0
+      vertex 32.1396 39.1784 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.1785 40.7082 0
+      vertex 54.8 50.8 0
+      vertex 30.1869 40.7023 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.1533 42.1344 0
+      vertex 54.8 50.8 0
+      vertex 30.1785 40.7082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 28.1533 42.1344 0
+      vertex 26.0606 43.4596 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 26.0606 43.4596 0
+      vertex 26.052 43.4651 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 26.052 43.4651 0
+      vertex 26.0431 43.4702 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 26.0431 43.4702 0
+      vertex 23.8879 44.6911 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 23.8879 44.6911 0
+      vertex 21.6754 45.8047 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 21.6754 45.8047 0
+      vertex 21.6662 45.8094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 21.6662 45.8094 0
+      vertex 21.6568 45.8135 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.1533 42.1344 0
+      vertex 20.5267 50.8 0
+      vertex 54.8 50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3924 46.8173 0
+      vertex 20.5267 50.8 0
+      vertex 21.6568 45.8135 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3828 46.821 0
+      vertex 20.5267 50.8 0
+      vertex 19.3924 46.8173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0718 47.7124 0
+      vertex 20.5267 50.8 0
+      vertex 19.3828 46.821 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 17.0718 47.7124 0
+      vertex 18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.0718 47.7124 0
+      vertex 15.9076 52.4403 0
+      vertex 18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7198 48.4894 0
+      vertex 15.9076 52.4403 0
+      vertex 17.0718 47.7124 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7101 48.4926 0
+      vertex 15.9076 52.4403 0
+      vertex 14.7198 48.4894 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7101 48.4926 0
+      vertex 13.3153 53.1577 0
+      vertex 15.9076 52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.3228 49.1533 0
+      vertex 13.3153 53.1577 0
+      vertex 14.7101 48.4926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.3129 49.156 0
+      vertex 13.3153 53.1577 0
+      vertex 12.3228 49.1533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.3029 49.1583 0
+      vertex 13.3153 53.1577 0
+      vertex 12.3129 49.156 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.3029 49.1583 0
+      vertex 10.6909 53.747 0
+      vertex 13.3153 53.1577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.88614 49.701 0
+      vertex 10.6909 53.747 0
+      vertex 12.3029 49.1583 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.88614 49.701 0
+      vertex 8.04083 54.2069 0
+      vertex 10.6909 53.747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.44562 50.1244 0
+      vertex 8.04083 54.2069 0
+      vertex 9.88614 49.701 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.43552 50.1262 0
+      vertex 8.04083 54.2069 0
+      vertex 7.44562 50.1244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.43552 50.1262 0
+      vertex 5.37134 54.5361 0
+      vertex 8.04083 54.2069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.97716 50.4294 0
+      vertex 5.37134 54.5361 0
+      vertex 7.43552 50.1262 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.96699 50.4307 0
+      vertex 5.37134 54.5361 0
+      vertex 4.97716 50.4294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.96699 50.4307 0
+      vertex 2.68891 54.734 0
+      vertex 5.37134 54.5361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.49671 50.6129 0
+      vertex 2.68891 54.734 0
+      vertex 4.96699 50.4307 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.48649 50.6136 0
+      vertex 2.68891 54.734 0
+      vertex 2.49671 50.6129 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.47624 50.6139 0
+      vertex 2.68891 54.734 0
+      vertex 2.48649 50.6136 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 50.6747 0
+      vertex 2.68891 54.734 0
+      vertex 2.47624 50.6139 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 50.6747 0
+      vertex 0 54.8 0
+      vertex 2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.47624 50.6139 0
+      vertex 0 54.8 0
+      vertex 0 50.6747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.68891 54.734 0
+      vertex -2.47624 50.6139 0
+      vertex -2.48649 50.6136 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.68891 54.734 0
+      vertex -2.48649 50.6136 0
+      vertex -2.49671 50.6129 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.47624 50.6139 0
+      vertex -2.68891 54.734 0
+      vertex 0 54.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.96699 50.4307 0
+      vertex -2.68891 54.734 0
+      vertex -2.49671 50.6129 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.37134 54.5361 0
+      vertex -4.96699 50.4307 0
+      vertex -4.97716 50.4294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.96699 50.4307 0
+      vertex -5.37134 54.5361 0
+      vertex -2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.43552 50.1262 0
+      vertex -5.37134 54.5361 0
+      vertex -4.97716 50.4294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.04083 54.2069 0
+      vertex -7.43552 50.1262 0
+      vertex -7.44562 50.1244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.43552 50.1262 0
+      vertex -8.04083 54.2069 0
+      vertex -5.37134 54.5361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.88614 49.701 0
+      vertex -8.04083 54.2069 0
+      vertex -7.44562 50.1244 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.88614 49.701 0
+      vertex -10.6909 53.747 0
+      vertex -8.04083 54.2069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3029 49.1583 0
+      vertex -10.6909 53.747 0
+      vertex -9.88614 49.701 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.3153 53.1577 0
+      vertex -12.3029 49.1583 0
+      vertex -12.3129 49.156 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.3153 53.1577 0
+      vertex -12.3129 49.156 0
+      vertex -12.3228 49.1533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.3029 49.1583 0
+      vertex -13.3153 53.1577 0
+      vertex -10.6909 53.747 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7101 48.4926 0
+      vertex -13.3153 53.1577 0
+      vertex -12.3228 49.1533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9076 52.4403 0
+      vertex -14.7101 48.4926 0
+      vertex -14.7198 48.4894 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7101 48.4926 0
+      vertex -15.9076 52.4403 0
+      vertex -13.3153 53.1577 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0718 47.7124 0
+      vertex -15.9076 52.4403 0
+      vertex -14.7198 48.4894 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0718 47.7124 0
+      vertex -18.4616 51.5966 0
+      vertex -15.9076 52.4403 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 50.8 0
+      vertex -17.0718 47.7124 0
+      vertex -19.3828 46.821 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.5267 50.8 0
+      vertex -19.3828 46.821 0
+      vertex -19.3924 46.8173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.0718 47.7124 0
+      vertex -20.5267 50.8 0
+      vertex -18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.6568 45.8135 0
+      vertex -20.5267 50.8 0
+      vertex -19.3924 46.8173 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.6662 45.8094 0
+      vertex -20.5267 50.8 0
+      vertex -21.6568 45.8135 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.6754 45.8047 0
+      vertex -20.5267 50.8 0
+      vertex -21.6662 45.8094 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.8879 44.6911 0
+      vertex -20.5267 50.8 0
+      vertex -21.6754 45.8047 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.0431 43.4702 0
+      vertex -20.5267 50.8 0
+      vertex -23.8879 44.6911 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.052 43.4651 0
+      vertex -20.5267 50.8 0
+      vertex -26.0431 43.4702 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.0606 43.4596 0
+      vertex -20.5267 50.8 0
+      vertex -26.052 43.4651 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.1533 42.1344 0
+      vertex -20.5267 50.8 0
+      vertex -26.0606 43.4596 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -28.1533 42.1344 0
+      vertex -30.1785 40.7082 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -30.1785 40.7082 0
+      vertex -30.1869 40.7023 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -30.1869 40.7023 0
+      vertex -32.1396 39.1784 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -32.1396 39.1784 0
+      vertex -32.1477 39.1721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -32.1477 39.1721 0
+      vertex -32.1554 39.1654 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -32.1554 39.1654 0
+      vertex -34.031 37.5475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -34.031 37.5475 0
+      vertex -35.825 35.8395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -35.825 35.8395 0
+      vertex -35.8324 35.8324 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -35.8395 35.825 0
+      vertex -37.5475 34.031 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -39.1654 32.1554 0
+      vertex -39.1721 32.1477 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -39.1784 32.1396 0
+      vertex -40.7023 30.1869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -40.7082 30.1785 0
+      vertex -42.1344 28.1533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -43.4596 26.0606 0
+      vertex -43.4651 26.052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -45.8047 21.6754 0
+      vertex -45.8094 21.6662 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -45.8135 21.6568 0
+      vertex -46.8173 19.3924 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -46.821 19.3828 0
+      vertex -47.7124 17.0718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -49.1533 12.3228 0
+      vertex -49.156 12.3129 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -50.1244 7.44562 0
+      vertex -50.1262 7.43552 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -50.4294 4.97716 0
+      vertex -50.4307 4.96699 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.6136 2.48649 0
+      vertex -50.4307 4.96699 0
+      vertex -50.6129 2.49671 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -50.6747 0 0
+      vertex -54.8 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.6747 0 0
+      vertex -54.8 50.8 0
+      vertex -50.6139 2.47624 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.6139 2.47624 0
+      vertex -54.8 50.8 0
+      vertex -50.6136 2.48649 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.1533 42.1344 0
+      vertex -54.8 50.8 0
+      vertex -20.5267 50.8 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.8395 35.825 0
+      vertex -54.8 50.8 0
+      vertex -35.8324 35.8324 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -39.1654 32.1554 0
+      vertex -54.8 50.8 0
+      vertex -37.5475 34.031 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -39.1784 32.1396 0
+      vertex -54.8 50.8 0
+      vertex -39.1721 32.1477 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -40.7082 30.1785 0
+      vertex -54.8 50.8 0
+      vertex -40.7023 30.1869 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -43.4596 26.0606 0
+      vertex -54.8 50.8 0
+      vertex -42.1344 28.1533 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -43.4702 26.0431 0
+      vertex -54.8 50.8 0
+      vertex -43.4651 26.052 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.6911 23.8879 0
+      vertex -54.8 50.8 0
+      vertex -43.4702 26.0431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -45.8047 21.6754 0
+      vertex -54.8 50.8 0
+      vertex -44.6911 23.8879 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -45.8135 21.6568 0
+      vertex -54.8 50.8 0
+      vertex -45.8094 21.6662 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -46.821 19.3828 0
+      vertex -54.8 50.8 0
+      vertex -46.8173 19.3924 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -48.4894 14.7198 0
+      vertex -54.8 50.8 0
+      vertex -47.7124 17.0718 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -48.4926 14.7101 0
+      vertex -54.8 50.8 0
+      vertex -48.4894 14.7198 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -49.1533 12.3228 0
+      vertex -54.8 50.8 0
+      vertex -48.4926 14.7101 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -49.1583 12.3029 0
+      vertex -54.8 50.8 0
+      vertex -49.156 12.3129 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -49.701 9.88614 0
+      vertex -54.8 50.8 0
+      vertex -49.1583 12.3029 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.1244 7.44562 0
+      vertex -54.8 50.8 0
+      vertex -49.701 9.88614 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.4294 4.97716 0
+      vertex -54.8 50.8 0
+      vertex -50.1262 7.43552 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.6136 2.48649 0
+      vertex -54.8 50.8 0
+      vertex -50.4307 4.96699 0
+    endloop
+  endfacet
+  facet normal -0.121415 0.984578 0.125951
+    outer loop
+      vertex -5.37134 54.5361 0
+      vertex -7.66813 51.6944 20
+      vertex -5.35458 51.9797 20
+    endloop
+  endfacet
+  facet normal -0.121418 0.984578 0.12595
+    outer loop
+      vertex -7.66813 51.6944 20
+      vertex -5.37134 54.5361 0
+      vertex -8.04083 54.2069 0
+    endloop
+  endfacet
+  facet normal -0.0729423 -0.989352 0.125947
+    outer loop
+      vertex -5.37134 -54.5361 0
+      vertex -2.7976 -52.1798 20
+      vertex -5.12238 -52.0084 20
+    endloop
+  endfacet
+  facet normal -0.0729905 -0.989347 0.125953
+    outer loop
+      vertex -2.7976 -52.1798 20
+      vertex -5.37134 -54.5361 0
+      vertex -2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal 0.311181 -0.941968 0.125949
+    outer loop
+      vertex 15.9076 -52.4403 0
+      vertex 18.1765 -50.8 6.66199
+      vertex 15.5701 -50.8 13.1016
+    endloop
+  endfacet
+  facet normal 0.311175 -0.94197 0.125952
+    outer loop
+      vertex 18.1765 -50.8 6.66199
+      vertex 15.9076 -52.4403 0
+      vertex 18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal -0.0243425 -0.991738 0.125951
+    outer loop
+      vertex 0 -54.8 0
+      vertex -2.33039 -52.2028 20
+      vertex -2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal -0.0243425 -0.991738 0.125951
+    outer loop
+      vertex -2.33039 -52.2028 20
+      vertex 0 -54.8 0
+      vertex 0 -52.26 20
+    endloop
+  endfacet
+  facet normal 0.264491 0.956128 0.125951
+    outer loop
+      vertex 13.3153 53.1577 0
+      vertex 12.7247 50.8 19.1382
+      vertex 12.9498 50.8 18.6655
+    endloop
+  endfacet
+  facet normal -0.217364 0.967932 0.125934
+    outer loop
+      vertex -10.4237 51.2046 20
+      vertex -12.7247 50.8 19.1382
+      vertex -12.2254 50.8 20
+    endloop
+  endfacet
+  facet normal -0.217369 0.96793 0.125947
+    outer loop
+      vertex -10.6909 53.747 0
+      vertex -12.7247 50.8 19.1382
+      vertex -10.4237 51.2046 20
+    endloop
+  endfacet
+  facet normal -0.217346 0.967934 0.12595
+    outer loop
+      vertex -12.7247 50.8 19.1382
+      vertex -10.6909 53.747 0
+      vertex -13.3153 53.1577 0
+    endloop
+  endfacet
+  facet normal 0.311175 0.94197 0.125952
+    outer loop
+      vertex 15.9076 52.4403 0
+      vertex 18.1765 50.8 6.66199
+      vertex 18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0.311181 0.941968 0.125949
+    outer loop
+      vertex 18.1765 50.8 6.66199
+      vertex 15.9076 52.4403 0
+      vertex 15.5701 50.8 13.1016
+    endloop
+  endfacet
+  facet normal 0.26459 -0.956101 0.125949
+    outer loop
+      vertex 13.3153 -53.1577 0
+      vertex 15.41 -50.8 13.4972
+      vertex 12.9498 -50.8 18.6655
+    endloop
+  endfacet
+  facet normal 0.264594 -0.9561 0.125949
+    outer loop
+      vertex 15.41 -50.8 13.4972
+      vertex 13.3153 -53.1577 0
+      vertex 15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal -0.169619 -0.977428 0.125951
+    outer loop
+      vertex -10.1954 -51.2558 20
+      vertex -10.6909 -53.747 0
+      vertex -9.9649 -51.2958 20
+    endloop
+  endfacet
+  facet normal -0.311181 0.941968 0.125949
+    outer loop
+      vertex -15.9076 52.4403 0
+      vertex -18.1765 50.8 6.66199
+      vertex -15.5701 50.8 13.1016
+    endloop
+  endfacet
+  facet normal -0.311175 0.94197 0.125952
+    outer loop
+      vertex -18.1765 50.8 6.66199
+      vertex -15.9076 52.4403 0
+      vertex -18.4616 51.5966 0
+    endloop
+  endfacet
+  facet normal 0.311213 -0.941957 0.125948
+    outer loop
+      vertex 15.5701 -50.8 13.1016
+      vertex 15.41 -50.8 13.4972
+      vertex 15.9076 -52.4403 0
+    endloop
+  endfacet
+  facet normal -0.264491 0.956128 0.125951
+    outer loop
+      vertex -12.7247 50.8 19.1382
+      vertex -13.3153 53.1577 0
+      vertex -12.9498 50.8 18.6655
+    endloop
+  endfacet
+  facet normal 0.35703 0.925562 0.125952
+    outer loop
+      vertex 18.4616 51.5966 0
+      vertex 18.1765 50.8 6.66199
+      vertex 20.5267 50.8 0
+    endloop
+  endfacet
+  facet normal -0.35703 0.925562 0.125952
+    outer loop
+      vertex -18.4616 51.5966 0
+      vertex -20.5267 50.8 0
+      vertex -18.1765 50.8 6.66199
+    endloop
+  endfacet
+  facet normal 0.0729423 -0.989351 0.125954
+    outer loop
+      vertex 2.68891 -54.734 0
+      vertex 5.12238 -52.0084 20
+      vertex 2.7976 -52.1798 20
+    endloop
+  endfacet
+  facet normal 0.0729905 -0.989348 0.125947
+    outer loop
+      vertex 5.12238 -52.0084 20
+      vertex 2.68891 -54.734 0
+      vertex 5.37134 -54.5361 0
+    endloop
+  endfacet
+  facet normal 0.217088 -0.967992 0.125951
+    outer loop
+      vertex 10.4237 -51.2046 20
+      vertex 10.1954 -51.2558 20
+      vertex 10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal -0.121418 -0.984578 0.12595
+    outer loop
+      vertex -5.37134 -54.5361 0
+      vertex -7.66813 -51.6944 20
+      vertex -8.04083 -54.2069 0
+    endloop
+  endfacet
+  facet normal -0.121415 -0.984578 0.125951
+    outer loop
+      vertex -7.66813 -51.6944 20
+      vertex -5.37134 -54.5361 0
+      vertex -5.35458 -51.9797 20
+    endloop
+  endfacet
+  facet normal -0.12169 -0.984545 0.125947
+    outer loop
+      vertex -5.35458 -51.9797 20
+      vertex -5.37134 -54.5361 0
+      vertex -5.12238 -52.0084 20
+    endloop
+  endfacet
+  facet normal 0.311213 0.941957 0.125948
+    outer loop
+      vertex 15.9076 52.4403 0
+      vertex 15.41 50.8 13.4972
+      vertex 15.5701 50.8 13.1016
+    endloop
+  endfacet
+  facet normal 0.217088 0.967992 0.125951
+    outer loop
+      vertex 10.6909 53.747 0
+      vertex 10.1954 51.2558 20
+      vertex 10.4237 51.2046 20
+    endloop
+  endfacet
+  facet normal 0.121415 -0.984578 0.125951
+    outer loop
+      vertex 5.37134 -54.5361 0
+      vertex 7.66813 -51.6944 20
+      vertex 5.35458 -51.9797 20
+    endloop
+  endfacet
+  facet normal 0.121418 -0.984578 0.12595
+    outer loop
+      vertex 7.66813 -51.6944 20
+      vertex 5.37134 -54.5361 0
+      vertex 8.04083 -54.2069 0
+    endloop
+  endfacet
+  facet normal -0.311213 -0.941957 0.125948
+    outer loop
+      vertex -15.5701 -50.8 13.1016
+      vertex -15.9076 -52.4403 0
+      vertex -15.41 -50.8 13.4972
+    endloop
+  endfacet
+  facet normal -0.169619 0.977428 0.125951
+    outer loop
+      vertex -9.9649 51.2958 20
+      vertex -10.6909 53.747 0
+      vertex -10.1954 51.2558 20
+    endloop
+  endfacet
+  facet normal -0.217088 -0.967992 0.125951
+    outer loop
+      vertex -10.4237 -51.2046 20
+      vertex -10.6909 -53.747 0
+      vertex -10.1954 -51.2558 20
+    endloop
+  endfacet
+  facet normal 0.12169 -0.984545 0.125947
+    outer loop
+      vertex 5.35458 -51.9797 20
+      vertex 5.12238 -52.0084 20
+      vertex 5.37134 -54.5361 0
+    endloop
+  endfacet
+  facet normal 0.0729423 0.989352 0.125947
+    outer loop
+      vertex 5.37134 54.5361 0
+      vertex 2.7976 52.1798 20
+      vertex 5.12238 52.0084 20
+    endloop
+  endfacet
+  facet normal 0.0729905 0.989347 0.125953
+    outer loop
+      vertex 2.7976 52.1798 20
+      vertex 5.37134 54.5361 0
+      vertex 2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal 0.169619 -0.977428 0.125951
+    outer loop
+      vertex 10.1954 -51.2558 20
+      vertex 9.9649 -51.2958 20
+      vertex 10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal 0.264594 0.9561 0.125949
+    outer loop
+      vertex 13.3153 53.1577 0
+      vertex 15.41 50.8 13.4972
+      vertex 15.9076 52.4403 0
+    endloop
+  endfacet
+  facet normal 0.26459 0.956101 0.125949
+    outer loop
+      vertex 15.41 50.8 13.4972
+      vertex 13.3153 53.1577 0
+      vertex 12.9498 50.8 18.6655
+    endloop
+  endfacet
+  facet normal -0.35703 -0.925562 0.125952
+    outer loop
+      vertex -18.1765 -50.8 6.66199
+      vertex -20.5267 -50.8 0
+      vertex -18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal 0.121418 0.984578 0.12595
+    outer loop
+      vertex 5.37134 54.5361 0
+      vertex 7.66813 51.6944 20
+      vertex 8.04083 54.2069 0
+    endloop
+  endfacet
+  facet normal 0.121415 0.984578 0.125951
+    outer loop
+      vertex 7.66813 51.6944 20
+      vertex 5.37134 54.5361 0
+      vertex 5.35458 51.9797 20
+    endloop
+  endfacet
+  facet normal -0.311213 0.941957 0.125948
+    outer loop
+      vertex -15.41 50.8 13.4972
+      vertex -15.9076 52.4403 0
+      vertex -15.5701 50.8 13.1016
+    endloop
+  endfacet
+  facet normal -0.0733553 0.989321 0.125948
+    outer loop
+      vertex -2.68891 54.734 0
+      vertex -2.7976 52.1798 20
+      vertex -2.56428 52.1971 20
+    endloop
+  endfacet
+  facet normal 0.16963 -0.977426 0.12595
+    outer loop
+      vertex 8.04083 -54.2069 0
+      vertex 9.9649 -51.2958 20
+      vertex 7.66813 -51.6944 20
+    endloop
+  endfacet
+  facet normal 0.169625 -0.977427 0.125951
+    outer loop
+      vertex 9.9649 -51.2958 20
+      vertex 8.04083 -54.2069 0
+      vertex 10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal -0.217364 -0.967932 0.125934
+    outer loop
+      vertex -12.7247 -50.8 19.1382
+      vertex -10.4237 -51.2046 20
+      vertex -12.2254 -50.8 20
+    endloop
+  endfacet
+  facet normal -0.217346 -0.967934 0.12595
+    outer loop
+      vertex -10.6909 -53.747 0
+      vertex -12.7247 -50.8 19.1382
+      vertex -13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal -0.217369 -0.96793 0.125947
+    outer loop
+      vertex -12.7247 -50.8 19.1382
+      vertex -10.6909 -53.747 0
+      vertex -10.4237 -51.2046 20
+    endloop
+  endfacet
+  facet normal -0.169625 -0.977427 0.125951
+    outer loop
+      vertex -8.04083 -54.2069 0
+      vertex -9.9649 -51.2958 20
+      vertex -10.6909 -53.747 0
+    endloop
+  endfacet
+  facet normal -0.16963 -0.977426 0.12595
+    outer loop
+      vertex -9.9649 -51.2958 20
+      vertex -8.04083 -54.2069 0
+      vertex -7.66813 -51.6944 20
+    endloop
+  endfacet
+  facet normal -0.0733553 -0.989321 0.125948
+    outer loop
+      vertex -2.56428 -52.1971 20
+      vertex -2.7976 -52.1798 20
+      vertex -2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal 0.0241692 0.991742 0.125948
+    outer loop
+      vertex 2.68891 54.734 0
+      vertex 2.33039 52.2028 20
+      vertex 2.56428 52.1971 20
+    endloop
+  endfacet
+  facet normal -0.0243425 0.991738 0.125951
+    outer loop
+      vertex 0 54.8 0
+      vertex -2.33039 52.2028 20
+      vertex 0 52.26 20
+    endloop
+  endfacet
+  facet normal -0.0243425 0.991738 0.125951
+    outer loop
+      vertex -2.33039 52.2028 20
+      vertex 0 54.8 0
+      vertex -2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal 0.35703 -0.925562 0.125952
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 18.1765 -50.8 6.66199
+      vertex 18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal 0.12169 0.984545 0.125947
+    outer loop
+      vertex 5.37134 54.5361 0
+      vertex 5.12238 52.0084 20
+      vertex 5.35458 51.9797 20
+    endloop
+  endfacet
+  facet normal 0.0243425 0.991738 0.125951
+    outer loop
+      vertex 0 54.8 0
+      vertex 2.33039 52.2028 20
+      vertex 2.68891 54.734 0
+    endloop
+  endfacet
+  facet normal 0.0243425 0.991738 0.125951
+    outer loop
+      vertex 2.33039 52.2028 20
+      vertex 0 54.8 0
+      vertex 0 52.26 20
+    endloop
+  endfacet
+  facet normal -0.0729423 0.989351 0.125954
+    outer loop
+      vertex -2.68891 54.734 0
+      vertex -5.12238 52.0084 20
+      vertex -2.7976 52.1798 20
+    endloop
+  endfacet
+  facet normal -0.0729905 0.989348 0.125947
+    outer loop
+      vertex -5.12238 52.0084 20
+      vertex -2.68891 54.734 0
+      vertex -5.37134 54.5361 0
+    endloop
+  endfacet
+  facet normal 0.0733553 0.989321 0.125948
+    outer loop
+      vertex 2.68891 54.734 0
+      vertex 2.56428 52.1971 20
+      vertex 2.7976 52.1798 20
+    endloop
+  endfacet
+  facet normal 0.0241692 -0.991742 0.125948
+    outer loop
+      vertex 2.56428 -52.1971 20
+      vertex 2.33039 -52.2028 20
+      vertex 2.68891 -54.734 0
+    endloop
+  endfacet
+  facet normal 0.264491 -0.956128 0.125951
+    outer loop
+      vertex 12.9498 -50.8 18.6655
+      vertex 12.7247 -50.8 19.1382
+      vertex 13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal -0.12169 0.984545 0.125947
+    outer loop
+      vertex -5.12238 52.0084 20
+      vertex -5.37134 54.5361 0
+      vertex -5.35458 51.9797 20
+    endloop
+  endfacet
+  facet normal -0.311175 -0.94197 0.125952
+    outer loop
+      vertex -15.9076 -52.4403 0
+      vertex -18.1765 -50.8 6.66199
+      vertex -18.4616 -51.5966 0
+    endloop
+  endfacet
+  facet normal -0.311181 -0.941968 0.125949
+    outer loop
+      vertex -18.1765 -50.8 6.66199
+      vertex -15.9076 -52.4403 0
+      vertex -15.5701 -50.8 13.1016
+    endloop
+  endfacet
+  facet normal -0.264491 -0.956128 0.125951
+    outer loop
+      vertex -12.9498 -50.8 18.6655
+      vertex -13.3153 -53.1577 0
+      vertex -12.7247 -50.8 19.1382
+    endloop
+  endfacet
+  facet normal 0.217364 -0.967932 0.125934
+    outer loop
+      vertex 10.4237 -51.2046 20
+      vertex 12.7247 -50.8 19.1382
+      vertex 12.2254 -50.8 20
+    endloop
+  endfacet
+  facet normal 0.217369 -0.96793 0.125947
+    outer loop
+      vertex 10.6909 -53.747 0
+      vertex 12.7247 -50.8 19.1382
+      vertex 10.4237 -51.2046 20
+    endloop
+  endfacet
+  facet normal 0.217346 -0.967934 0.12595
+    outer loop
+      vertex 12.7247 -50.8 19.1382
+      vertex 10.6909 -53.747 0
+      vertex 13.3153 -53.1577 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 54.8 50.8 0
+      vertex 54.8 50.8 20
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 54.8 -10.4701 20
+      vertex 54.8 50.8 0
+      vertex 54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 54.8 -50.8 0
+      vertex 54.8 -10.4701 20
+      vertex 54.8 -50.8 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 54.8 -10.4701 20
+      vertex 54.8 -50.8 0
+      vertex 54.8 50.8 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -23.8576 50.4426 20
+      vertex -23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -26.3039 49.2112 20
+      vertex -23.8576 50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -28.6869 47.8613 20
+      vertex -26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -31.0008 46.396 20
+      vertex -28.6869 47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -33.24 44.819 20
+      vertex -31.0008 46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -35.3991 43.134 20
+      vertex -33.24 44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -37.473 41.3451 20
+      vertex -35.3991 43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -39.4566 39.4566 20
+      vertex -37.473 41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -41.3451 37.473 20
+      vertex -39.4566 39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -43.134 35.3991 20
+      vertex -41.3451 37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -44.819 33.24 20
+      vertex -43.134 35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -46.396 31.0008 20
+      vertex -44.819 33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -47.8613 28.6869 20
+      vertex -46.396 31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -49.2112 26.3039 20
+      vertex -47.8613 28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -50.4426 23.8576 20
+      vertex -49.2112 26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -51.5525 21.3537 20
+      vertex -50.4426 23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -52.5382 18.7985 20
+      vertex -51.5525 21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -53.3973 16.1979 20
+      vertex -52.5382 18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -54.1277 13.5583 20
+      vertex -53.3973 16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 50.8 20
+      vertex -54.7278 10.886 20
+      vertex -54.1277 13.5583 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.7278 10.886 20
+      vertex -54.8 50.8 20
+      vertex -54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 54.7278 10.886 20
+      vertex 54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 54.1277 13.5583 20
+      vertex 54.7278 10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 53.3973 16.1979 20
+      vertex 54.1277 13.5583 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 52.5382 18.7985 20
+      vertex 53.3973 16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 51.5525 21.3537 20
+      vertex 52.5382 18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 50.4426 23.8576 20
+      vertex 51.5525 21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 49.2112 26.3039 20
+      vertex 50.4426 23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 47.8613 28.6869 20
+      vertex 49.2112 26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 46.396 31.0008 20
+      vertex 47.8613 28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 44.819 33.24 20
+      vertex 46.396 31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 43.134 35.3991 20
+      vertex 44.819 33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 41.3451 37.473 20
+      vertex 43.134 35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 39.4566 39.4566 20
+      vertex 41.3451 37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 37.473 41.3451 20
+      vertex 39.4566 39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 35.3991 43.134 20
+      vertex 37.473 41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 33.24 44.819 20
+      vertex 35.3991 43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 31.0008 46.396 20
+      vertex 33.24 44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 28.6869 47.8613 20
+      vertex 31.0008 46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 26.3039 49.2112 20
+      vertex 28.6869 47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 50.8 20
+      vertex 23.8576 50.4426 20
+      vertex 26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 23.8576 50.4426 20
+      vertex 54.8 50.8 20
+      vertex 23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.8576 -50.4426 20
+      vertex -54.8 -50.8 20
+      vertex -23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.3039 -49.2112 20
+      vertex -54.8 -50.8 20
+      vertex -23.8576 -50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.6869 -47.8613 20
+      vertex -54.8 -50.8 20
+      vertex -26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.0008 -46.396 20
+      vertex -54.8 -50.8 20
+      vertex -28.6869 -47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.24 -44.819 20
+      vertex -54.8 -50.8 20
+      vertex -31.0008 -46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.3991 -43.134 20
+      vertex -54.8 -50.8 20
+      vertex -33.24 -44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.473 -41.3451 20
+      vertex -54.8 -50.8 20
+      vertex -35.3991 -43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -39.4566 -39.4566 20
+      vertex -54.8 -50.8 20
+      vertex -37.473 -41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.3451 -37.473 20
+      vertex -54.8 -50.8 20
+      vertex -39.4566 -39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.134 -35.3991 20
+      vertex -54.8 -50.8 20
+      vertex -41.3451 -37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.819 -33.24 20
+      vertex -54.8 -50.8 20
+      vertex -43.134 -35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.396 -31.0008 20
+      vertex -54.8 -50.8 20
+      vertex -44.819 -33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.8613 -28.6869 20
+      vertex -54.8 -50.8 20
+      vertex -46.396 -31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.2112 -26.3039 20
+      vertex -54.8 -50.8 20
+      vertex -47.8613 -28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.4426 -23.8576 20
+      vertex -54.8 -50.8 20
+      vertex -49.2112 -26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -51.5525 -21.3537 20
+      vertex -54.8 -50.8 20
+      vertex -50.4426 -23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -52.5382 -18.7985 20
+      vertex -54.8 -50.8 20
+      vertex -51.5525 -21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -53.3973 -16.1979 20
+      vertex -54.8 -50.8 20
+      vertex -52.5382 -18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.1277 -13.5583 20
+      vertex -54.8 -50.8 20
+      vertex -53.3973 -16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.7278 -10.886 20
+      vertex -54.8 -50.8 20
+      vertex -54.1277 -13.5583 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -50.8 20
+      vertex -54.7278 -10.886 20
+      vertex -54.8 -10.4701 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 54.7278 -10.886 20
+      vertex 54.8 -50.8 20
+      vertex 54.8 -10.4701 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 54.1277 -13.5583 20
+      vertex 54.8 -50.8 20
+      vertex 54.7278 -10.886 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 53.3973 -16.1979 20
+      vertex 54.8 -50.8 20
+      vertex 54.1277 -13.5583 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 52.5382 -18.7985 20
+      vertex 54.8 -50.8 20
+      vertex 53.3973 -16.1979 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 51.5525 -21.3537 20
+      vertex 54.8 -50.8 20
+      vertex 52.5382 -18.7985 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 50.4426 -23.8576 20
+      vertex 54.8 -50.8 20
+      vertex 51.5525 -21.3537 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 49.2112 -26.3039 20
+      vertex 54.8 -50.8 20
+      vertex 50.4426 -23.8576 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 47.8613 -28.6869 20
+      vertex 54.8 -50.8 20
+      vertex 49.2112 -26.3039 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 46.396 -31.0008 20
+      vertex 54.8 -50.8 20
+      vertex 47.8613 -28.6869 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 44.819 -33.24 20
+      vertex 54.8 -50.8 20
+      vertex 46.396 -31.0008 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 43.134 -35.3991 20
+      vertex 54.8 -50.8 20
+      vertex 44.819 -33.24 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 41.3451 -37.473 20
+      vertex 54.8 -50.8 20
+      vertex 43.134 -35.3991 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 39.4566 -39.4566 20
+      vertex 54.8 -50.8 20
+      vertex 41.3451 -37.473 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 37.473 -41.3451 20
+      vertex 54.8 -50.8 20
+      vertex 39.4566 -39.4566 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35.3991 -43.134 20
+      vertex 54.8 -50.8 20
+      vertex 37.473 -41.3451 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 33.24 -44.819 20
+      vertex 54.8 -50.8 20
+      vertex 35.3991 -43.134 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 31.0008 -46.396 20
+      vertex 54.8 -50.8 20
+      vertex 33.24 -44.819 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 28.6869 -47.8613 20
+      vertex 54.8 -50.8 20
+      vertex 31.0008 -46.396 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.3039 -49.2112 20
+      vertex 54.8 -50.8 20
+      vertex 28.6869 -47.8613 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.8576 -50.4426 20
+      vertex 54.8 -50.8 20
+      vertex 26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 -50.8 20
+      vertex 23.8576 -50.4426 20
+      vertex 23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 47.2426 9.39713 20
+      vertex 54.8 10.4701 20
+      vertex 54.7278 10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 48.1681 0 20
+      vertex 54.8 -10.4701 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 46.7717 11.4938 20
+      vertex 54.7278 10.886 20
+      vertex 54.1277 13.5583 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 48.1154 -2.14826 20
+      vertex 54.8 -10.4701 20
+      vertex 48.1681 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 46.6671 11.9114 20
+      vertex 54.1277 13.5583 20
+      vertex 53.3973 16.1979 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 48.1101 -2.3635 20
+      vertex 54.8 -10.4701 20
+      vertex 48.1154 -2.14826 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 46.0265 14.1869 20
+      vertex 53.3973 16.1979 20
+      vertex 52.5382 18.7985 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 48.0942 -2.57821 20
+      vertex 54.8 -10.4701 20
+      vertex 48.1101 -2.3635 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 44.579 18.2323 20
+      vertex 52.5382 18.7985 20
+      vertex 51.5525 21.3537 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 47.9361 -4.7213 20
+      vertex 54.8 -10.4701 20
+      vertex 48.0942 -2.57821 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.6307 20.3977 20
+      vertex 51.5525 21.3537 20
+      vertex 50.4426 23.8576 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 47.9098 -4.93498 20
+      vertex 54.8 -10.4701 20
+      vertex 47.9361 -4.7213 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.4466 20.7868 20
+      vertex 50.4426 23.8576 20
+      vertex 49.2112 26.3039 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 47.6467 -7.06773 20
+      vertex 54.8 -10.4701 20
+      vertex 47.9098 -4.93498 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 47.6099 -7.27986 20
+      vertex 54.8 -10.4701 20
+      vertex 47.6467 -7.06773 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 48.1154 2.14826 20
+      vertex 48.1681 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 48.1101 2.3635 20
+      vertex 48.1154 2.14826 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 48.0942 2.57821 20
+      vertex 48.1101 2.3635 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 47.9361 4.7213 20
+      vertex 48.0942 2.57821 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 47.9098 4.93498 20
+      vertex 47.9361 4.7213 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.4213 24.576 20
+      vertex 49.2112 26.3039 20
+      vertex 47.8613 28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 47.6467 7.06773 20
+      vertex 47.9098 4.93498 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 47.6099 7.27986 20
+      vertex 47.6467 7.06773 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 10.4701 20
+      vertex 47.2426 9.39713 20
+      vertex 47.6099 7.27986 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.7278 10.886 20
+      vertex 46.7717 11.4938 20
+      vertex 47.2426 9.39713 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.1277 13.5583 20
+      vertex 46.7246 11.7039 20
+      vertex 46.7717 11.4938 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.1277 13.5583 20
+      vertex 46.6671 11.9114 20
+      vertex 46.7246 11.7039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.2 24.9452 20
+      vertex 47.8613 28.6869 20
+      vertex 46.396 31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 53.3973 16.1979 20
+      vertex 46.094 13.9825 20
+      vertex 46.6671 11.9114 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 53.3973 16.1979 20
+      vertex 46.0265 14.1869 20
+      vertex 46.094 13.9825 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 52.5382 18.7985 20
+      vertex 45.3524 16.2273 20
+      vertex 46.0265 14.1869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.8129 28.5177 20
+      vertex 46.396 31.0008 20
+      vertex 44.819 33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 52.5382 18.7985 20
+      vertex 44.579 18.2323 20
+      vertex 45.3524 16.2273 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.5525 21.3537 20
+      vertex 44.5015 18.4331 20
+      vertex 44.579 18.2323 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.5525 21.3537 20
+      vertex 43.6307 20.3977 20
+      vertex 44.5015 18.4331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 50.4426 23.8576 20
+      vertex 43.5434 20.5945 20
+      vertex 43.6307 20.3977 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 50.4426 23.8576 20
+      vertex 43.4466 20.7868 20
+      vertex 43.5434 20.5945 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 37.3669 30.3878 20
+      vertex 44.819 33.24 20
+      vertex 43.134 35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.2112 26.3039 20
+      vertex 42.4805 22.7063 20
+      vertex 43.4466 20.7868 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.2112 26.3039 20
+      vertex 41.4213 24.576 20
+      vertex 42.4805 22.7063 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 37.0938 30.7205 20
+      vertex 43.134 35.3991 20
+      vertex 41.3451 37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 47.8613 28.6869 20
+      vertex 41.3152 24.7633 20
+      vertex 41.4213 24.576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 47.8613 28.6869 20
+      vertex 41.2 24.9452 20
+      vertex 41.3152 24.7633 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 46.396 31.0008 20
+      vertex 40.0503 26.7608 20
+      vertex 41.2 24.9452 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.2084 33.9041 20
+      vertex 41.3451 37.473 20
+      vertex 39.4566 39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 46.396 31.0008 20
+      vertex 38.8129 28.5177 20
+      vertex 40.0503 26.7608 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 44.819 33.24 20
+      vertex 38.689 28.6937 20
+      vertex 38.8129 28.5177 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.9041 34.2084 20
+      vertex 39.4566 39.4566 20
+      vertex 37.473 41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 44.819 33.24 20
+      vertex 37.3669 30.3878 20
+      vertex 38.689 28.6937 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.134 35.3991 20
+      vertex 37.2344 30.5575 20
+      vertex 37.3669 30.3878 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.134 35.3991 20
+      vertex 37.0938 30.7205 20
+      vertex 37.2344 30.5575 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.3451 37.473 20
+      vertex 35.6902 32.3477 20
+      vertex 37.0938 30.7205 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.7205 37.0938 20
+      vertex 37.473 41.3451 20
+      vertex 35.3991 43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.3451 37.473 20
+      vertex 34.2084 33.9041 20
+      vertex 35.6902 32.3477 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.4566 39.4566 20
+      vertex 34.06 34.06 20
+      vertex 34.2084 33.9041 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.4566 39.4566 20
+      vertex 33.9041 34.2084 20
+      vertex 34.06 34.06 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.3878 37.3669 20
+      vertex 35.3991 43.134 20
+      vertex 33.24 44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 37.473 41.3451 20
+      vertex 32.3477 35.6902 20
+      vertex 33.9041 34.2084 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.5177 38.8129 20
+      vertex 33.24 44.819 20
+      vertex 31.0008 46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 37.473 41.3451 20
+      vertex 30.7205 37.0938 20
+      vertex 32.3477 35.6902 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.3991 43.134 20
+      vertex 30.5575 37.2344 20
+      vertex 30.7205 37.0938 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.3991 43.134 20
+      vertex 30.3878 37.3669 20
+      vertex 30.5575 37.2344 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.24 44.819 20
+      vertex 28.6937 38.689 20
+      vertex 30.3878 37.3669 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.9452 41.2 20
+      vertex 31.0008 46.396 20
+      vertex 28.6869 47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.24 44.819 20
+      vertex 28.5177 38.8129 20
+      vertex 28.6937 38.689 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.0008 46.396 20
+      vertex 26.7608 40.0503 20
+      vertex 28.5177 38.8129 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.576 41.4213 20
+      vertex 28.6869 47.8613 20
+      vertex 26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.0008 46.396 20
+      vertex 24.9452 41.2 20
+      vertex 26.7608 40.0503 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.6869 47.8613 20
+      vertex 24.7633 41.3152 20
+      vertex 24.9452 41.2 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.6869 47.8613 20
+      vertex 24.576 41.4213 20
+      vertex 24.7633 41.3152 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.7868 43.4466 20
+      vertex 26.3039 49.2112 20
+      vertex 23.8576 50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.3977 43.6307 20
+      vertex 23.8576 50.4426 20
+      vertex 23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.3039 49.2112 20
+      vertex 22.7063 42.4805 20
+      vertex 24.576 41.4213 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.3039 49.2112 20
+      vertex 20.7868 43.4466 20
+      vertex 22.7063 42.4805 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.8576 50.4426 20
+      vertex 20.5945 43.5434 20
+      vertex 20.7868 43.4466 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.8576 50.4426 20
+      vertex 20.3977 43.6307 20
+      vertex 20.5945 43.5434 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0513 50.8 20
+      vertex 18.4331 44.5015 20
+      vertex 20.3977 43.6307 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0513 50.8 20
+      vertex 18.2323 44.579 20
+      vertex 18.4331 44.5015 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.0513 50.8 20
+      vertex 16.2273 45.3524 20
+      vertex 18.2323 44.579 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.2254 50.8 20
+      vertex 16.2273 45.3524 20
+      vertex 23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.2273 45.3524 20
+      vertex 12.2254 50.8 20
+      vertex 14.1869 46.0265 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1869 46.0265 20
+      vertex 12.2254 50.8 20
+      vertex 13.9825 46.094 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.2254 50.8 20
+      vertex 11.9114 46.6671 20
+      vertex 13.9825 46.094 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.2254 50.8 20
+      vertex 11.7039 46.7246 20
+      vertex 11.9114 46.6671 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.2254 50.8 20
+      vertex 11.4938 46.7717 20
+      vertex 11.7039 46.7246 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.4237 51.2046 20
+      vertex 11.4938 46.7717 20
+      vertex 12.2254 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.39713 47.2426 20
+      vertex 10.4237 51.2046 20
+      vertex 10.1954 51.2558 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.39713 47.2426 20
+      vertex 10.1954 51.2558 20
+      vertex 9.9649 51.2958 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.4237 51.2046 20
+      vertex 9.39713 47.2426 20
+      vertex 11.4938 46.7717 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.27986 47.6099 20
+      vertex 9.9649 51.2958 20
+      vertex 7.66813 51.6944 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.9649 51.2958 20
+      vertex 7.27986 47.6099 20
+      vertex 9.39713 47.2426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.66813 51.6944 20
+      vertex 7.06773 47.6467 20
+      vertex 7.27986 47.6099 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.35458 51.9797 20
+      vertex 7.06773 47.6467 20
+      vertex 7.66813 51.6944 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.7213 47.9361 20
+      vertex 5.35458 51.9797 20
+      vertex 5.12238 52.0084 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.35458 51.9797 20
+      vertex 4.93498 47.9098 20
+      vertex 7.06773 47.6467 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.35458 51.9797 20
+      vertex 4.7213 47.9361 20
+      vertex 4.93498 47.9098 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.7976 52.1798 20
+      vertex 4.7213 47.9361 20
+      vertex 5.12238 52.0084 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.7976 52.1798 20
+      vertex 2.57821 48.0942 20
+      vertex 4.7213 47.9361 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.3635 48.1101 20
+      vertex 2.7976 52.1798 20
+      vertex 2.56428 52.1971 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.7976 52.1798 20
+      vertex 2.3635 48.1101 20
+      vertex 2.57821 48.0942 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.33039 52.2028 20
+      vertex 2.3635 48.1101 20
+      vertex 2.56428 52.1971 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.33039 52.2028 20
+      vertex 2.14826 48.1154 20
+      vertex 2.3635 48.1101 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 52.26 20
+      vertex 2.14826 48.1154 20
+      vertex 2.33039 52.2028 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 52.26 20
+      vertex 0 48.1681 20
+      vertex 2.14826 48.1154 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 52.26 20
+      vertex -2.14826 48.1154 20
+      vertex 0 48.1681 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.33039 52.2028 20
+      vertex -2.14826 48.1154 20
+      vertex 0 52.26 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.33039 52.2028 20
+      vertex -2.3635 48.1101 20
+      vertex -2.14826 48.1154 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.56428 52.1971 20
+      vertex -2.3635 48.1101 20
+      vertex -2.33039 52.2028 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.7976 52.1798 20
+      vertex -2.3635 48.1101 20
+      vertex -2.56428 52.1971 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.3635 48.1101 20
+      vertex -2.7976 52.1798 20
+      vertex -2.57821 48.0942 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.7976 52.1798 20
+      vertex -4.7213 47.9361 20
+      vertex -2.57821 48.0942 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.12238 52.0084 20
+      vertex -4.7213 47.9361 20
+      vertex -2.7976 52.1798 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.35458 51.9797 20
+      vertex -4.7213 47.9361 20
+      vertex -5.12238 52.0084 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.7213 47.9361 20
+      vertex -5.35458 51.9797 20
+      vertex -4.93498 47.9098 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.35458 51.9797 20
+      vertex -7.06773 47.6467 20
+      vertex -4.93498 47.9098 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.66813 51.6944 20
+      vertex -7.06773 47.6467 20
+      vertex -5.35458 51.9797 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.06773 47.6467 20
+      vertex -7.66813 51.6944 20
+      vertex -7.27986 47.6099 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.9649 51.2958 20
+      vertex -7.27986 47.6099 20
+      vertex -7.66813 51.6944 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.27986 47.6099 20
+      vertex -9.9649 51.2958 20
+      vertex -9.39713 47.2426 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.1954 51.2558 20
+      vertex -9.39713 47.2426 20
+      vertex -9.9649 51.2958 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.4237 51.2046 20
+      vertex -9.39713 47.2426 20
+      vertex -10.1954 51.2558 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.4237 51.2046 20
+      vertex -11.4938 46.7717 20
+      vertex -9.39713 47.2426 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.2254 50.8 20
+      vertex -11.4938 46.7717 20
+      vertex -10.4237 51.2046 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.4938 46.7717 20
+      vertex -12.2254 50.8 20
+      vertex -11.7039 46.7246 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7039 46.7246 20
+      vertex -12.2254 50.8 20
+      vertex -11.9114 46.6671 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.2254 50.8 20
+      vertex -13.9825 46.094 20
+      vertex -11.9114 46.6671 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.2254 50.8 20
+      vertex -14.1869 46.0265 20
+      vertex -13.9825 46.094 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.2254 50.8 20
+      vertex -16.2273 45.3524 20
+      vertex -14.1869 46.0265 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.0513 50.8 20
+      vertex -16.2273 45.3524 20
+      vertex -12.2254 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.2273 45.3524 20
+      vertex -23.0513 50.8 20
+      vertex -18.2323 44.579 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2323 44.579 20
+      vertex -23.0513 50.8 20
+      vertex -18.4331 44.5015 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4331 44.5015 20
+      vertex -23.0513 50.8 20
+      vertex -20.3977 43.6307 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.8576 50.4426 20
+      vertex -20.3977 43.6307 20
+      vertex -23.0513 50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.3977 43.6307 20
+      vertex -23.8576 50.4426 20
+      vertex -20.5945 43.5434 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.5945 43.5434 20
+      vertex -23.8576 50.4426 20
+      vertex -20.7868 43.4466 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -26.3039 49.2112 20
+      vertex -20.7868 43.4466 20
+      vertex -23.8576 50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.7868 43.4466 20
+      vertex -26.3039 49.2112 20
+      vertex -22.7063 42.4805 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.7063 42.4805 20
+      vertex -26.3039 49.2112 20
+      vertex -24.576 41.4213 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.6869 47.8613 20
+      vertex -24.576 41.4213 20
+      vertex -26.3039 49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.576 41.4213 20
+      vertex -28.6869 47.8613 20
+      vertex -24.7633 41.3152 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.7633 41.3152 20
+      vertex -28.6869 47.8613 20
+      vertex -24.9452 41.2 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -31.0008 46.396 20
+      vertex -24.9452 41.2 20
+      vertex -28.6869 47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.9452 41.2 20
+      vertex -31.0008 46.396 20
+      vertex -26.7608 40.0503 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.7608 40.0503 20
+      vertex -31.0008 46.396 20
+      vertex -28.5177 38.8129 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -33.24 44.819 20
+      vertex -28.5177 38.8129 20
+      vertex -31.0008 46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.5177 38.8129 20
+      vertex -33.24 44.819 20
+      vertex -28.6937 38.689 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.6937 38.689 20
+      vertex -33.24 44.819 20
+      vertex -30.3878 37.3669 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35.3991 43.134 20
+      vertex -30.3878 37.3669 20
+      vertex -33.24 44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.3878 37.3669 20
+      vertex -35.3991 43.134 20
+      vertex -30.5575 37.2344 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.5575 37.2344 20
+      vertex -35.3991 43.134 20
+      vertex -30.7205 37.0938 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -37.473 41.3451 20
+      vertex -30.7205 37.0938 20
+      vertex -35.3991 43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.7205 37.0938 20
+      vertex -37.473 41.3451 20
+      vertex -32.3477 35.6902 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -32.3477 35.6902 20
+      vertex -37.473 41.3451 20
+      vertex -33.9041 34.2084 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -39.4566 39.4566 20
+      vertex -33.9041 34.2084 20
+      vertex -37.473 41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.9041 34.2084 20
+      vertex -39.4566 39.4566 20
+      vertex -34.06 34.06 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.06 34.06 20
+      vertex -39.4566 39.4566 20
+      vertex -34.2084 33.9041 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -41.3451 37.473 20
+      vertex -34.2084 33.9041 20
+      vertex -39.4566 39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.2084 33.9041 20
+      vertex -41.3451 37.473 20
+      vertex -35.6902 32.3477 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.6902 32.3477 20
+      vertex -41.3451 37.473 20
+      vertex -37.0938 30.7205 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -43.134 35.3991 20
+      vertex -37.0938 30.7205 20
+      vertex -41.3451 37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.0938 30.7205 20
+      vertex -43.134 35.3991 20
+      vertex -37.2344 30.5575 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.2344 30.5575 20
+      vertex -43.134 35.3991 20
+      vertex -37.3669 30.3878 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -44.819 33.24 20
+      vertex -37.3669 30.3878 20
+      vertex -43.134 35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.3669 30.3878 20
+      vertex -44.819 33.24 20
+      vertex -38.689 28.6937 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -38.689 28.6937 20
+      vertex -44.819 33.24 20
+      vertex -38.8129 28.5177 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -46.396 31.0008 20
+      vertex -38.8129 28.5177 20
+      vertex -44.819 33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -38.8129 28.5177 20
+      vertex -46.396 31.0008 20
+      vertex -40.0503 26.7608 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -40.0503 26.7608 20
+      vertex -46.396 31.0008 20
+      vertex -41.2 24.9452 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -47.8613 28.6869 20
+      vertex -41.2 24.9452 20
+      vertex -46.396 31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.2 24.9452 20
+      vertex -47.8613 28.6869 20
+      vertex -41.3152 24.7633 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.3152 24.7633 20
+      vertex -47.8613 28.6869 20
+      vertex -41.4213 24.576 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -49.2112 26.3039 20
+      vertex -41.4213 24.576 20
+      vertex -47.8613 28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.4213 24.576 20
+      vertex -49.2112 26.3039 20
+      vertex -42.4805 22.7063 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -42.4805 22.7063 20
+      vertex -49.2112 26.3039 20
+      vertex -43.4466 20.7868 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -50.4426 23.8576 20
+      vertex -43.4466 20.7868 20
+      vertex -49.2112 26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.4466 20.7868 20
+      vertex -50.4426 23.8576 20
+      vertex -43.5434 20.5945 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.5434 20.5945 20
+      vertex -50.4426 23.8576 20
+      vertex -43.6307 20.3977 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -51.5525 21.3537 20
+      vertex -43.6307 20.3977 20
+      vertex -50.4426 23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.6307 20.3977 20
+      vertex -51.5525 21.3537 20
+      vertex -44.5015 18.4331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.5015 18.4331 20
+      vertex -51.5525 21.3537 20
+      vertex -44.579 18.2323 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -52.5382 18.7985 20
+      vertex -44.579 18.2323 20
+      vertex -51.5525 21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.579 18.2323 20
+      vertex -52.5382 18.7985 20
+      vertex -45.3524 16.2273 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -45.3524 16.2273 20
+      vertex -52.5382 18.7985 20
+      vertex -46.0265 14.1869 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -53.3973 16.1979 20
+      vertex -46.0265 14.1869 20
+      vertex -52.5382 18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.0265 14.1869 20
+      vertex -53.3973 16.1979 20
+      vertex -46.094 13.9825 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.094 13.9825 20
+      vertex -53.3973 16.1979 20
+      vertex -46.6671 11.9114 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -54.1277 13.5583 20
+      vertex -46.6671 11.9114 20
+      vertex -53.3973 16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.6671 11.9114 20
+      vertex -54.1277 13.5583 20
+      vertex -46.7246 11.7039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.7246 11.7039 20
+      vertex -54.1277 13.5583 20
+      vertex -46.7717 11.4938 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.7278 10.886 20
+      vertex -46.7717 11.4938 20
+      vertex -54.1277 13.5583 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.7717 11.4938 20
+      vertex -54.7278 10.886 20
+      vertex -47.2426 9.39713 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -54.8 10.4701 20
+      vertex -47.2426 9.39713 20
+      vertex -54.7278 10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.2426 9.39713 20
+      vertex -54.8 10.4701 20
+      vertex -47.6099 7.27986 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 47.2426 -9.39713 20
+      vertex 54.8 -10.4701 20
+      vertex 47.6099 -7.27986 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.8 -10.4701 20
+      vertex 47.2426 -9.39713 20
+      vertex 54.7278 -10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 46.7717 -11.4938 20
+      vertex 54.7278 -10.886 20
+      vertex 47.2426 -9.39713 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.7278 -10.886 20
+      vertex 46.7717 -11.4938 20
+      vertex 54.1277 -13.5583 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 46.7246 -11.7039 20
+      vertex 54.1277 -13.5583 20
+      vertex 46.7717 -11.4938 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 46.6671 -11.9114 20
+      vertex 54.1277 -13.5583 20
+      vertex 46.7246 -11.7039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 54.1277 -13.5583 20
+      vertex 46.6671 -11.9114 20
+      vertex 53.3973 -16.1979 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 46.094 -13.9825 20
+      vertex 53.3973 -16.1979 20
+      vertex 46.6671 -11.9114 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 46.0265 -14.1869 20
+      vertex 53.3973 -16.1979 20
+      vertex 46.094 -13.9825 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 53.3973 -16.1979 20
+      vertex 46.0265 -14.1869 20
+      vertex 52.5382 -18.7985 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 45.3524 -16.2273 20
+      vertex 52.5382 -18.7985 20
+      vertex 46.0265 -14.1869 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 44.579 -18.2323 20
+      vertex 52.5382 -18.7985 20
+      vertex 45.3524 -16.2273 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 52.5382 -18.7985 20
+      vertex 44.579 -18.2323 20
+      vertex 51.5525 -21.3537 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 44.5015 -18.4331 20
+      vertex 51.5525 -21.3537 20
+      vertex 44.579 -18.2323 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 43.6307 -20.3977 20
+      vertex 51.5525 -21.3537 20
+      vertex 44.5015 -18.4331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.5525 -21.3537 20
+      vertex 43.6307 -20.3977 20
+      vertex 50.4426 -23.8576 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 43.5434 -20.5945 20
+      vertex 50.4426 -23.8576 20
+      vertex 43.6307 -20.3977 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 43.4466 -20.7868 20
+      vertex 50.4426 -23.8576 20
+      vertex 43.5434 -20.5945 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 50.4426 -23.8576 20
+      vertex 43.4466 -20.7868 20
+      vertex 49.2112 -26.3039 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.4805 -22.7063 20
+      vertex 49.2112 -26.3039 20
+      vertex 43.4466 -20.7868 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 41.4213 -24.576 20
+      vertex 49.2112 -26.3039 20
+      vertex 42.4805 -22.7063 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 49.2112 -26.3039 20
+      vertex 41.4213 -24.576 20
+      vertex 47.8613 -28.6869 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 41.3152 -24.7633 20
+      vertex 47.8613 -28.6869 20
+      vertex 41.4213 -24.576 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 41.2 -24.9452 20
+      vertex 47.8613 -28.6869 20
+      vertex 41.3152 -24.7633 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 47.8613 -28.6869 20
+      vertex 41.2 -24.9452 20
+      vertex 46.396 -31.0008 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 40.0503 -26.7608 20
+      vertex 46.396 -31.0008 20
+      vertex 41.2 -24.9452 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 38.8129 -28.5177 20
+      vertex 46.396 -31.0008 20
+      vertex 40.0503 -26.7608 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 46.396 -31.0008 20
+      vertex 38.8129 -28.5177 20
+      vertex 44.819 -33.24 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 38.689 -28.6937 20
+      vertex 44.819 -33.24 20
+      vertex 38.8129 -28.5177 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 37.3669 -30.3878 20
+      vertex 44.819 -33.24 20
+      vertex 38.689 -28.6937 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 44.819 -33.24 20
+      vertex 37.3669 -30.3878 20
+      vertex 43.134 -35.3991 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 37.2344 -30.5575 20
+      vertex 43.134 -35.3991 20
+      vertex 37.3669 -30.3878 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 37.0938 -30.7205 20
+      vertex 43.134 -35.3991 20
+      vertex 37.2344 -30.5575 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.134 -35.3991 20
+      vertex 37.0938 -30.7205 20
+      vertex 41.3451 -37.473 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35.6902 -32.3477 20
+      vertex 41.3451 -37.473 20
+      vertex 37.0938 -30.7205 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 34.2084 -33.9041 20
+      vertex 41.3451 -37.473 20
+      vertex 35.6902 -32.3477 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.3451 -37.473 20
+      vertex 34.2084 -33.9041 20
+      vertex 39.4566 -39.4566 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 34.06 -34.06 20
+      vertex 39.4566 -39.4566 20
+      vertex 34.2084 -33.9041 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 33.9041 -34.2084 20
+      vertex 39.4566 -39.4566 20
+      vertex 34.06 -34.06 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.4566 -39.4566 20
+      vertex 33.9041 -34.2084 20
+      vertex 37.473 -41.3451 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 32.3477 -35.6902 20
+      vertex 37.473 -41.3451 20
+      vertex 33.9041 -34.2084 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 30.7205 -37.0938 20
+      vertex 37.473 -41.3451 20
+      vertex 32.3477 -35.6902 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 37.473 -41.3451 20
+      vertex 30.7205 -37.0938 20
+      vertex 35.3991 -43.134 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 30.5575 -37.2344 20
+      vertex 35.3991 -43.134 20
+      vertex 30.7205 -37.0938 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 30.3878 -37.3669 20
+      vertex 35.3991 -43.134 20
+      vertex 30.5575 -37.2344 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.3991 -43.134 20
+      vertex 30.3878 -37.3669 20
+      vertex 33.24 -44.819 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 28.6937 -38.689 20
+      vertex 33.24 -44.819 20
+      vertex 30.3878 -37.3669 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 28.5177 -38.8129 20
+      vertex 33.24 -44.819 20
+      vertex 28.6937 -38.689 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.24 -44.819 20
+      vertex 28.5177 -38.8129 20
+      vertex 31.0008 -46.396 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.7608 -40.0503 20
+      vertex 31.0008 -46.396 20
+      vertex 28.5177 -38.8129 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.9452 -41.2 20
+      vertex 31.0008 -46.396 20
+      vertex 26.7608 -40.0503 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.0008 -46.396 20
+      vertex 24.9452 -41.2 20
+      vertex 28.6869 -47.8613 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.7633 -41.3152 20
+      vertex 28.6869 -47.8613 20
+      vertex 24.9452 -41.2 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 24.576 -41.4213 20
+      vertex 28.6869 -47.8613 20
+      vertex 24.7633 -41.3152 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.6869 -47.8613 20
+      vertex 24.576 -41.4213 20
+      vertex 26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.7063 -42.4805 20
+      vertex 26.3039 -49.2112 20
+      vertex 24.576 -41.4213 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.7868 -43.4466 20
+      vertex 26.3039 -49.2112 20
+      vertex 22.7063 -42.4805 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.3039 -49.2112 20
+      vertex 20.7868 -43.4466 20
+      vertex 23.8576 -50.4426 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.5945 -43.5434 20
+      vertex 23.8576 -50.4426 20
+      vertex 20.7868 -43.4466 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.3977 -43.6307 20
+      vertex 23.8576 -50.4426 20
+      vertex 20.5945 -43.5434 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.8576 -50.4426 20
+      vertex 20.3977 -43.6307 20
+      vertex 23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.4331 -44.5015 20
+      vertex 23.0513 -50.8 20
+      vertex 20.3977 -43.6307 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.2323 -44.579 20
+      vertex 23.0513 -50.8 20
+      vertex 18.4331 -44.5015 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.2273 -45.3524 20
+      vertex 23.0513 -50.8 20
+      vertex 18.2323 -44.579 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.2254 -50.8 20
+      vertex 16.2273 -45.3524 20
+      vertex 14.1869 -46.0265 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.2254 -50.8 20
+      vertex 14.1869 -46.0265 20
+      vertex 13.9825 -46.094 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.2273 -45.3524 20
+      vertex 12.2254 -50.8 20
+      vertex 23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.9114 -46.6671 20
+      vertex 12.2254 -50.8 20
+      vertex 13.9825 -46.094 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.7039 -46.7246 20
+      vertex 12.2254 -50.8 20
+      vertex 11.9114 -46.6671 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.4938 -46.7717 20
+      vertex 12.2254 -50.8 20
+      vertex 11.7039 -46.7246 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4938 -46.7717 20
+      vertex 10.4237 -51.2046 20
+      vertex 12.2254 -50.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.39713 -47.2426 20
+      vertex 10.4237 -51.2046 20
+      vertex 11.4938 -46.7717 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.4237 -51.2046 20
+      vertex 9.39713 -47.2426 20
+      vertex 10.1954 -51.2558 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.1954 -51.2558 20
+      vertex 9.39713 -47.2426 20
+      vertex 9.9649 -51.2958 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.27986 -47.6099 20
+      vertex 9.9649 -51.2958 20
+      vertex 9.39713 -47.2426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.9649 -51.2958 20
+      vertex 7.27986 -47.6099 20
+      vertex 7.66813 -51.6944 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 7.06773 -47.6467 20
+      vertex 7.66813 -51.6944 20
+      vertex 7.27986 -47.6099 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.06773 -47.6467 20
+      vertex 5.35458 -51.9797 20
+      vertex 7.66813 -51.6944 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.93498 -47.9098 20
+      vertex 5.35458 -51.9797 20
+      vertex 7.06773 -47.6467 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.7213 -47.9361 20
+      vertex 5.35458 -51.9797 20
+      vertex 4.93498 -47.9098 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.35458 -51.9797 20
+      vertex 4.7213 -47.9361 20
+      vertex 5.12238 -52.0084 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.7213 -47.9361 20
+      vertex 2.7976 -52.1798 20
+      vertex 5.12238 -52.0084 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.57821 -48.0942 20
+      vertex 2.7976 -52.1798 20
+      vertex 4.7213 -47.9361 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.3635 -48.1101 20
+      vertex 2.7976 -52.1798 20
+      vertex 2.57821 -48.0942 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.7976 -52.1798 20
+      vertex 2.3635 -48.1101 20
+      vertex 2.56428 -52.1971 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.3635 -48.1101 20
+      vertex 2.33039 -52.2028 20
+      vertex 2.56428 -52.1971 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.14826 -48.1154 20
+      vertex 2.33039 -52.2028 20
+      vertex 2.3635 -48.1101 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -48.1681 20
+      vertex 2.33039 -52.2028 20
+      vertex 2.14826 -48.1154 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -48.1681 20
+      vertex 0 -52.26 20
+      vertex 2.33039 -52.2028 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.14826 -48.1154 20
+      vertex 0 -52.26 20
+      vertex 0 -48.1681 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.14826 -48.1154 20
+      vertex -2.33039 -52.2028 20
+      vertex 0 -52.26 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.3635 -48.1101 20
+      vertex -2.33039 -52.2028 20
+      vertex -2.14826 -48.1154 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.3635 -48.1101 20
+      vertex -2.56428 -52.1971 20
+      vertex -2.33039 -52.2028 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.7976 -52.1798 20
+      vertex -2.3635 -48.1101 20
+      vertex -2.57821 -48.0942 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.3635 -48.1101 20
+      vertex -2.7976 -52.1798 20
+      vertex -2.56428 -52.1971 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.7213 -47.9361 20
+      vertex -2.7976 -52.1798 20
+      vertex -2.57821 -48.0942 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.35458 -51.9797 20
+      vertex -4.7213 -47.9361 20
+      vertex -4.93498 -47.9098 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.7213 -47.9361 20
+      vertex -5.12238 -52.0084 20
+      vertex -2.7976 -52.1798 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.7213 -47.9361 20
+      vertex -5.35458 -51.9797 20
+      vertex -5.12238 -52.0084 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.06773 -47.6467 20
+      vertex -5.35458 -51.9797 20
+      vertex -4.93498 -47.9098 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.66813 -51.6944 20
+      vertex -7.06773 -47.6467 20
+      vertex -7.27986 -47.6099 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.06773 -47.6467 20
+      vertex -7.66813 -51.6944 20
+      vertex -5.35458 -51.9797 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.9649 -51.2958 20
+      vertex -7.27986 -47.6099 20
+      vertex -9.39713 -47.2426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.27986 -47.6099 20
+      vertex -9.9649 -51.2958 20
+      vertex -7.66813 -51.6944 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.39713 -47.2426 20
+      vertex -10.1954 -51.2558 20
+      vertex -9.9649 -51.2958 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.39713 -47.2426 20
+      vertex -10.4237 -51.2046 20
+      vertex -10.1954 -51.2558 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.4938 -46.7717 20
+      vertex -10.4237 -51.2046 20
+      vertex -9.39713 -47.2426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.2254 -50.8 20
+      vertex -11.4938 -46.7717 20
+      vertex -11.7039 -46.7246 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.2254 -50.8 20
+      vertex -11.7039 -46.7246 20
+      vertex -11.9114 -46.6671 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.4938 -46.7717 20
+      vertex -12.2254 -50.8 20
+      vertex -10.4237 -51.2046 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.9825 -46.094 20
+      vertex -12.2254 -50.8 20
+      vertex -11.9114 -46.6671 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.1869 -46.0265 20
+      vertex -12.2254 -50.8 20
+      vertex -13.9825 -46.094 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.2273 -45.3524 20
+      vertex -12.2254 -50.8 20
+      vertex -14.1869 -46.0265 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0513 -50.8 20
+      vertex -16.2273 -45.3524 20
+      vertex -18.2323 -44.579 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0513 -50.8 20
+      vertex -18.2323 -44.579 20
+      vertex -18.4331 -44.5015 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.0513 -50.8 20
+      vertex -18.4331 -44.5015 20
+      vertex -20.3977 -43.6307 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.8576 -50.4426 20
+      vertex -20.3977 -43.6307 20
+      vertex -20.5945 -43.5434 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.8576 -50.4426 20
+      vertex -20.5945 -43.5434 20
+      vertex -20.7868 -43.4466 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.3039 -49.2112 20
+      vertex -20.7868 -43.4466 20
+      vertex -22.7063 -42.4805 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.2273 -45.3524 20
+      vertex -23.0513 -50.8 20
+      vertex -12.2254 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.3977 -43.6307 20
+      vertex -23.8576 -50.4426 20
+      vertex -23.0513 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.3039 -49.2112 20
+      vertex -22.7063 -42.4805 20
+      vertex -24.576 -41.4213 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.6869 -47.8613 20
+      vertex -24.576 -41.4213 20
+      vertex -24.7633 -41.3152 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.6869 -47.8613 20
+      vertex -24.7633 -41.3152 20
+      vertex -24.9452 -41.2 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.7868 -43.4466 20
+      vertex -26.3039 -49.2112 20
+      vertex -23.8576 -50.4426 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.0008 -46.396 20
+      vertex -24.9452 -41.2 20
+      vertex -26.7608 -40.0503 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.0008 -46.396 20
+      vertex -26.7608 -40.0503 20
+      vertex -28.5177 -38.8129 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.576 -41.4213 20
+      vertex -28.6869 -47.8613 20
+      vertex -26.3039 -49.2112 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.24 -44.819 20
+      vertex -28.5177 -38.8129 20
+      vertex -28.6937 -38.689 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.24 -44.819 20
+      vertex -28.6937 -38.689 20
+      vertex -30.3878 -37.3669 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.3991 -43.134 20
+      vertex -30.3878 -37.3669 20
+      vertex -30.5575 -37.2344 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35.3991 -43.134 20
+      vertex -30.5575 -37.2344 20
+      vertex -30.7205 -37.0938 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.9452 -41.2 20
+      vertex -31.0008 -46.396 20
+      vertex -28.6869 -47.8613 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.473 -41.3451 20
+      vertex -30.7205 -37.0938 20
+      vertex -32.3477 -35.6902 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.5177 -38.8129 20
+      vertex -33.24 -44.819 20
+      vertex -31.0008 -46.396 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.473 -41.3451 20
+      vertex -32.3477 -35.6902 20
+      vertex -33.9041 -34.2084 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -39.4566 -39.4566 20
+      vertex -33.9041 -34.2084 20
+      vertex -34.06 -34.06 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -39.4566 -39.4566 20
+      vertex -34.06 -34.06 20
+      vertex -34.2084 -33.9041 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.3878 -37.3669 20
+      vertex -35.3991 -43.134 20
+      vertex -33.24 -44.819 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.3451 -37.473 20
+      vertex -34.2084 -33.9041 20
+      vertex -35.6902 -32.3477 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.3451 -37.473 20
+      vertex -35.6902 -32.3477 20
+      vertex -37.0938 -30.7205 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.134 -35.3991 20
+      vertex -37.0938 -30.7205 20
+      vertex -37.2344 -30.5575 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.134 -35.3991 20
+      vertex -37.2344 -30.5575 20
+      vertex -37.3669 -30.3878 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.7205 -37.0938 20
+      vertex -37.473 -41.3451 20
+      vertex -35.3991 -43.134 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.819 -33.24 20
+      vertex -37.3669 -30.3878 20
+      vertex -38.689 -28.6937 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.819 -33.24 20
+      vertex -38.689 -28.6937 20
+      vertex -38.8129 -28.5177 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.9041 -34.2084 20
+      vertex -39.4566 -39.4566 20
+      vertex -37.473 -41.3451 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.396 -31.0008 20
+      vertex -38.8129 -28.5177 20
+      vertex -40.0503 -26.7608 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.396 -31.0008 20
+      vertex -40.0503 -26.7608 20
+      vertex -41.2 -24.9452 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.8613 -28.6869 20
+      vertex -41.2 -24.9452 20
+      vertex -41.3152 -24.7633 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.2084 -33.9041 20
+      vertex -41.3451 -37.473 20
+      vertex -39.4566 -39.4566 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.8613 -28.6869 20
+      vertex -41.3152 -24.7633 20
+      vertex -41.4213 -24.576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.2112 -26.3039 20
+      vertex -41.4213 -24.576 20
+      vertex -42.4805 -22.7063 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.0938 -30.7205 20
+      vertex -43.134 -35.3991 20
+      vertex -41.3451 -37.473 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.2112 -26.3039 20
+      vertex -42.4805 -22.7063 20
+      vertex -43.4466 -20.7868 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.4426 -23.8576 20
+      vertex -43.4466 -20.7868 20
+      vertex -43.5434 -20.5945 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.4426 -23.8576 20
+      vertex -43.5434 -20.5945 20
+      vertex -43.6307 -20.3977 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -51.5525 -21.3537 20
+      vertex -43.6307 -20.3977 20
+      vertex -44.5015 -18.4331 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -51.5525 -21.3537 20
+      vertex -44.5015 -18.4331 20
+      vertex -44.579 -18.2323 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -37.3669 -30.3878 20
+      vertex -44.819 -33.24 20
+      vertex -43.134 -35.3991 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -52.5382 -18.7985 20
+      vertex -44.579 -18.2323 20
+      vertex -45.3524 -16.2273 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -52.5382 -18.7985 20
+      vertex -45.3524 -16.2273 20
+      vertex -46.0265 -14.1869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -53.3973 -16.1979 20
+      vertex -46.0265 -14.1869 20
+      vertex -46.094 -13.9825 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -38.8129 -28.5177 20
+      vertex -46.396 -31.0008 20
+      vertex -44.819 -33.24 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -53.3973 -16.1979 20
+      vertex -46.094 -13.9825 20
+      vertex -46.6671 -11.9114 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.1277 -13.5583 20
+      vertex -46.6671 -11.9114 20
+      vertex -46.7246 -11.7039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.1277 -13.5583 20
+      vertex -46.7246 -11.7039 20
+      vertex -46.7717 -11.4938 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -54.7278 -10.886 20
+      vertex -46.7717 -11.4938 20
+      vertex -47.2426 -9.39713 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -47.2426 -9.39713 20
+      vertex -47.6099 -7.27986 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -47.6099 -7.27986 20
+      vertex -47.6467 -7.06773 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.2 -24.9452 20
+      vertex -47.8613 -28.6869 20
+      vertex -46.396 -31.0008 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -47.6467 -7.06773 20
+      vertex -47.9098 -4.93498 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -47.9098 -4.93498 20
+      vertex -47.9361 -4.7213 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -47.9361 -4.7213 20
+      vertex -48.0942 -2.57821 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -48.0942 -2.57821 20
+      vertex -48.1101 -2.3635 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -48.1101 -2.3635 20
+      vertex -48.1154 -2.14826 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -48.1154 -2.14826 20
+      vertex -48.1681 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.6099 7.27986 20
+      vertex -54.8 10.4701 20
+      vertex -47.6467 7.06773 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.4213 -24.576 20
+      vertex -49.2112 -26.3039 20
+      vertex -47.8613 -28.6869 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.6467 7.06773 20
+      vertex -54.8 10.4701 20
+      vertex -47.9098 4.93498 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.4466 -20.7868 20
+      vertex -50.4426 -23.8576 20
+      vertex -49.2112 -26.3039 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.9098 4.93498 20
+      vertex -54.8 10.4701 20
+      vertex -47.9361 4.7213 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.6307 -20.3977 20
+      vertex -51.5525 -21.3537 20
+      vertex -50.4426 -23.8576 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.9361 4.7213 20
+      vertex -54.8 10.4701 20
+      vertex -48.0942 2.57821 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.579 -18.2323 20
+      vertex -52.5382 -18.7985 20
+      vertex -51.5525 -21.3537 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.0942 2.57821 20
+      vertex -54.8 10.4701 20
+      vertex -48.1101 2.3635 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.0265 -14.1869 20
+      vertex -53.3973 -16.1979 20
+      vertex -52.5382 -18.7985 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1101 2.3635 20
+      vertex -54.8 10.4701 20
+      vertex -48.1154 2.14826 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.6671 -11.9114 20
+      vertex -54.1277 -13.5583 20
+      vertex -53.3973 -16.1979 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.1154 2.14826 20
+      vertex -54.8 10.4701 20
+      vertex -48.1681 0 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -48.1681 0 20
+      vertex -54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -47.2426 -9.39713 20
+      vertex -54.8 -10.4701 20
+      vertex -54.7278 -10.886 20
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -46.7717 -11.4938 20
+      vertex -54.7278 -10.886 20
+      vertex -54.1277 -13.5583 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -54.8 10.4701 20
+      vertex -54.8 50.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -54.8 50.8 0
+      vertex -54.8 -10.4701 20
+      vertex -54.8 10.4701 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -54.8 -10.4701 20
+      vertex -54.8 50.8 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -54.8 -10.4701 20
+      vertex -54.8 -50.8 0
+      vertex -54.8 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -12.7247 50.8 19.1382
+      vertex -23.0513 50.8 20
+      vertex -12.2254 50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -12.9498 50.8 18.6655
+      vertex -23.0513 50.8 20
+      vertex -12.7247 50.8 19.1382
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -15.41 50.8 13.4972
+      vertex -23.0513 50.8 20
+      vertex -12.9498 50.8 18.6655
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -15.5701 50.8 13.1016
+      vertex -23.0513 50.8 20
+      vertex -15.41 50.8 13.4972
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -18.1765 50.8 6.66199
+      vertex -23.0513 50.8 20
+      vertex -15.5701 50.8 13.1016
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -20.5267 50.8 0
+      vertex -23.0513 50.8 20
+      vertex -18.1765 50.8 6.66199
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -23.0513 50.8 20
+      vertex -20.5267 50.8 0
+      vertex -54.8 50.8 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -23.0513 50.8 20
+      vertex -54.8 50.8 0
+      vertex -54.8 50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 54.8 50.8 0
+      vertex 23.0513 50.8 20
+      vertex 54.8 50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 23.0513 50.8 20
+      vertex 12.7247 50.8 19.1382
+      vertex 12.2254 50.8 20
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 23.0513 50.8 20
+      vertex 12.9498 50.8 18.6655
+      vertex 12.7247 50.8 19.1382
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 23.0513 50.8 20
+      vertex 15.41 50.8 13.4972
+      vertex 12.9498 50.8 18.6655
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 23.0513 50.8 20
+      vertex 15.5701 50.8 13.1016
+      vertex 15.41 50.8 13.4972
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 23.0513 50.8 20
+      vertex 18.1765 50.8 6.66199
+      vertex 15.5701 50.8 13.1016
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.5267 50.8 0
+      vertex 23.0513 50.8 20
+      vertex 54.8 50.8 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 23.0513 50.8 20
+      vertex 20.5267 50.8 0
+      vertex 18.1765 50.8 6.66199
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -54.8 -50.8 0
+      vertex -23.0513 -50.8 20
+      vertex -54.8 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -23.0513 -50.8 20
+      vertex -12.7247 -50.8 19.1382
+      vertex -12.2254 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -23.0513 -50.8 20
+      vertex -12.9498 -50.8 18.6655
+      vertex -12.7247 -50.8 19.1382
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -23.0513 -50.8 20
+      vertex -15.41 -50.8 13.4972
+      vertex -12.9498 -50.8 18.6655
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -23.0513 -50.8 20
+      vertex -15.5701 -50.8 13.1016
+      vertex -15.41 -50.8 13.4972
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -23.0513 -50.8 20
+      vertex -18.1765 -50.8 6.66199
+      vertex -15.5701 -50.8 13.1016
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -20.5267 -50.8 0
+      vertex -23.0513 -50.8 20
+      vertex -54.8 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -23.0513 -50.8 20
+      vertex -20.5267 -50.8 0
+      vertex -18.1765 -50.8 6.66199
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 12.7247 -50.8 19.1382
+      vertex 23.0513 -50.8 20
+      vertex 12.2254 -50.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 12.9498 -50.8 18.6655
+      vertex 23.0513 -50.8 20
+      vertex 12.7247 -50.8 19.1382
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15.41 -50.8 13.4972
+      vertex 23.0513 -50.8 20
+      vertex 12.9498 -50.8 18.6655
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15.5701 -50.8 13.1016
+      vertex 23.0513 -50.8 20
+      vertex 15.41 -50.8 13.4972
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 18.1765 -50.8 6.66199
+      vertex 23.0513 -50.8 20
+      vertex 15.5701 -50.8 13.1016
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 20.5267 -50.8 0
+      vertex 23.0513 -50.8 20
+      vertex 18.1765 -50.8 6.66199
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 23.0513 -50.8 20
+      vertex 20.5267 -50.8 0
+      vertex 54.8 -50.8 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 23.0513 -50.8 20
+      vertex 54.8 -50.8 0
+      vertex 54.8 -50.8 20
+    endloop
+  endfacet
+  facet normal -0.991943 -0.0243555 -0.124318
+    outer loop
+      vertex 50.6747 0 0
+      vertex 48.1154 2.14826 20
+      vertex 50.6139 2.47624 0
+    endloop
+  endfacet
+  facet normal -0.991944 -0.0243338 -0.12432
+    outer loop
+      vertex 48.1154 2.14826 20
+      vertex 50.6747 0 0
+      vertex 48.1681 0 20
+    endloop
+  endfacet
+  facet normal -0.97764 0.1696 -0.124322
+    outer loop
+      vertex 50.1262 -7.43552 0
+      vertex 47.6099 -7.27986 20
+      vertex 47.6467 -7.06773 20
+    endloop
+  endfacet
+  facet normal -0.976858 0.174093 -0.124258
+    outer loop
+      vertex 47.6099 -7.27986 20
+      vertex 50.1262 -7.43552 0
+      vertex 50.1244 -7.44562 0
+    endloop
+  endfacet
+  facet normal -0.98478 -0.121457 -0.124322
+    outer loop
+      vertex 50.4294 4.97716 0
+      vertex 47.6467 7.06773 20
+      vertex 50.1262 7.43552 0
+    endloop
+  endfacet
+  facet normal -0.984777 -0.121484 -0.124318
+    outer loop
+      vertex 47.6467 7.06773 20
+      vertex 50.4294 4.97716 0
+      vertex 47.9098 4.93498 20
+    endloop
+  endfacet
+  facet normal -0.991944 0.0243338 -0.12432
+    outer loop
+      vertex 50.6747 0 0
+      vertex 48.1154 -2.14826 20
+      vertex 48.1681 0 20
+    endloop
+  endfacet
+  facet normal -0.991943 0.0243555 -0.124318
+    outer loop
+      vertex 48.1154 -2.14826 20
+      vertex 50.6747 0 0
+      vertex 50.6139 -2.47624 0
+    endloop
+  endfacet
+  facet normal 0.977639 -0.169608 -0.124318
+    outer loop
+      vertex -47.2426 9.39713 20
+      vertex -50.1244 7.44562 0
+      vertex -49.701 9.88614 0
+    endloop
+  endfacet
+  facet normal 0.97764 -0.169599 -0.124319
+    outer loop
+      vertex -50.1244 7.44562 0
+      vertex -47.2426 9.39713 20
+      vertex -47.6099 7.27986 20
+    endloop
+  endfacet
+  facet normal 0.907125 0.402079 -0.124322
+    outer loop
+      vertex -43.6307 -20.3977 20
+      vertex -46.8173 -19.3924 0
+      vertex -44.5015 -18.4331 20
+    endloop
+  endfacet
+  facet normal 0.907109 0.402118 -0.124317
+    outer loop
+      vertex -46.8173 -19.3924 0
+      vertex -43.6307 -20.3977 20
+      vertex -45.8135 -21.6568 0
+    endloop
+  endfacet
+  facet normal -0.984777 0.121484 -0.124318
+    outer loop
+      vertex 50.4294 -4.97716 0
+      vertex 47.6467 -7.06773 20
+      vertex 47.9098 -4.93498 20
+    endloop
+  endfacet
+  facet normal -0.98478 0.121457 -0.124322
+    outer loop
+      vertex 47.6467 -7.06773 20
+      vertex 50.4294 -4.97716 0
+      vertex 50.1262 -7.43552 0
+    endloop
+  endfacet
+  facet normal -0.1696 -0.97764 -0.124322
+    outer loop
+      vertex 7.43552 50.1262 0
+      vertex 7.27986 47.6099 20
+      vertex 7.06773 47.6467 20
+    endloop
+  endfacet
+  facet normal -0.174093 -0.976858 -0.124258
+    outer loop
+      vertex 7.27986 47.6099 20
+      vertex 7.43552 50.1262 0
+      vertex 7.44562 50.1244 0
+    endloop
+  endfacet
+  facet normal 0.956209 0.264973 -0.124315
+    outer loop
+      vertex -46.6671 -11.9114 20
+      vertex -49.156 -12.3129 0
+      vertex -46.7246 -11.7039 20
+    endloop
+  endfacet
+  facet normal 0.957273 0.261075 -0.124369
+    outer loop
+      vertex -49.156 -12.3129 0
+      vertex -46.6671 -11.9114 20
+      vertex -49.1533 -12.3228 0
+    endloop
+  endfacet
+  facet normal 0.811262 -0.571313 -0.124321
+    outer loop
+      vertex -38.8129 28.5177 20
+      vertex -42.1344 28.1533 0
+      vertex -40.7082 30.1785 0
+    endloop
+  endfacet
+  facet normal 0.811231 -0.571357 -0.124315
+    outer loop
+      vertex -42.1344 28.1533 0
+      vertex -38.8129 28.5177 20
+      vertex -40.0503 26.7608 20
+    endloop
+  endfacet
+  facet normal -0.886308 -0.446098 -0.124319
+    outer loop
+      vertex 45.8047 21.6754 0
+      vertex 42.4805 22.7063 20
+      vertex 44.6911 23.8879 0
+    endloop
+  endfacet
+  facet normal -0.886312 -0.446088 -0.12432
+    outer loop
+      vertex 42.4805 22.7063 20
+      vertex 45.8047 21.6754 0
+      vertex 43.4466 20.7868 20
+    endloop
+  endfacet
+  facet normal -0.942196 0.311146 -0.124317
+    outer loop
+      vertex 48.4926 -14.7101 0
+      vertex 46.0265 -14.1869 20
+      vertex 46.094 -13.9825 20
+    endloop
+  endfacet
+  facet normal -0.94229 0.310859 -0.124321
+    outer loop
+      vertex 46.0265 -14.1869 20
+      vertex 48.4926 -14.7101 0
+      vertex 48.4894 -14.7198 0
+    endloop
+  endfacet
+  facet normal 0.684187 0.718632 -0.12432
+    outer loop
+      vertex -34.031 -37.5475 0
+      vertex -33.9041 -34.2084 20
+      vertex -32.3477 -35.6902 20
+    endloop
+  endfacet
+  facet normal 0.684185 0.718634 -0.124321
+    outer loop
+      vertex -33.9041 -34.2084 20
+      vertex -34.031 -37.5475 0
+      vertex -35.825 -35.8395 0
+    endloop
+  endfacet
+  facet normal 0.991942 0.0244252 -0.124319
+    outer loop
+      vertex -48.1101 -2.3635 20
+      vertex -50.6139 -2.47624 0
+      vertex -48.1154 -2.14826 20
+    endloop
+  endfacet
+  facet normal 0.991816 0.0290288 -0.124329
+    outer loop
+      vertex -50.6139 -2.47624 0
+      vertex -48.1101 -2.3635 20
+      vertex -50.6136 -2.48649 0
+    endloop
+  endfacet
+  facet normal -0.991942 0.0244252 -0.124319
+    outer loop
+      vertex 50.6139 -2.47624 0
+      vertex 48.1101 -2.3635 20
+      vertex 48.1154 -2.14826 20
+    endloop
+  endfacet
+  facet normal -0.991816 0.0290288 -0.124329
+    outer loop
+      vertex 48.1101 -2.3635 20
+      vertex 50.6139 -2.47624 0
+      vertex 50.6136 -2.48649 0
+    endloop
+  endfacet
+  facet normal 0.169599 0.97764 -0.124319
+    outer loop
+      vertex -7.44562 -50.1244 0
+      vertex -9.39713 -47.2426 20
+      vertex -7.27986 -47.6099 20
+    endloop
+  endfacet
+  facet normal 0.169608 0.977639 -0.124318
+    outer loop
+      vertex -9.39713 -47.2426 20
+      vertex -7.44562 -50.1244 0
+      vertex -9.88614 -49.701 0
+    endloop
+  endfacet
+  facet normal -0.863345 0.48906 -0.12432
+    outer loop
+      vertex 43.4702 -26.0431 0
+      vertex 41.3152 -24.7633 20
+      vertex 41.4213 -24.576 20
+    endloop
+  endfacet
+  facet normal -0.86091 0.493331 -0.124331
+    outer loop
+      vertex 41.3152 -24.7633 20
+      vertex 43.4702 -26.0431 0
+      vertex 43.4651 -26.052 0
+    endloop
+  endfacet
+  facet normal 0.991944 -0.0243338 -0.12432
+    outer loop
+      vertex -50.6747 0 0
+      vertex -48.1154 2.14826 20
+      vertex -48.1681 0 20
+    endloop
+  endfacet
+  facet normal 0.991943 -0.0243555 -0.124318
+    outer loop
+      vertex -48.1154 2.14826 20
+      vertex -50.6747 0 0
+      vertex -50.6139 2.47624 0
+    endloop
+  endfacet
+  facet normal 0.0243555 -0.991943 -0.124318
+    outer loop
+      vertex 0 50.6747 0
+      vertex -2.14826 48.1154 20
+      vertex -2.47624 50.6139 0
+    endloop
+  endfacet
+  facet normal 0.0243338 -0.991944 -0.12432
+    outer loop
+      vertex -2.14826 48.1154 20
+      vertex 0 50.6747 0
+      vertex 0 48.1681 20
+    endloop
+  endfacet
+  facet normal 0.0730013 0.989553 -0.124322
+    outer loop
+      vertex -2.49671 -50.6129 0
+      vertex -4.7213 -47.9361 20
+      vertex -2.57821 -48.0942 20
+    endloop
+  endfacet
+  facet normal 0.0729863 0.989554 -0.124324
+    outer loop
+      vertex -4.7213 -47.9361 20
+      vertex -2.49671 -50.6129 0
+      vertex -4.96699 -50.4307 0
+    endloop
+  endfacet
+  facet normal 0.751335 -0.648105 -0.12432
+    outer loop
+      vertex -35.6902 32.3477 20
+      vertex -39.1654 32.1554 0
+      vertex -37.5475 34.031 0
+    endloop
+  endfacet
+  facet normal 0.751342 -0.648097 -0.124322
+    outer loop
+      vertex -39.1654 32.1554 0
+      vertex -35.6902 32.3477 20
+      vertex -37.0938 30.7205 20
+    endloop
+  endfacet
+  facet normal -0.648105 0.751335 -0.12432
+    outer loop
+      vertex 32.1554 -39.1654 0
+      vertex 32.3477 -35.6902 20
+      vertex 34.031 -37.5475 0
+    endloop
+  endfacet
+  facet normal -0.648097 0.751342 -0.124322
+    outer loop
+      vertex 32.3477 -35.6902 20
+      vertex 32.1554 -39.1654 0
+      vertex 30.7205 -37.0938 20
+    endloop
+  endfacet
+  facet normal 0.261075 -0.957273 -0.124369
+    outer loop
+      vertex -12.3129 49.156 0
+      vertex -11.9114 46.6671 20
+      vertex -12.3228 49.1533 0
+    endloop
+  endfacet
+  facet normal 0.264973 -0.956209 -0.124315
+    outer loop
+      vertex -11.9114 46.6671 20
+      vertex -12.3129 49.156 0
+      vertex -11.7039 46.7246 20
+    endloop
+  endfacet
+  facet normal 0.718634 -0.684185 -0.124321
+    outer loop
+      vertex -34.2084 33.9041 20
+      vertex -37.5475 34.031 0
+      vertex -35.8395 35.825 0
+    endloop
+  endfacet
+  facet normal 0.718632 -0.684187 -0.12432
+    outer loop
+      vertex -37.5475 34.031 0
+      vertex -34.2084 33.9041 20
+      vertex -35.6902 32.3477 20
+    endloop
+  endfacet
+  facet normal 0.264973 0.956209 -0.124315
+    outer loop
+      vertex -12.3129 -49.156 0
+      vertex -11.9114 -46.6671 20
+      vertex -11.7039 -46.7246 20
+    endloop
+  endfacet
+  facet normal 0.261075 0.957273 -0.124369
+    outer loop
+      vertex -11.9114 -46.6671 20
+      vertex -12.3129 -49.156 0
+      vertex -12.3228 -49.1533 0
+    endloop
+  endfacet
+  facet normal 0.446088 0.886312 -0.12432
+    outer loop
+      vertex -21.6754 -45.8047 0
+      vertex -22.7063 -42.4805 20
+      vertex -20.7868 -43.4466 20
+    endloop
+  endfacet
+  facet normal 0.446098 0.886308 -0.124319
+    outer loop
+      vertex -22.7063 -42.4805 20
+      vertex -21.6754 -45.8047 0
+      vertex -23.8879 -44.6911 0
+    endloop
+  endfacet
+  facet normal 0.925757 0.357098 -0.124318
+    outer loop
+      vertex -44.579 -18.2323 20
+      vertex -47.7124 -17.0718 0
+      vertex -45.3524 -16.2273 20
+    endloop
+  endfacet
+  facet normal 0.925762 0.357085 -0.124319
+    outer loop
+      vertex -47.7124 -17.0718 0
+      vertex -44.579 -18.2323 20
+      vertex -46.821 -19.3828 0
+    endloop
+  endfacet
+  facet normal 0.489073 -0.863338 -0.124321
+    outer loop
+      vertex -23.8879 44.6911 0
+      vertex -24.576 41.4213 20
+      vertex -26.0431 43.4702 0
+    endloop
+  endfacet
+  facet normal 0.489084 -0.863332 -0.124319
+    outer loop
+      vertex -24.576 41.4213 20
+      vertex -23.8879 44.6911 0
+      vertex -22.7063 42.4805 20
+    endloop
+  endfacet
+  facet normal -0.863332 0.489084 -0.124319
+    outer loop
+      vertex 44.6911 -23.8879 0
+      vertex 41.4213 -24.576 20
+      vertex 42.4805 -22.7063 20
+    endloop
+  endfacet
+  facet normal -0.863338 0.489073 -0.124321
+    outer loop
+      vertex 41.4213 -24.576 20
+      vertex 44.6911 -23.8879 0
+      vertex 43.4702 -26.0431 0
+    endloop
+  endfacet
+  facet normal 0.571357 0.811231 -0.124315
+    outer loop
+      vertex -28.1533 -42.1344 0
+      vertex -28.5177 -38.8129 20
+      vertex -26.7608 -40.0503 20
+    endloop
+  endfacet
+  facet normal 0.571313 0.811262 -0.124321
+    outer loop
+      vertex -28.5177 -38.8129 20
+      vertex -28.1533 -42.1344 0
+      vertex -30.1785 -40.7082 0
+    endloop
+  endfacet
+  facet normal 0.0730013 -0.989553 -0.124324
+    outer loop
+      vertex -4.96699 50.4307 0
+      vertex -2.57821 48.0942 20
+      vertex -4.7213 47.9361 20
+    endloop
+  endfacet
+  facet normal 0.0729864 -0.989554 -0.124322
+    outer loop
+      vertex -2.57821 48.0942 20
+      vertex -4.96699 50.4307 0
+      vertex -2.49671 50.6129 0
+    endloop
+  endfacet
+  facet normal 0.446098 -0.886308 -0.124319
+    outer loop
+      vertex -21.6754 45.8047 0
+      vertex -22.7063 42.4805 20
+      vertex -23.8879 44.6911 0
+    endloop
+  endfacet
+  facet normal 0.446088 -0.886312 -0.12432
+    outer loop
+      vertex -22.7063 42.4805 20
+      vertex -21.6754 45.8047 0
+      vertex -20.7868 43.4466 20
+    endloop
+  endfacet
+  facet normal 0.907109 -0.402118 -0.124317
+    outer loop
+      vertex -43.6307 20.3977 20
+      vertex -46.8173 19.3924 0
+      vertex -45.8135 21.6568 0
+    endloop
+  endfacet
+  facet normal 0.907125 -0.402079 -0.124322
+    outer loop
+      vertex -46.8173 19.3924 0
+      vertex -43.6307 20.3977 20
+      vertex -44.5015 18.4331 20
+    endloop
+  endfacet
+  facet normal 0.610458 -0.782231 -0.124321
+    outer loop
+      vertex -30.1869 40.7023 0
+      vertex -30.3878 37.3669 20
+      vertex -32.1396 39.1784 0
+    endloop
+  endfacet
+  facet normal 0.610462 -0.782228 -0.12432
+    outer loop
+      vertex -30.3878 37.3669 20
+      vertex -30.1869 40.7023 0
+      vertex -28.6937 38.689 20
+    endloop
+  endfacet
+  facet normal -0.907007 0.402346 -0.12432
+    outer loop
+      vertex 45.8135 -21.6568 0
+      vertex 43.5434 -20.5945 20
+      vertex 43.6307 -20.3977 20
+    endloop
+  endfacet
+  facet normal -0.909495 0.396695 -0.124303
+    outer loop
+      vertex 43.5434 -20.5945 20
+      vertex 45.8135 -21.6568 0
+      vertex 45.8094 -21.6662 0
+    endloop
+  endfacet
+  facet normal 0.838303 0.530842 -0.124317
+    outer loop
+      vertex -40.0503 -26.7608 20
+      vertex -43.4596 -26.0606 0
+      vertex -41.2 -24.9452 20
+    endloop
+  endfacet
+  facet normal 0.838298 0.530851 -0.124315
+    outer loop
+      vertex -43.4596 -26.0606 0
+      vertex -40.0503 -26.7608 20
+      vertex -42.1344 -28.1533 0
+    endloop
+  endfacet
+  facet normal 0.984777 0.121484 -0.124318
+    outer loop
+      vertex -47.6467 -7.06773 20
+      vertex -50.4294 -4.97716 0
+      vertex -47.9098 -4.93498 20
+    endloop
+  endfacet
+  facet normal 0.98478 0.121457 -0.124322
+    outer loop
+      vertex -50.4294 -4.97716 0
+      vertex -47.6467 -7.06773 20
+      vertex -50.1262 -7.43552 0
+    endloop
+  endfacet
+  facet normal 0.811358 0.571177 -0.124319
+    outer loop
+      vertex -38.689 -28.6937 20
+      vertex -40.7082 -30.1785 0
+      vertex -38.8129 -28.5177 20
+    endloop
+  endfacet
+  facet normal 0.811968 0.570311 -0.124316
+    outer loop
+      vertex -40.7082 -30.1785 0
+      vertex -38.689 -28.6937 20
+      vertex -40.7023 -30.1869 0
+    endloop
+  endfacet
+  facet normal 0.609178 -0.783229 -0.124319
+    outer loop
+      vertex -32.1396 39.1784 0
+      vertex -30.5575 37.2344 20
+      vertex -32.1477 39.1721 0
+    endloop
+  endfacet
+  facet normal 0.610644 -0.782085 -0.124324
+    outer loop
+      vertex -30.5575 37.2344 20
+      vertex -32.1396 39.1784 0
+      vertex -30.3878 37.3669 20
+    endloop
+  endfacet
+  facet normal -0.0730013 -0.989553 -0.124322
+    outer loop
+      vertex 2.49671 50.6129 0
+      vertex 4.7213 47.9361 20
+      vertex 2.57821 48.0942 20
+    endloop
+  endfacet
+  facet normal -0.0729863 -0.989554 -0.124324
+    outer loop
+      vertex 4.7213 47.9361 20
+      vertex 2.49671 50.6129 0
+      vertex 4.96699 50.4307 0
+    endloop
+  endfacet
+  facet normal -0.989553 0.0730013 -0.124322
+    outer loop
+      vertex 50.6129 -2.49671 0
+      vertex 47.9361 -4.7213 20
+      vertex 48.0942 -2.57821 20
+    endloop
+  endfacet
+  facet normal -0.989554 0.0729863 -0.124324
+    outer loop
+      vertex 47.9361 -4.7213 20
+      vertex 50.6129 -2.49671 0
+      vertex 50.4307 -4.96699 0
+    endloop
+  endfacet
+  facet normal 0.718632 0.684187 -0.12432
+    outer loop
+      vertex -34.2084 -33.9041 20
+      vertex -37.5475 -34.031 0
+      vertex -35.6902 -32.3477 20
+    endloop
+  endfacet
+  facet normal 0.718634 0.684185 -0.124321
+    outer loop
+      vertex -37.5475 -34.031 0
+      vertex -34.2084 -33.9041 20
+      vertex -35.8395 -35.825 0
+    endloop
+  endfacet
+  facet normal 0.311266 0.942157 -0.124316
+    outer loop
+      vertex -14.7198 -48.4894 0
+      vertex -16.2273 -45.3524 20
+      vertex -14.1869 -46.0265 20
+    endloop
+  endfacet
+  facet normal 0.31125 0.942162 -0.124318
+    outer loop
+      vertex -16.2273 -45.3524 20
+      vertex -14.7198 -48.4894 0
+      vertex -17.0718 -47.7124 0
+    endloop
+  endfacet
+  facet normal -0.446098 0.886308 -0.124319
+    outer loop
+      vertex 21.6754 -45.8047 0
+      vertex 22.7063 -42.4805 20
+      vertex 23.8879 -44.6911 0
+    endloop
+  endfacet
+  facet normal -0.446088 0.886312 -0.12432
+    outer loop
+      vertex 22.7063 -42.4805 20
+      vertex 21.6754 -45.8047 0
+      vertex 20.7868 -43.4466 20
+    endloop
+  endfacet
+  facet normal 0.86091 -0.493331 -0.124331
+    outer loop
+      vertex -41.3152 24.7633 20
+      vertex -43.4702 26.0431 0
+      vertex -43.4651 26.052 0
+    endloop
+  endfacet
+  facet normal 0.863345 -0.48906 -0.12432
+    outer loop
+      vertex -43.4702 26.0431 0
+      vertex -41.3152 24.7633 20
+      vertex -41.4213 24.576 20
+    endloop
+  endfacet
+  facet normal -0.751342 0.648097 -0.124322
+    outer loop
+      vertex 39.1654 -32.1554 0
+      vertex 35.6902 -32.3477 20
+      vertex 37.0938 -30.7205 20
+    endloop
+  endfacet
+  facet normal -0.751335 0.648105 -0.12432
+    outer loop
+      vertex 35.6902 -32.3477 20
+      vertex 39.1654 -32.1554 0
+      vertex 37.5475 -34.031 0
+    endloop
+  endfacet
+  facet normal -0.571357 -0.811231 -0.124315
+    outer loop
+      vertex 28.1533 42.1344 0
+      vertex 28.5177 38.8129 20
+      vertex 26.7608 40.0503 20
+    endloop
+  endfacet
+  facet normal -0.571313 -0.811262 -0.124321
+    outer loop
+      vertex 28.5177 38.8129 20
+      vertex 28.1533 42.1344 0
+      vertex 30.1785 40.7082 0
+    endloop
+  endfacet
+  facet normal 0.0732783 0.989533 -0.124315
+    outer loop
+      vertex -2.48649 -50.6136 0
+      vertex -2.57821 -48.0942 20
+      vertex -2.3635 -48.1101 20
+    endloop
+  endfacet
+  facet normal 0.0678023 0.989914 -0.124389
+    outer loop
+      vertex -2.57821 -48.0942 20
+      vertex -2.48649 -50.6136 0
+      vertex -2.49671 -50.6129 0
+    endloop
+  endfacet
+  facet normal -0.98481 0.121212 -0.124324
+    outer loop
+      vertex 50.4307 -4.96699 0
+      vertex 47.9098 -4.93498 20
+      vertex 47.9361 -4.7213 20
+    endloop
+  endfacet
+  facet normal -0.984241 0.125813 -0.12426
+    outer loop
+      vertex 47.9098 -4.93498 20
+      vertex 50.4307 -4.96699 0
+      vertex 50.4294 -4.97716 0
+    endloop
+  endfacet
+  facet normal -0.402346 -0.907007 -0.12432
+    outer loop
+      vertex 21.6568 45.8135 0
+      vertex 20.5945 43.5434 20
+      vertex 20.3977 43.6307 20
+    endloop
+  endfacet
+  facet normal -0.396695 -0.909495 -0.124303
+    outer loop
+      vertex 20.5945 43.5434 20
+      vertex 21.6568 45.8135 0
+      vertex 21.6662 45.8094 0
+    endloop
+  endfacet
+  facet normal 0.863338 -0.489073 -0.124321
+    outer loop
+      vertex -41.4213 24.576 20
+      vertex -44.6911 23.8879 0
+      vertex -43.4702 26.0431 0
+    endloop
+  endfacet
+  facet normal 0.863332 -0.489084 -0.124319
+    outer loop
+      vertex -44.6911 23.8879 0
+      vertex -41.4213 24.576 20
+      vertex -42.4805 22.7063 20
+    endloop
+  endfacet
+  facet normal -0.925757 0.357098 -0.124318
+    outer loop
+      vertex 47.7124 -17.0718 0
+      vertex 44.579 -18.2323 20
+      vertex 45.3524 -16.2273 20
+    endloop
+  endfacet
+  facet normal -0.925762 0.357085 -0.124319
+    outer loop
+      vertex 44.579 -18.2323 20
+      vertex 47.7124 -17.0718 0
+      vertex 46.821 -19.3828 0
+    endloop
+  endfacet
+  facet normal 0.570311 -0.811968 -0.124316
+    outer loop
+      vertex -30.1785 40.7082 0
+      vertex -28.6937 38.689 20
+      vertex -30.1869 40.7023 0
+    endloop
+  endfacet
+  facet normal 0.571177 -0.811358 -0.124319
+    outer loop
+      vertex -28.6937 38.689 20
+      vertex -30.1785 40.7082 0
+      vertex -28.5177 38.8129 20
+    endloop
+  endfacet
+  facet normal -0.883622 -0.451416 -0.12424
+    outer loop
+      vertex 45.8094 21.6662 0
+      vertex 43.4466 20.7868 20
+      vertex 45.8047 21.6754 0
+    endloop
+  endfacet
+  facet normal -0.886287 -0.446139 -0.124323
+    outer loop
+      vertex 43.4466 20.7868 20
+      vertex 45.8094 21.6662 0
+      vertex 43.5434 20.5945 20
+    endloop
+  endfacet
+  facet normal -0.610462 -0.782228 -0.12432
+    outer loop
+      vertex 30.1869 40.7023 0
+      vertex 30.3878 37.3669 20
+      vertex 28.6937 38.689 20
+    endloop
+  endfacet
+  facet normal -0.610458 -0.782231 -0.124321
+    outer loop
+      vertex 30.3878 37.3669 20
+      vertex 30.1869 40.7023 0
+      vertex 32.1396 39.1784 0
+    endloop
+  endfacet
+  facet normal -0.907109 -0.402118 -0.124317
+    outer loop
+      vertex 46.8173 19.3924 0
+      vertex 43.6307 20.3977 20
+      vertex 45.8135 21.6568 0
+    endloop
+  endfacet
+  facet normal -0.907125 -0.402079 -0.124322
+    outer loop
+      vertex 43.6307 20.3977 20
+      vertex 46.8173 19.3924 0
+      vertex 44.5015 18.4331 20
+    endloop
+  endfacet
+  facet normal 0.748547 -0.651333 -0.124264
+    outer loop
+      vertex -37.0938 30.7205 20
+      vertex -39.1721 32.1477 0
+      vertex -39.1654 32.1554 0
+    endloop
+  endfacet
+  facet normal 0.751345 -0.648093 -0.124324
+    outer loop
+      vertex -39.1721 32.1477 0
+      vertex -37.0938 30.7205 20
+      vertex -37.2344 30.5575 20
+    endloop
+  endfacet
+  facet normal -0.715983 -0.686957 -0.124329
+    outer loop
+      vertex 35.8395 35.825 0
+      vertex 34.06 34.06 20
+      vertex 35.8324 35.8324 0
+    endloop
+  endfacet
+  facet normal -0.718696 -0.684121 -0.12432
+    outer loop
+      vertex 34.06 34.06 20
+      vertex 35.8395 35.825 0
+      vertex 34.2084 33.9041 20
+    endloop
+  endfacet
+  facet normal -0.311266 -0.942157 -0.124316
+    outer loop
+      vertex 14.7198 48.4894 0
+      vertex 16.2273 45.3524 20
+      vertex 14.1869 46.0265 20
+    endloop
+  endfacet
+  facet normal -0.31125 -0.942162 -0.124318
+    outer loop
+      vertex 16.2273 45.3524 20
+      vertex 14.7198 48.4894 0
+      vertex 17.0718 47.7124 0
+    endloop
+  endfacet
+  facet normal 0.83592 -0.5346 -0.124257
+    outer loop
+      vertex -41.2 24.9452 20
+      vertex -43.4651 26.052 0
+      vertex -43.4596 26.0606 0
+    endloop
+  endfacet
+  facet normal 0.838272 -0.53089 -0.124318
+    outer loop
+      vertex -43.4651 26.052 0
+      vertex -41.2 24.9452 20
+      vertex -41.3152 24.7633 20
+    endloop
+  endfacet
+  facet normal -0.942162 -0.31125 -0.124318
+    outer loop
+      vertex 48.4894 14.7198 0
+      vertex 45.3524 16.2273 20
+      vertex 47.7124 17.0718 0
+    endloop
+  endfacet
+  facet normal -0.942157 -0.311266 -0.124316
+    outer loop
+      vertex 45.3524 16.2273 20
+      vertex 48.4894 14.7198 0
+      vertex 46.0265 14.1869 20
+    endloop
+  endfacet
+  facet normal -0.956295 -0.264661 -0.124317
+    outer loop
+      vertex 49.1533 12.3228 0
+      vertex 46.094 13.9825 20
+      vertex 48.4926 14.7101 0
+    endloop
+  endfacet
+  facet normal -0.956305 -0.264622 -0.124322
+    outer loop
+      vertex 46.094 13.9825 20
+      vertex 49.1533 12.3228 0
+      vertex 46.6671 11.9114 20
+    endloop
+  endfacet
+  facet normal 0.909495 -0.396695 -0.124303
+    outer loop
+      vertex -43.5434 20.5945 20
+      vertex -45.8135 21.6568 0
+      vertex -45.8094 21.6662 0
+    endloop
+  endfacet
+  facet normal 0.907007 -0.402346 -0.12432
+    outer loop
+      vertex -45.8135 21.6568 0
+      vertex -43.5434 20.5945 20
+      vertex -43.6307 20.3977 20
+    endloop
+  endfacet
+  facet normal -0.942157 0.311266 -0.124316
+    outer loop
+      vertex 48.4894 -14.7198 0
+      vertex 45.3524 -16.2273 20
+      vertex 46.0265 -14.1869 20
+    endloop
+  endfacet
+  facet normal -0.942162 0.31125 -0.124318
+    outer loop
+      vertex 45.3524 -16.2273 20
+      vertex 48.4894 -14.7198 0
+      vertex 47.7124 -17.0718 0
+    endloop
+  endfacet
+  facet normal -0.811262 -0.571313 -0.124321
+    outer loop
+      vertex 42.1344 28.1533 0
+      vertex 38.8129 28.5177 20
+      vertex 40.7082 30.1785 0
+    endloop
+  endfacet
+  facet normal -0.811231 -0.571357 -0.124315
+    outer loop
+      vertex 38.8129 28.5177 20
+      vertex 42.1344 28.1533 0
+      vertex 40.0503 26.7608 20
+    endloop
+  endfacet
+  facet normal -0.718634 -0.684185 -0.124321
+    outer loop
+      vertex 37.5475 34.031 0
+      vertex 34.2084 33.9041 20
+      vertex 35.8395 35.825 0
+    endloop
+  endfacet
+  facet normal -0.718632 -0.684187 -0.12432
+    outer loop
+      vertex 34.2084 33.9041 20
+      vertex 37.5475 34.031 0
+      vertex 35.6902 32.3477 20
+    endloop
+  endfacet
+  facet normal -0.811358 0.571177 -0.124319
+    outer loop
+      vertex 40.7082 -30.1785 0
+      vertex 38.689 -28.6937 20
+      vertex 38.8129 -28.5177 20
+    endloop
+  endfacet
+  facet normal -0.811968 0.570311 -0.124316
+    outer loop
+      vertex 38.689 -28.6937 20
+      vertex 40.7082 -30.1785 0
+      vertex 40.7023 -30.1869 0
+    endloop
+  endfacet
+  facet normal 0.98478 -0.121457 -0.124322
+    outer loop
+      vertex -47.6467 7.06773 20
+      vertex -50.4294 4.97716 0
+      vertex -50.1262 7.43552 0
+    endloop
+  endfacet
+  facet normal 0.984777 -0.121484 -0.124318
+    outer loop
+      vertex -50.4294 4.97716 0
+      vertex -47.6467 7.06773 20
+      vertex -47.9098 4.93498 20
+    endloop
+  endfacet
+  facet normal 0.925762 -0.357085 -0.124319
+    outer loop
+      vertex -44.579 18.2323 20
+      vertex -47.7124 17.0718 0
+      vertex -46.821 19.3828 0
+    endloop
+  endfacet
+  facet normal 0.925757 -0.357098 -0.124318
+    outer loop
+      vertex -47.7124 17.0718 0
+      vertex -44.579 18.2323 20
+      vertex -45.3524 16.2273 20
+    endloop
+  endfacet
+  facet normal -0.956305 0.264622 -0.124322
+    outer loop
+      vertex 49.1533 -12.3228 0
+      vertex 46.094 -13.9825 20
+      vertex 46.6671 -11.9114 20
+    endloop
+  endfacet
+  facet normal -0.956295 0.264661 -0.124317
+    outer loop
+      vertex 46.094 -13.9825 20
+      vertex 49.1533 -12.3228 0
+      vertex 48.4926 -14.7101 0
+    endloop
+  endfacet
+  facet normal -0.396695 0.909495 -0.124303
+    outer loop
+      vertex 21.6568 -45.8135 0
+      vertex 20.5945 -43.5434 20
+      vertex 21.6662 -45.8094 0
+    endloop
+  endfacet
+  facet normal -0.402346 0.907007 -0.12432
+    outer loop
+      vertex 20.5945 -43.5434 20
+      vertex 21.6568 -45.8135 0
+      vertex 20.3977 -43.6307 20
+    endloop
+  endfacet
+  facet normal -0.925762 -0.357085 -0.124319
+    outer loop
+      vertex 47.7124 17.0718 0
+      vertex 44.579 18.2323 20
+      vertex 46.821 19.3828 0
+    endloop
+  endfacet
+  facet normal -0.925757 -0.357098 -0.124318
+    outer loop
+      vertex 44.579 18.2323 20
+      vertex 47.7124 17.0718 0
+      vertex 45.3524 16.2273 20
+    endloop
+  endfacet
+  facet normal -0.684187 -0.718632 -0.12432
+    outer loop
+      vertex 34.031 37.5475 0
+      vertex 33.9041 34.2084 20
+      vertex 32.3477 35.6902 20
+    endloop
+  endfacet
+  facet normal -0.684185 -0.718634 -0.124321
+    outer loop
+      vertex 33.9041 34.2084 20
+      vertex 34.031 37.5475 0
+      vertex 35.825 35.8395 0
+    endloop
+  endfacet
+  facet normal 0.968211 0.217053 -0.124318
+    outer loop
+      vertex -46.7246 -11.7039 20
+      vertex -49.1583 -12.3029 0
+      vertex -46.7717 -11.4938 20
+    endloop
+  endfacet
+  facet normal 0.966994 0.222409 -0.12433
+    outer loop
+      vertex -49.1583 -12.3029 0
+      vertex -46.7246 -11.7039 20
+      vertex -49.156 -12.3129 0
+    endloop
+  endfacet
+  facet normal 0.686957 -0.715983 -0.124329
+    outer loop
+      vertex -35.825 35.8395 0
+      vertex -34.06 34.06 20
+      vertex -35.8324 35.8324 0
+    endloop
+  endfacet
+  facet normal 0.684121 -0.718696 -0.12432
+    outer loop
+      vertex -34.06 34.06 20
+      vertex -35.825 35.8395 0
+      vertex -33.9041 34.2084 20
+    endloop
+  endfacet
+  facet normal -0.863338 -0.489073 -0.124321
+    outer loop
+      vertex 44.6911 23.8879 0
+      vertex 41.4213 24.576 20
+      vertex 43.4702 26.0431 0
+    endloop
+  endfacet
+  facet normal -0.863332 -0.489084 -0.124319
+    outer loop
+      vertex 41.4213 24.576 20
+      vertex 44.6911 23.8879 0
+      vertex 42.4805 22.7063 20
+    endloop
+  endfacet
+  facet normal -0.217401 0.968133 -0.124322
+    outer loop
+      vertex 9.88614 -49.701 0
+      vertex 11.4938 -46.7717 20
+      vertex 12.3029 -49.1583 0
+    endloop
+  endfacet
+  facet normal -0.217435 0.968125 -0.124318
+    outer loop
+      vertex 11.4938 -46.7717 20
+      vertex 9.88614 -49.701 0
+      vertex 9.39713 -47.2426 20
+    endloop
+  endfacet
+  facet normal -0.357085 0.925762 -0.124319
+    outer loop
+      vertex 17.0718 -47.7124 0
+      vertex 18.2323 -44.579 20
+      vertex 19.3828 -46.821 0
+    endloop
+  endfacet
+  facet normal -0.357098 0.925757 -0.124318
+    outer loop
+      vertex 18.2323 -44.579 20
+      vertex 17.0718 -47.7124 0
+      vertex 16.2273 -45.3524 20
+    endloop
+  endfacet
+  facet normal -0.571177 -0.811358 -0.124319
+    outer loop
+      vertex 30.1785 40.7082 0
+      vertex 28.6937 38.689 20
+      vertex 28.5177 38.8129 20
+    endloop
+  endfacet
+  facet normal -0.570311 -0.811968 -0.124316
+    outer loop
+      vertex 28.6937 38.689 20
+      vertex 30.1785 40.7082 0
+      vertex 30.1869 40.7023 0
+    endloop
+  endfacet
+  facet normal 0.751342 0.648097 -0.124322
+    outer loop
+      vertex -35.6902 -32.3477 20
+      vertex -39.1654 -32.1554 0
+      vertex -37.0938 -30.7205 20
+    endloop
+  endfacet
+  facet normal 0.751335 0.648105 -0.12432
+    outer loop
+      vertex -39.1654 -32.1554 0
+      vertex -35.6902 -32.3477 20
+      vertex -37.5475 -34.031 0
+    endloop
+  endfacet
+  facet normal 0.648105 -0.751335 -0.12432
+    outer loop
+      vertex -32.1554 39.1654 0
+      vertex -32.3477 35.6902 20
+      vertex -34.031 37.5475 0
+    endloop
+  endfacet
+  facet normal 0.648097 -0.751342 -0.124322
+    outer loop
+      vertex -32.3477 35.6902 20
+      vertex -32.1554 39.1654 0
+      vertex -30.7205 37.0938 20
+    endloop
+  endfacet
+  facet normal -0.838298 -0.530851 -0.124315
+    outer loop
+      vertex 43.4596 26.0606 0
+      vertex 40.0503 26.7608 20
+      vertex 42.1344 28.1533 0
+    endloop
+  endfacet
+  facet normal -0.838303 -0.530842 -0.124317
+    outer loop
+      vertex 40.0503 26.7608 20
+      vertex 43.4596 26.0606 0
+      vertex 41.2 24.9452 20
+    endloop
+  endfacet
+  facet normal -0.94229 -0.310859 -0.124321
+    outer loop
+      vertex 48.4926 14.7101 0
+      vertex 46.0265 14.1869 20
+      vertex 48.4894 14.7198 0
+    endloop
+  endfacet
+  facet normal -0.942196 -0.311146 -0.124317
+    outer loop
+      vertex 46.0265 14.1869 20
+      vertex 48.4926 14.7101 0
+      vertex 46.094 13.9825 20
+    endloop
+  endfacet
+  facet normal -0.0243555 0.991943 -0.124318
+    outer loop
+      vertex 0 -50.6747 0
+      vertex 2.14826 -48.1154 20
+      vertex 2.47624 -50.6139 0
+    endloop
+  endfacet
+  facet normal -0.0243338 0.991944 -0.12432
+    outer loop
+      vertex 2.14826 -48.1154 20
+      vertex 0 -50.6747 0
+      vertex 0 -48.1681 20
+    endloop
+  endfacet
+  facet normal 0.886308 -0.446098 -0.124319
+    outer loop
+      vertex -42.4805 22.7063 20
+      vertex -45.8047 21.6754 0
+      vertex -44.6911 23.8879 0
+    endloop
+  endfacet
+  facet normal 0.886312 -0.446088 -0.12432
+    outer loop
+      vertex -45.8047 21.6754 0
+      vertex -42.4805 22.7063 20
+      vertex -43.4466 20.7868 20
+    endloop
+  endfacet
+  facet normal -0.402118 0.907109 -0.124317
+    outer loop
+      vertex 19.3924 -46.8173 0
+      vertex 20.3977 -43.6307 20
+      vertex 21.6568 -45.8135 0
+    endloop
+  endfacet
+  facet normal -0.402079 0.907125 -0.124322
+    outer loop
+      vertex 20.3977 -43.6307 20
+      vertex 19.3924 -46.8173 0
+      vertex 18.4331 -44.5015 20
+    endloop
+  endfacet
+  facet normal 0.838298 -0.530851 -0.124315
+    outer loop
+      vertex -40.0503 26.7608 20
+      vertex -43.4596 26.0606 0
+      vertex -42.1344 28.1533 0
+    endloop
+  endfacet
+  facet normal 0.838303 -0.530842 -0.124317
+    outer loop
+      vertex -43.4596 26.0606 0
+      vertex -40.0503 26.7608 20
+      vertex -41.2 24.9452 20
+    endloop
+  endfacet
+  facet normal 0.989922 0.0678028 -0.12433
+    outer loop
+      vertex -48.1101 -2.3635 20
+      vertex -50.6129 -2.49671 0
+      vertex -50.6136 -2.48649 0
+    endloop
+  endfacet
+  facet normal 0.989533 0.0732782 -0.124318
+    outer loop
+      vertex -50.6129 -2.49671 0
+      vertex -48.1101 -2.3635 20
+      vertex -48.0942 -2.57821 20
+    endloop
+  endfacet
+  facet normal 0.783229 -0.609178 -0.124319
+    outer loop
+      vertex -37.2344 30.5575 20
+      vertex -39.1784 32.1396 0
+      vertex -39.1721 32.1477 0
+    endloop
+  endfacet
+  facet normal 0.782085 -0.610644 -0.124324
+    outer loop
+      vertex -39.1784 32.1396 0
+      vertex -37.2344 30.5575 20
+      vertex -37.3669 30.3878 20
+    endloop
+  endfacet
+  facet normal -0.751345 0.648093 -0.124324
+    outer loop
+      vertex 39.1721 -32.1477 0
+      vertex 37.0938 -30.7205 20
+      vertex 37.2344 -30.5575 20
+    endloop
+  endfacet
+  facet normal -0.748547 0.651333 -0.124264
+    outer loop
+      vertex 37.0938 -30.7205 20
+      vertex 39.1721 -32.1477 0
+      vertex 39.1654 -32.1554 0
+    endloop
+  endfacet
+  facet normal 0.968125 0.217435 -0.124318
+    outer loop
+      vertex -46.7717 -11.4938 20
+      vertex -49.701 -9.88614 0
+      vertex -47.2426 -9.39713 20
+    endloop
+  endfacet
+  facet normal 0.968133 0.217401 -0.124322
+    outer loop
+      vertex -49.701 -9.88614 0
+      vertex -46.7717 -11.4938 20
+      vertex -49.1583 -12.3029 0
+    endloop
+  endfacet
+  facet normal -0.31125 0.942162 -0.124318
+    outer loop
+      vertex 14.7198 -48.4894 0
+      vertex 16.2273 -45.3524 20
+      vertex 17.0718 -47.7124 0
+    endloop
+  endfacet
+  facet normal -0.311266 0.942157 -0.124316
+    outer loop
+      vertex 16.2273 -45.3524 20
+      vertex 14.7198 -48.4894 0
+      vertex 14.1869 -46.0265 20
+    endloop
+  endfacet
+  facet normal -0.957273 -0.261075 -0.124369
+    outer loop
+      vertex 49.156 12.3129 0
+      vertex 46.6671 11.9114 20
+      vertex 49.1533 12.3228 0
+    endloop
+  endfacet
+  facet normal -0.956209 -0.264973 -0.124315
+    outer loop
+      vertex 46.6671 11.9114 20
+      vertex 49.156 12.3129 0
+      vertex 46.7246 11.7039 20
+    endloop
+  endfacet
+  facet normal 0.886312 0.446088 -0.12432
+    outer loop
+      vertex -42.4805 -22.7063 20
+      vertex -45.8047 -21.6754 0
+      vertex -43.4466 -20.7868 20
+    endloop
+  endfacet
+  facet normal 0.886308 0.446098 -0.124319
+    outer loop
+      vertex -45.8047 -21.6754 0
+      vertex -42.4805 -22.7063 20
+      vertex -44.6911 -23.8879 0
+    endloop
+  endfacet
+  facet normal -0.748547 -0.651333 -0.124264
+    outer loop
+      vertex 39.1721 32.1477 0
+      vertex 37.0938 30.7205 20
+      vertex 39.1654 32.1554 0
+    endloop
+  endfacet
+  facet normal -0.751345 -0.648093 -0.124324
+    outer loop
+      vertex 37.0938 30.7205 20
+      vertex 39.1721 32.1477 0
+      vertex 37.2344 30.5575 20
+    endloop
+  endfacet
+  facet normal 0.493331 -0.86091 -0.124331
+    outer loop
+      vertex -26.0431 43.4702 0
+      vertex -24.7633 41.3152 20
+      vertex -26.052 43.4651 0
+    endloop
+  endfacet
+  facet normal 0.48906 -0.863345 -0.12432
+    outer loop
+      vertex -24.7633 41.3152 20
+      vertex -26.0431 43.4702 0
+      vertex -24.576 41.4213 20
+    endloop
+  endfacet
+  facet normal -0.886287 0.446139 -0.124323
+    outer loop
+      vertex 45.8094 -21.6662 0
+      vertex 43.4466 -20.7868 20
+      vertex 43.5434 -20.5945 20
+    endloop
+  endfacet
+  facet normal -0.883622 0.451416 -0.12424
+    outer loop
+      vertex 43.4466 -20.7868 20
+      vertex 45.8094 -21.6662 0
+      vertex 45.8047 -21.6754 0
+    endloop
+  endfacet
+  facet normal 0.718696 0.684121 -0.12432
+    outer loop
+      vertex -34.06 -34.06 20
+      vertex -35.8395 -35.825 0
+      vertex -34.2084 -33.9041 20
+    endloop
+  endfacet
+  facet normal 0.715983 0.686957 -0.124329
+    outer loop
+      vertex -35.8395 -35.825 0
+      vertex -34.06 -34.06 20
+      vertex -35.8324 -35.8324 0
+    endloop
+  endfacet
+  facet normal -0.907125 0.402079 -0.124322
+    outer loop
+      vertex 46.8173 -19.3924 0
+      vertex 43.6307 -20.3977 20
+      vertex 44.5015 -18.4331 20
+    endloop
+  endfacet
+  facet normal -0.907109 0.402118 -0.124317
+    outer loop
+      vertex 43.6307 -20.3977 20
+      vertex 46.8173 -19.3924 0
+      vertex 45.8135 -21.6568 0
+    endloop
+  endfacet
+  facet normal -0.925856 -0.35684 -0.124321
+    outer loop
+      vertex 46.821 19.3828 0
+      vertex 44.5015 18.4331 20
+      vertex 46.8173 19.3924 0
+    endloop
+  endfacet
+  facet normal -0.925688 -0.357275 -0.124322
+    outer loop
+      vertex 44.5015 18.4331 20
+      vertex 46.821 19.3828 0
+      vertex 44.579 18.2323 20
+    endloop
+  endfacet
+  facet normal -0.357098 -0.925757 -0.124318
+    outer loop
+      vertex 17.0718 47.7124 0
+      vertex 18.2323 44.579 20
+      vertex 16.2273 45.3524 20
+    endloop
+  endfacet
+  facet normal -0.357085 -0.925762 -0.124319
+    outer loop
+      vertex 18.2323 44.579 20
+      vertex 17.0718 47.7124 0
+      vertex 19.3828 46.821 0
+    endloop
+  endfacet
+  facet normal 0.883622 -0.451416 -0.12424
+    outer loop
+      vertex -43.4466 20.7868 20
+      vertex -45.8094 21.6662 0
+      vertex -45.8047 21.6754 0
+    endloop
+  endfacet
+  facet normal 0.886287 -0.446139 -0.124323
+    outer loop
+      vertex -45.8094 21.6662 0
+      vertex -43.4466 20.7868 20
+      vertex -43.5434 20.5945 20
+    endloop
+  endfacet
+  facet normal 0.989553 0.0730013 -0.124322
+    outer loop
+      vertex -47.9361 -4.7213 20
+      vertex -50.6129 -2.49671 0
+      vertex -48.0942 -2.57821 20
+    endloop
+  endfacet
+  facet normal 0.989554 0.0729863 -0.124324
+    outer loop
+      vertex -50.6129 -2.49671 0
+      vertex -47.9361 -4.7213 20
+      vertex -50.4307 -4.96699 0
+    endloop
+  endfacet
+  facet normal -0.782231 -0.610458 -0.124321
+    outer loop
+      vertex 40.7023 30.1869 0
+      vertex 37.3669 30.3878 20
+      vertex 39.1784 32.1396 0
+    endloop
+  endfacet
+  facet normal -0.782228 -0.610462 -0.12432
+    outer loop
+      vertex 37.3669 30.3878 20
+      vertex 40.7023 30.1869 0
+      vertex 38.689 28.6937 20
+    endloop
+  endfacet
+  facet normal -0.97764 0.169599 -0.124319
+    outer loop
+      vertex 50.1244 -7.44562 0
+      vertex 47.2426 -9.39713 20
+      vertex 47.6099 -7.27986 20
+    endloop
+  endfacet
+  facet normal -0.977639 0.169608 -0.124318
+    outer loop
+      vertex 47.2426 -9.39713 20
+      vertex 50.1244 -7.44562 0
+      vertex 49.701 -9.88614 0
+    endloop
+  endfacet
+  facet normal -0.989914 -0.0678023 -0.124389
+    outer loop
+      vertex 50.6136 2.48649 0
+      vertex 48.0942 2.57821 20
+      vertex 50.6129 2.49671 0
+    endloop
+  endfacet
+  facet normal -0.989533 -0.0732783 -0.124315
+    outer loop
+      vertex 48.0942 2.57821 20
+      vertex 50.6136 2.48649 0
+      vertex 48.1101 2.3635 20
+    endloop
+  endfacet
+  facet normal -0.489073 0.863338 -0.124321
+    outer loop
+      vertex 23.8879 -44.6911 0
+      vertex 24.576 -41.4213 20
+      vertex 26.0431 -43.4702 0
+    endloop
+  endfacet
+  facet normal -0.489084 0.863332 -0.124319
+    outer loop
+      vertex 24.576 -41.4213 20
+      vertex 23.8879 -44.6911 0
+      vertex 22.7063 -42.4805 20
+    endloop
+  endfacet
+  facet normal 0.684185 -0.718634 -0.124321
+    outer loop
+      vertex -34.031 37.5475 0
+      vertex -33.9041 34.2084 20
+      vertex -35.825 35.8395 0
+    endloop
+  endfacet
+  facet normal 0.684187 -0.718632 -0.12432
+    outer loop
+      vertex -33.9041 34.2084 20
+      vertex -34.031 37.5475 0
+      vertex -32.3477 35.6902 20
+    endloop
+  endfacet
+  facet normal -0.838303 0.530842 -0.124317
+    outer loop
+      vertex 43.4596 -26.0606 0
+      vertex 40.0503 -26.7608 20
+      vertex 41.2 -24.9452 20
+    endloop
+  endfacet
+  facet normal -0.838298 0.530851 -0.124315
+    outer loop
+      vertex 40.0503 -26.7608 20
+      vertex 43.4596 -26.0606 0
+      vertex 42.1344 -28.1533 0
+    endloop
+  endfacet
+  facet normal 0.811231 0.571357 -0.124315
+    outer loop
+      vertex -38.8129 -28.5177 20
+      vertex -42.1344 -28.1533 0
+      vertex -40.0503 -26.7608 20
+    endloop
+  endfacet
+  facet normal 0.811262 0.571313 -0.124321
+    outer loop
+      vertex -42.1344 -28.1533 0
+      vertex -38.8129 -28.5177 20
+      vertex -40.7082 -30.1785 0
+    endloop
+  endfacet
+  facet normal 0.942157 0.311266 -0.124316
+    outer loop
+      vertex -45.3524 -16.2273 20
+      vertex -48.4894 -14.7198 0
+      vertex -46.0265 -14.1869 20
+    endloop
+  endfacet
+  facet normal 0.942162 0.31125 -0.124318
+    outer loop
+      vertex -48.4894 -14.7198 0
+      vertex -45.3524 -16.2273 20
+      vertex -47.7124 -17.0718 0
+    endloop
+  endfacet
+  facet normal -0.0732783 -0.989533 -0.124315
+    outer loop
+      vertex 2.48649 50.6136 0
+      vertex 2.57821 48.0942 20
+      vertex 2.3635 48.1101 20
+    endloop
+  endfacet
+  facet normal -0.0678023 -0.989914 -0.124389
+    outer loop
+      vertex 2.57821 48.0942 20
+      vertex 2.48649 50.6136 0
+      vertex 2.49671 50.6129 0
+    endloop
+  endfacet
+  facet normal 0.169608 -0.977639 -0.124318
+    outer loop
+      vertex -7.44562 50.1244 0
+      vertex -9.39713 47.2426 20
+      vertex -9.88614 49.701 0
+    endloop
+  endfacet
+  facet normal 0.169599 -0.97764 -0.124319
+    outer loop
+      vertex -9.39713 47.2426 20
+      vertex -7.44562 50.1244 0
+      vertex -7.27986 47.6099 20
+    endloop
+  endfacet
+  facet normal 0.782231 -0.610458 -0.124321
+    outer loop
+      vertex -37.3669 30.3878 20
+      vertex -40.7023 30.1869 0
+      vertex -39.1784 32.1396 0
+    endloop
+  endfacet
+  facet normal 0.782228 -0.610462 -0.12432
+    outer loop
+      vertex -40.7023 30.1869 0
+      vertex -37.3669 30.3878 20
+      vertex -38.689 28.6937 20
+    endloop
+  endfacet
+  facet normal -0.311146 -0.942196 -0.124317
+    outer loop
+      vertex 14.7101 48.4926 0
+      vertex 14.1869 46.0265 20
+      vertex 13.9825 46.094 20
+    endloop
+  endfacet
+  facet normal -0.310859 -0.94229 -0.124321
+    outer loop
+      vertex 14.1869 46.0265 20
+      vertex 14.7101 48.4926 0
+      vertex 14.7198 48.4894 0
+    endloop
+  endfacet
+  facet normal 0.984241 -0.125813 -0.12426
+    outer loop
+      vertex -47.9098 4.93498 20
+      vertex -50.4307 4.96699 0
+      vertex -50.4294 4.97716 0
+    endloop
+  endfacet
+  facet normal 0.98481 -0.121212 -0.124324
+    outer loop
+      vertex -50.4307 4.96699 0
+      vertex -47.9098 4.93498 20
+      vertex -47.9361 4.7213 20
+    endloop
+  endfacet
+  facet normal -0.968133 -0.217401 -0.124322
+    outer loop
+      vertex 49.701 9.88614 0
+      vertex 46.7717 11.4938 20
+      vertex 49.1583 12.3029 0
+    endloop
+  endfacet
+  facet normal -0.968125 -0.217435 -0.124318
+    outer loop
+      vertex 46.7717 11.4938 20
+      vertex 49.701 9.88614 0
+      vertex 47.2426 9.39713 20
+    endloop
+  endfacet
+  facet normal -0.977639 -0.169608 -0.124318
+    outer loop
+      vertex 50.1244 7.44562 0
+      vertex 47.2426 9.39713 20
+      vertex 49.701 9.88614 0
+    endloop
+  endfacet
+  facet normal -0.97764 -0.169599 -0.124319
+    outer loop
+      vertex 47.2426 9.39713 20
+      vertex 50.1244 7.44562 0
+      vertex 47.6099 7.27986 20
+    endloop
+  endfacet
+  facet normal -0.121484 -0.984777 -0.124318
+    outer loop
+      vertex 4.97716 50.4294 0
+      vertex 7.06773 47.6467 20
+      vertex 4.93498 47.9098 20
+    endloop
+  endfacet
+  facet normal -0.121457 -0.98478 -0.124322
+    outer loop
+      vertex 7.06773 47.6467 20
+      vertex 4.97716 50.4294 0
+      vertex 7.43552 50.1262 0
+    endloop
+  endfacet
+  facet normal -0.0730013 0.989553 -0.124324
+    outer loop
+      vertex 4.96699 -50.4307 0
+      vertex 2.57821 -48.0942 20
+      vertex 4.7213 -47.9361 20
+    endloop
+  endfacet
+  facet normal -0.0729864 0.989554 -0.124322
+    outer loop
+      vertex 2.57821 -48.0942 20
+      vertex 4.96699 -50.4307 0
+      vertex 2.49671 -50.6129 0
+    endloop
+  endfacet
+  facet normal 0.530851 -0.838298 -0.124315
+    outer loop
+      vertex -26.0606 43.4596 0
+      vertex -26.7608 40.0503 20
+      vertex -28.1533 42.1344 0
+    endloop
+  endfacet
+  facet normal 0.530842 -0.838303 -0.124317
+    outer loop
+      vertex -26.7608 40.0503 20
+      vertex -26.0606 43.4596 0
+      vertex -24.9452 41.2 20
+    endloop
+  endfacet
+  facet normal -0.357275 -0.925688 -0.124322
+    outer loop
+      vertex 19.3828 46.821 0
+      vertex 18.4331 44.5015 20
+      vertex 18.2323 44.579 20
+    endloop
+  endfacet
+  facet normal -0.35684 -0.925856 -0.124321
+    outer loop
+      vertex 18.4331 44.5015 20
+      vertex 19.3828 46.821 0
+      vertex 19.3924 46.8173 0
+    endloop
+  endfacet
+  facet normal 0.684121 0.718696 -0.12432
+    outer loop
+      vertex -35.825 -35.8395 0
+      vertex -34.06 -34.06 20
+      vertex -33.9041 -34.2084 20
+    endloop
+  endfacet
+  facet normal 0.686957 0.715983 -0.124329
+    outer loop
+      vertex -34.06 -34.06 20
+      vertex -35.825 -35.8395 0
+      vertex -35.8324 -35.8324 0
+    endloop
+  endfacet
+  facet normal -0.609178 0.783229 -0.124319
+    outer loop
+      vertex 32.1396 -39.1784 0
+      vertex 30.5575 -37.2344 20
+      vertex 32.1477 -39.1721 0
+    endloop
+  endfacet
+  facet normal -0.610644 0.782085 -0.124324
+    outer loop
+      vertex 30.5575 -37.2344 20
+      vertex 32.1396 -39.1784 0
+      vertex 30.3878 -37.3669 20
+    endloop
+  endfacet
+  facet normal -0.53089 -0.838272 -0.124318
+    outer loop
+      vertex 26.052 43.4651 0
+      vertex 24.9452 41.2 20
+      vertex 24.7633 41.3152 20
+    endloop
+  endfacet
+  facet normal -0.5346 -0.83592 -0.124257
+    outer loop
+      vertex 24.9452 41.2 20
+      vertex 26.052 43.4651 0
+      vertex 26.0606 43.4596 0
+    endloop
+  endfacet
+  facet normal -0.718632 0.684187 -0.12432
+    outer loop
+      vertex 37.5475 -34.031 0
+      vertex 34.2084 -33.9041 20
+      vertex 35.6902 -32.3477 20
+    endloop
+  endfacet
+  facet normal -0.718634 0.684185 -0.124321
+    outer loop
+      vertex 34.2084 -33.9041 20
+      vertex 37.5475 -34.031 0
+      vertex 35.8395 -35.825 0
+    endloop
+  endfacet
+  facet normal 0.942196 0.311146 -0.124317
+    outer loop
+      vertex -46.0265 -14.1869 20
+      vertex -48.4926 -14.7101 0
+      vertex -46.094 -13.9825 20
+    endloop
+  endfacet
+  facet normal 0.94229 0.310859 -0.124321
+    outer loop
+      vertex -48.4926 -14.7101 0
+      vertex -46.0265 -14.1869 20
+      vertex -48.4894 -14.7198 0
+    endloop
+  endfacet
+  facet normal 0.715983 -0.686957 -0.124329
+    outer loop
+      vertex -34.06 34.06 20
+      vertex -35.8395 35.825 0
+      vertex -35.8324 35.8324 0
+    endloop
+  endfacet
+  facet normal 0.718696 -0.684121 -0.12432
+    outer loop
+      vertex -35.8395 35.825 0
+      vertex -34.06 34.06 20
+      vertex -34.2084 33.9041 20
+    endloop
+  endfacet
+  facet normal 0.610462 0.782228 -0.12432
+    outer loop
+      vertex -30.1869 -40.7023 0
+      vertex -30.3878 -37.3669 20
+      vertex -28.6937 -38.689 20
+    endloop
+  endfacet
+  facet normal 0.610458 0.782231 -0.124321
+    outer loop
+      vertex -30.3878 -37.3669 20
+      vertex -30.1869 -40.7023 0
+      vertex -32.1396 -39.1784 0
+    endloop
+  endfacet
+  facet normal -0.169608 0.977639 -0.124318
+    outer loop
+      vertex 7.44562 -50.1244 0
+      vertex 9.39713 -47.2426 20
+      vertex 9.88614 -49.701 0
+    endloop
+  endfacet
+  facet normal -0.169599 0.97764 -0.124319
+    outer loop
+      vertex 9.39713 -47.2426 20
+      vertex 7.44562 -50.1244 0
+      vertex 7.27986 -47.6099 20
+    endloop
+  endfacet
+  facet normal 0.782085 0.610644 -0.124324
+    outer loop
+      vertex -37.2344 -30.5575 20
+      vertex -39.1784 -32.1396 0
+      vertex -37.3669 -30.3878 20
+    endloop
+  endfacet
+  facet normal 0.783229 0.609178 -0.124319
+    outer loop
+      vertex -39.1784 -32.1396 0
+      vertex -37.2344 -30.5575 20
+      vertex -39.1721 -32.1477 0
+    endloop
+  endfacet
+  facet normal -0.966994 -0.222409 -0.12433
+    outer loop
+      vertex 49.1583 12.3029 0
+      vertex 46.7246 11.7039 20
+      vertex 49.156 12.3129 0
+    endloop
+  endfacet
+  facet normal -0.968211 -0.217053 -0.124318
+    outer loop
+      vertex 46.7246 11.7039 20
+      vertex 49.1583 12.3029 0
+      vertex 46.7717 11.4938 20
+    endloop
+  endfacet
+  facet normal -0.493331 0.86091 -0.124331
+    outer loop
+      vertex 26.0431 -43.4702 0
+      vertex 24.7633 -41.3152 20
+      vertex 26.052 -43.4651 0
+    endloop
+  endfacet
+  facet normal -0.48906 0.863345 -0.12432
+    outer loop
+      vertex 24.7633 -41.3152 20
+      vertex 26.0431 -43.4702 0
+      vertex 24.576 -41.4213 20
+    endloop
+  endfacet
+  facet normal -0.610644 -0.782085 -0.124324
+    outer loop
+      vertex 32.1396 39.1784 0
+      vertex 30.5575 37.2344 20
+      vertex 30.3878 37.3669 20
+    endloop
+  endfacet
+  facet normal -0.609178 -0.783229 -0.124319
+    outer loop
+      vertex 30.5575 37.2344 20
+      vertex 32.1396 39.1784 0
+      vertex 32.1477 39.1721 0
+    endloop
+  endfacet
+  facet normal 0.991944 0.0243338 -0.12432
+    outer loop
+      vertex -48.1154 -2.14826 20
+      vertex -50.6747 0 0
+      vertex -48.1681 0 20
+    endloop
+  endfacet
+  facet normal 0.991943 0.0243555 -0.124318
+    outer loop
+      vertex -50.6747 0 0
+      vertex -48.1154 -2.14826 20
+      vertex -50.6139 -2.47624 0
+    endloop
+  endfacet
+  facet normal 0.571313 -0.811262 -0.124321
+    outer loop
+      vertex -28.1533 42.1344 0
+      vertex -28.5177 38.8129 20
+      vertex -30.1785 40.7082 0
+    endloop
+  endfacet
+  facet normal 0.571357 -0.811231 -0.124315
+    outer loop
+      vertex -28.5177 38.8129 20
+      vertex -28.1533 42.1344 0
+      vertex -26.7608 40.0503 20
+    endloop
+  endfacet
+  facet normal 0.121484 0.984777 -0.124318
+    outer loop
+      vertex -4.97716 -50.4294 0
+      vertex -7.06773 -47.6467 20
+      vertex -4.93498 -47.9098 20
+    endloop
+  endfacet
+  facet normal 0.121457 0.98478 -0.124322
+    outer loop
+      vertex -7.06773 -47.6467 20
+      vertex -4.97716 -50.4294 0
+      vertex -7.43552 -50.1262 0
+    endloop
+  endfacet
+  facet normal -0.684121 -0.718696 -0.12432
+    outer loop
+      vertex 35.825 35.8395 0
+      vertex 34.06 34.06 20
+      vertex 33.9041 34.2084 20
+    endloop
+  endfacet
+  facet normal -0.686957 -0.715983 -0.124329
+    outer loop
+      vertex 34.06 34.06 20
+      vertex 35.825 35.8395 0
+      vertex 35.8324 35.8324 0
+    endloop
+  endfacet
+  facet normal -0.984241 -0.125813 -0.12426
+    outer loop
+      vertex 50.4307 4.96699 0
+      vertex 47.9098 4.93498 20
+      vertex 50.4294 4.97716 0
+    endloop
+  endfacet
+  facet normal -0.98481 -0.121212 -0.124324
+    outer loop
+      vertex 47.9098 4.93498 20
+      vertex 50.4307 4.96699 0
+      vertex 47.9361 4.7213 20
+    endloop
+  endfacet
+  facet normal -0.489084 -0.863332 -0.124319
+    outer loop
+      vertex 23.8879 44.6911 0
+      vertex 24.576 41.4213 20
+      vertex 22.7063 42.4805 20
+    endloop
+  endfacet
+  facet normal -0.489073 -0.863338 -0.124321
+    outer loop
+      vertex 24.576 41.4213 20
+      vertex 23.8879 44.6911 0
+      vertex 26.0431 43.4702 0
+    endloop
+  endfacet
+  facet normal -0.989553 -0.0730013 -0.124324
+    outer loop
+      vertex 50.4307 4.96699 0
+      vertex 48.0942 2.57821 20
+      vertex 47.9361 4.7213 20
+    endloop
+  endfacet
+  facet normal -0.989554 -0.0729864 -0.124322
+    outer loop
+      vertex 48.0942 2.57821 20
+      vertex 50.4307 4.96699 0
+      vertex 50.6129 2.49671 0
+    endloop
+  endfacet
+  facet normal -0.648093 -0.751345 -0.124324
+    outer loop
+      vertex 32.1477 39.1721 0
+      vertex 30.7205 37.0938 20
+      vertex 30.5575 37.2344 20
+    endloop
+  endfacet
+  facet normal -0.651333 -0.748547 -0.124264
+    outer loop
+      vertex 30.7205 37.0938 20
+      vertex 32.1477 39.1721 0
+      vertex 32.1554 39.1654 0
+    endloop
+  endfacet
+  facet normal -0.264622 -0.956305 -0.124322
+    outer loop
+      vertex 12.3228 49.1533 0
+      vertex 13.9825 46.094 20
+      vertex 11.9114 46.6671 20
+    endloop
+  endfacet
+  facet normal -0.264661 -0.956295 -0.124317
+    outer loop
+      vertex 13.9825 46.094 20
+      vertex 12.3228 49.1533 0
+      vertex 14.7101 48.4926 0
+    endloop
+  endfacet
+  facet normal 0.396695 -0.909495 -0.124303
+    outer loop
+      vertex -21.6568 45.8135 0
+      vertex -20.5945 43.5434 20
+      vertex -21.6662 45.8094 0
+    endloop
+  endfacet
+  facet normal 0.402346 -0.907007 -0.12432
+    outer loop
+      vertex -20.5945 43.5434 20
+      vertex -21.6568 45.8135 0
+      vertex -20.3977 43.6307 20
+    endloop
+  endfacet
+  facet normal 0.956295 -0.264661 -0.124317
+    outer loop
+      vertex -46.094 13.9825 20
+      vertex -49.1533 12.3228 0
+      vertex -48.4926 14.7101 0
+    endloop
+  endfacet
+  facet normal 0.956305 -0.264622 -0.124322
+    outer loop
+      vertex -49.1533 12.3228 0
+      vertex -46.094 13.9825 20
+      vertex -46.6671 11.9114 20
+    endloop
+  endfacet
+  facet normal 0.5346 -0.83592 -0.124257
+    outer loop
+      vertex -26.052 43.4651 0
+      vertex -24.9452 41.2 20
+      vertex -26.0606 43.4596 0
+    endloop
+  endfacet
+  facet normal 0.53089 -0.838272 -0.124318
+    outer loop
+      vertex -24.9452 41.2 20
+      vertex -26.052 43.4651 0
+      vertex -24.7633 41.3152 20
+    endloop
+  endfacet
+  facet normal -0.571313 0.811262 -0.124321
+    outer loop
+      vertex 28.1533 -42.1344 0
+      vertex 28.5177 -38.8129 20
+      vertex 30.1785 -40.7082 0
+    endloop
+  endfacet
+  facet normal -0.571357 0.811231 -0.124315
+    outer loop
+      vertex 28.5177 -38.8129 20
+      vertex 28.1533 -42.1344 0
+      vertex 26.7608 -40.0503 20
+    endloop
+  endfacet
+  facet normal 0.989553 -0.0730013 -0.124324
+    outer loop
+      vertex -48.0942 2.57821 20
+      vertex -50.4307 4.96699 0
+      vertex -47.9361 4.7213 20
+    endloop
+  endfacet
+  facet normal 0.989554 -0.0729864 -0.124322
+    outer loop
+      vertex -50.4307 4.96699 0
+      vertex -48.0942 2.57821 20
+      vertex -50.6129 2.49671 0
+    endloop
+  endfacet
+  facet normal -0.968125 0.217435 -0.124318
+    outer loop
+      vertex 49.701 -9.88614 0
+      vertex 46.7717 -11.4938 20
+      vertex 47.2426 -9.39713 20
+    endloop
+  endfacet
+  facet normal -0.968133 0.217401 -0.124322
+    outer loop
+      vertex 46.7717 -11.4938 20
+      vertex 49.701 -9.88614 0
+      vertex 49.1583 -12.3029 0
+    endloop
+  endfacet
+  facet normal -0.718696 0.684121 -0.12432
+    outer loop
+      vertex 35.8395 -35.825 0
+      vertex 34.06 -34.06 20
+      vertex 34.2084 -33.9041 20
+    endloop
+  endfacet
+  facet normal -0.715983 0.686957 -0.124329
+    outer loop
+      vertex 34.06 -34.06 20
+      vertex 35.8395 -35.825 0
+      vertex 35.8324 -35.8324 0
+    endloop
+  endfacet
+  facet normal 0.942162 -0.31125 -0.124318
+    outer loop
+      vertex -45.3524 16.2273 20
+      vertex -48.4894 14.7198 0
+      vertex -47.7124 17.0718 0
+    endloop
+  endfacet
+  facet normal 0.942157 -0.311266 -0.124316
+    outer loop
+      vertex -48.4894 14.7198 0
+      vertex -45.3524 16.2273 20
+      vertex -46.0265 14.1869 20
+    endloop
+  endfacet
+  facet normal 0.811968 -0.570311 -0.124316
+    outer loop
+      vertex -38.689 28.6937 20
+      vertex -40.7082 30.1785 0
+      vertex -40.7023 30.1869 0
+    endloop
+  endfacet
+  facet normal 0.811358 -0.571177 -0.124319
+    outer loop
+      vertex -40.7082 30.1785 0
+      vertex -38.689 28.6937 20
+      vertex -38.8129 28.5177 20
+    endloop
+  endfacet
+  facet normal 0.648097 0.751342 -0.124322
+    outer loop
+      vertex -32.1554 -39.1654 0
+      vertex -32.3477 -35.6902 20
+      vertex -30.7205 -37.0938 20
+    endloop
+  endfacet
+  facet normal 0.648105 0.751335 -0.12432
+    outer loop
+      vertex -32.3477 -35.6902 20
+      vertex -32.1554 -39.1654 0
+      vertex -34.031 -37.5475 0
+    endloop
+  endfacet
+  facet normal 0.991816 -0.0290288 -0.124329
+    outer loop
+      vertex -48.1101 2.3635 20
+      vertex -50.6139 2.47624 0
+      vertex -50.6136 2.48649 0
+    endloop
+  endfacet
+  facet normal 0.991942 -0.0244252 -0.124319
+    outer loop
+      vertex -50.6139 2.47624 0
+      vertex -48.1101 2.3635 20
+      vertex -48.1154 2.14826 20
+    endloop
+  endfacet
+  facet normal -0.838272 0.53089 -0.124318
+    outer loop
+      vertex 43.4651 -26.052 0
+      vertex 41.2 -24.9452 20
+      vertex 41.3152 -24.7633 20
+    endloop
+  endfacet
+  facet normal -0.83592 0.5346 -0.124257
+    outer loop
+      vertex 41.2 -24.9452 20
+      vertex 43.4651 -26.052 0
+      vertex 43.4596 -26.0606 0
+    endloop
+  endfacet
+  facet normal -0.222409 0.966994 -0.12433
+    outer loop
+      vertex 12.3029 -49.1583 0
+      vertex 11.7039 -46.7246 20
+      vertex 12.3129 -49.156 0
+    endloop
+  endfacet
+  facet normal -0.217053 0.968211 -0.124318
+    outer loop
+      vertex 11.7039 -46.7246 20
+      vertex 12.3029 -49.1583 0
+      vertex 11.4938 -46.7717 20
+    endloop
+  endfacet
+  facet normal -0.991816 -0.0290288 -0.124329
+    outer loop
+      vertex 50.6139 2.47624 0
+      vertex 48.1101 2.3635 20
+      vertex 50.6136 2.48649 0
+    endloop
+  endfacet
+  facet normal -0.991942 -0.0244252 -0.124319
+    outer loop
+      vertex 48.1101 2.3635 20
+      vertex 50.6139 2.47624 0
+      vertex 48.1154 2.14826 20
+    endloop
+  endfacet
+  facet normal -0.751335 -0.648105 -0.12432
+    outer loop
+      vertex 39.1654 32.1554 0
+      vertex 35.6902 32.3477 20
+      vertex 37.5475 34.031 0
+    endloop
+  endfacet
+  facet normal -0.751342 -0.648097 -0.124322
+    outer loop
+      vertex 35.6902 32.3477 20
+      vertex 39.1654 32.1554 0
+      vertex 37.0938 30.7205 20
+    endloop
+  endfacet
+  facet normal -0.811968 -0.570311 -0.124316
+    outer loop
+      vertex 40.7082 30.1785 0
+      vertex 38.689 28.6937 20
+      vertex 40.7023 30.1869 0
+    endloop
+  endfacet
+  facet normal -0.811358 -0.571177 -0.124319
+    outer loop
+      vertex 38.689 28.6937 20
+      vertex 40.7082 30.1785 0
+      vertex 38.8129 28.5177 20
+    endloop
+  endfacet
+  facet normal 0.357098 0.925757 -0.124318
+    outer loop
+      vertex -17.0718 -47.7124 0
+      vertex -18.2323 -44.579 20
+      vertex -16.2273 -45.3524 20
+    endloop
+  endfacet
+  facet normal 0.357085 0.925762 -0.124319
+    outer loop
+      vertex -18.2323 -44.579 20
+      vertex -17.0718 -47.7124 0
+      vertex -19.3828 -46.821 0
+    endloop
+  endfacet
+  facet normal -0.451416 0.883622 -0.12424
+    outer loop
+      vertex 21.6662 -45.8094 0
+      vertex 20.7868 -43.4466 20
+      vertex 21.6754 -45.8047 0
+    endloop
+  endfacet
+  facet normal -0.446139 0.886287 -0.124323
+    outer loop
+      vertex 20.7868 -43.4466 20
+      vertex 21.6662 -45.8094 0
+      vertex 20.5945 -43.5434 20
+    endloop
+  endfacet
+  facet normal 0.651333 -0.748547 -0.124264
+    outer loop
+      vertex -32.1477 39.1721 0
+      vertex -30.7205 37.0938 20
+      vertex -32.1554 39.1654 0
+    endloop
+  endfacet
+  facet normal 0.648093 -0.751345 -0.124324
+    outer loop
+      vertex -30.7205 37.0938 20
+      vertex -32.1477 39.1721 0
+      vertex -30.5575 37.2344 20
+    endloop
+  endfacet
+  facet normal 0.217435 0.968125 -0.124318
+    outer loop
+      vertex -9.88614 -49.701 0
+      vertex -11.4938 -46.7717 20
+      vertex -9.39713 -47.2426 20
+    endloop
+  endfacet
+  facet normal 0.217401 0.968133 -0.124322
+    outer loop
+      vertex -11.4938 -46.7717 20
+      vertex -9.88614 -49.701 0
+      vertex -12.3029 -49.1583 0
+    endloop
+  endfacet
+  facet normal 0.402079 0.907125 -0.124322
+    outer loop
+      vertex -19.3924 -46.8173 0
+      vertex -20.3977 -43.6307 20
+      vertex -18.4331 -44.5015 20
+    endloop
+  endfacet
+  facet normal 0.402118 0.907109 -0.124317
+    outer loop
+      vertex -20.3977 -43.6307 20
+      vertex -19.3924 -46.8173 0
+      vertex -21.6568 -45.8135 0
+    endloop
+  endfacet
+  facet normal -0.217435 -0.968125 -0.124318
+    outer loop
+      vertex 9.88614 49.701 0
+      vertex 11.4938 46.7717 20
+      vertex 9.39713 47.2426 20
+    endloop
+  endfacet
+  facet normal -0.217401 -0.968133 -0.124322
+    outer loop
+      vertex 11.4938 46.7717 20
+      vertex 9.88614 49.701 0
+      vertex 12.3029 49.1583 0
+    endloop
+  endfacet
+  facet normal -0.976858 -0.174093 -0.124258
+    outer loop
+      vertex 50.1262 7.43552 0
+      vertex 47.6099 7.27986 20
+      vertex 50.1244 7.44562 0
+    endloop
+  endfacet
+  facet normal -0.97764 -0.1696 -0.124322
+    outer loop
+      vertex 47.6099 7.27986 20
+      vertex 50.1262 7.43552 0
+      vertex 47.6467 7.06773 20
+    endloop
+  endfacet
+  facet normal -0.121457 0.98478 -0.124322
+    outer loop
+      vertex 4.97716 -50.4294 0
+      vertex 7.06773 -47.6467 20
+      vertex 7.43552 -50.1262 0
+    endloop
+  endfacet
+  facet normal -0.121484 0.984777 -0.124318
+    outer loop
+      vertex 7.06773 -47.6467 20
+      vertex 4.97716 -50.4294 0
+      vertex 4.93498 -47.9098 20
+    endloop
+  endfacet
+  facet normal 0.782228 0.610462 -0.12432
+    outer loop
+      vertex -37.3669 -30.3878 20
+      vertex -40.7023 -30.1869 0
+      vertex -38.689 -28.6937 20
+    endloop
+  endfacet
+  facet normal 0.782231 0.610458 -0.124321
+    outer loop
+      vertex -40.7023 -30.1869 0
+      vertex -37.3669 -30.3878 20
+      vertex -39.1784 -32.1396 0
+    endloop
+  endfacet
+  facet normal -0.446088 -0.886312 -0.12432
+    outer loop
+      vertex 21.6754 45.8047 0
+      vertex 22.7063 42.4805 20
+      vertex 20.7868 43.4466 20
+    endloop
+  endfacet
+  facet normal -0.446098 -0.886308 -0.124319
+    outer loop
+      vertex 22.7063 42.4805 20
+      vertex 21.6754 45.8047 0
+      vertex 23.8879 44.6911 0
+    endloop
+  endfacet
+  facet normal 0.925688 0.357275 -0.124322
+    outer loop
+      vertex -44.5015 -18.4331 20
+      vertex -46.821 -19.3828 0
+      vertex -44.579 -18.2323 20
+    endloop
+  endfacet
+  facet normal 0.925856 0.35684 -0.124321
+    outer loop
+      vertex -46.821 -19.3828 0
+      vertex -44.5015 -18.4331 20
+      vertex -46.8173 -19.3924 0
+    endloop
+  endfacet
+  facet normal -0.648097 -0.751342 -0.124322
+    outer loop
+      vertex 32.1554 39.1654 0
+      vertex 32.3477 35.6902 20
+      vertex 30.7205 37.0938 20
+    endloop
+  endfacet
+  facet normal -0.648105 -0.751335 -0.12432
+    outer loop
+      vertex 32.3477 35.6902 20
+      vertex 32.1554 39.1654 0
+      vertex 34.031 37.5475 0
+    endloop
+  endfacet
+  facet normal -0.402079 -0.907125 -0.124322
+    outer loop
+      vertex 19.3924 46.8173 0
+      vertex 20.3977 43.6307 20
+      vertex 18.4331 44.5015 20
+    endloop
+  endfacet
+  facet normal -0.402118 -0.907109 -0.124317
+    outer loop
+      vertex 20.3977 43.6307 20
+      vertex 19.3924 46.8173 0
+      vertex 21.6568 45.8135 0
+    endloop
+  endfacet
+  facet normal 0.1696 0.97764 -0.124322
+    outer loop
+      vertex -7.43552 -50.1262 0
+      vertex -7.27986 -47.6099 20
+      vertex -7.06773 -47.6467 20
+    endloop
+  endfacet
+  facet normal 0.174093 0.976858 -0.124258
+    outer loop
+      vertex -7.27986 -47.6099 20
+      vertex -7.43552 -50.1262 0
+      vertex -7.44562 -50.1244 0
+    endloop
+  endfacet
+  facet normal -0.909495 -0.396695 -0.124303
+    outer loop
+      vertex 45.8135 21.6568 0
+      vertex 43.5434 20.5945 20
+      vertex 45.8094 21.6662 0
+    endloop
+  endfacet
+  facet normal -0.907007 -0.402346 -0.12432
+    outer loop
+      vertex 43.5434 20.5945 20
+      vertex 45.8135 21.6568 0
+      vertex 43.6307 20.3977 20
+    endloop
+  endfacet
+  facet normal 0.402346 0.907007 -0.12432
+    outer loop
+      vertex -21.6568 -45.8135 0
+      vertex -20.5945 -43.5434 20
+      vertex -20.3977 -43.6307 20
+    endloop
+  endfacet
+  facet normal 0.396695 0.909495 -0.124303
+    outer loop
+      vertex -20.5945 -43.5434 20
+      vertex -21.6568 -45.8135 0
+      vertex -21.6662 -45.8094 0
+    endloop
+  endfacet
+  facet normal -0.811231 0.571357 -0.124315
+    outer loop
+      vertex 42.1344 -28.1533 0
+      vertex 38.8129 -28.5177 20
+      vertex 40.0503 -26.7608 20
+    endloop
+  endfacet
+  facet normal -0.811262 0.571313 -0.124321
+    outer loop
+      vertex 38.8129 -28.5177 20
+      vertex 42.1344 -28.1533 0
+      vertex 40.7082 -30.1785 0
+    endloop
+  endfacet
+  facet normal -0.925688 0.357275 -0.124322
+    outer loop
+      vertex 46.821 -19.3828 0
+      vertex 44.5015 -18.4331 20
+      vertex 44.579 -18.2323 20
+    endloop
+  endfacet
+  facet normal -0.925856 0.35684 -0.124321
+    outer loop
+      vertex 44.5015 -18.4331 20
+      vertex 46.821 -19.3828 0
+      vertex 46.8173 -19.3924 0
+    endloop
+  endfacet
+  facet normal 0.310859 -0.94229 -0.124321
+    outer loop
+      vertex -14.7101 48.4926 0
+      vertex -14.1869 46.0265 20
+      vertex -14.7198 48.4894 0
+    endloop
+  endfacet
+  facet normal 0.311146 -0.942196 -0.124317
+    outer loop
+      vertex -14.1869 46.0265 20
+      vertex -14.7101 48.4926 0
+      vertex -13.9825 46.094 20
+    endloop
+  endfacet
+  facet normal 0.48906 0.863345 -0.12432
+    outer loop
+      vertex -26.0431 -43.4702 0
+      vertex -24.7633 -41.3152 20
+      vertex -24.576 -41.4213 20
+    endloop
+  endfacet
+  facet normal 0.493331 0.86091 -0.124331
+    outer loop
+      vertex -24.7633 -41.3152 20
+      vertex -26.0431 -43.4702 0
+      vertex -26.052 -43.4651 0
+    endloop
+  endfacet
+  facet normal -0.310859 0.94229 -0.124321
+    outer loop
+      vertex 14.7101 -48.4926 0
+      vertex 14.1869 -46.0265 20
+      vertex 14.7198 -48.4894 0
+    endloop
+  endfacet
+  facet normal -0.311146 0.942196 -0.124317
+    outer loop
+      vertex 14.1869 -46.0265 20
+      vertex 14.7101 -48.4926 0
+      vertex 13.9825 -46.094 20
+    endloop
+  endfacet
+  facet normal -0.530842 -0.838303 -0.124317
+    outer loop
+      vertex 26.0606 43.4596 0
+      vertex 26.7608 40.0503 20
+      vertex 24.9452 41.2 20
+    endloop
+  endfacet
+  facet normal -0.530851 -0.838298 -0.124315
+    outer loop
+      vertex 26.7608 40.0503 20
+      vertex 26.0606 43.4596 0
+      vertex 28.1533 42.1344 0
+    endloop
+  endfacet
+  facet normal -0.989922 0.0678028 -0.12433
+    outer loop
+      vertex 50.6129 -2.49671 0
+      vertex 48.1101 -2.3635 20
+      vertex 50.6136 -2.48649 0
+    endloop
+  endfacet
+  facet normal -0.989533 0.0732782 -0.124318
+    outer loop
+      vertex 48.1101 -2.3635 20
+      vertex 50.6129 -2.49671 0
+      vertex 48.0942 -2.57821 20
+    endloop
+  endfacet
+  facet normal -0.886312 0.446088 -0.12432
+    outer loop
+      vertex 45.8047 -21.6754 0
+      vertex 42.4805 -22.7063 20
+      vertex 43.4466 -20.7868 20
+    endloop
+  endfacet
+  facet normal -0.886308 0.446098 -0.124319
+    outer loop
+      vertex 42.4805 -22.7063 20
+      vertex 45.8047 -21.6754 0
+      vertex 44.6911 -23.8879 0
+    endloop
+  endfacet
+  facet normal 0.94229 -0.310859 -0.124321
+    outer loop
+      vertex -46.0265 14.1869 20
+      vertex -48.4926 14.7101 0
+      vertex -48.4894 14.7198 0
+    endloop
+  endfacet
+  facet normal 0.942196 -0.311146 -0.124317
+    outer loop
+      vertex -48.4926 14.7101 0
+      vertex -46.0265 14.1869 20
+      vertex -46.094 13.9825 20
+    endloop
+  endfacet
+  facet normal 0.571177 0.811358 -0.124319
+    outer loop
+      vertex -30.1785 -40.7082 0
+      vertex -28.6937 -38.689 20
+      vertex -28.5177 -38.8129 20
+    endloop
+  endfacet
+  facet normal 0.570311 0.811968 -0.124316
+    outer loop
+      vertex -28.6937 -38.689 20
+      vertex -30.1785 -40.7082 0
+      vertex -30.1869 -40.7023 0
+    endloop
+  endfacet
+  facet normal 0.0732782 -0.989533 -0.124318
+    outer loop
+      vertex -2.49671 50.6129 0
+      vertex -2.3635 48.1101 20
+      vertex -2.57821 48.0942 20
+    endloop
+  endfacet
+  facet normal 0.0678028 -0.989922 -0.12433
+    outer loop
+      vertex -2.3635 48.1101 20
+      vertex -2.49671 50.6129 0
+      vertex -2.48649 50.6136 0
+    endloop
+  endfacet
+  facet normal 0.217401 -0.968133 -0.124322
+    outer loop
+      vertex -9.88614 49.701 0
+      vertex -11.4938 46.7717 20
+      vertex -12.3029 49.1583 0
+    endloop
+  endfacet
+  facet normal 0.217435 -0.968125 -0.124318
+    outer loop
+      vertex -11.4938 46.7717 20
+      vertex -9.88614 49.701 0
+      vertex -9.39713 47.2426 20
+    endloop
+  endfacet
+  facet normal 0.217053 0.968211 -0.124318
+    outer loop
+      vertex -12.3029 -49.1583 0
+      vertex -11.7039 -46.7246 20
+      vertex -11.4938 -46.7717 20
+    endloop
+  endfacet
+  facet normal 0.222409 0.966994 -0.12433
+    outer loop
+      vertex -11.7039 -46.7246 20
+      vertex -12.3029 -49.1583 0
+      vertex -12.3129 -49.156 0
+    endloop
+  endfacet
+  facet normal -0.686957 0.715983 -0.124329
+    outer loop
+      vertex 35.825 -35.8395 0
+      vertex 34.06 -34.06 20
+      vertex 35.8324 -35.8324 0
+    endloop
+  endfacet
+  facet normal -0.684121 0.718696 -0.12432
+    outer loop
+      vertex 34.06 -34.06 20
+      vertex 35.825 -35.8395 0
+      vertex 33.9041 -34.2084 20
+    endloop
+  endfacet
+  facet normal -0.783229 -0.609178 -0.124319
+    outer loop
+      vertex 39.1784 32.1396 0
+      vertex 37.2344 30.5575 20
+      vertex 39.1721 32.1477 0
+    endloop
+  endfacet
+  facet normal -0.782085 -0.610644 -0.124324
+    outer loop
+      vertex 37.2344 30.5575 20
+      vertex 39.1784 32.1396 0
+      vertex 37.3669 30.3878 20
+    endloop
+  endfacet
+  facet normal -0.651333 0.748547 -0.124264
+    outer loop
+      vertex 32.1477 -39.1721 0
+      vertex 30.7205 -37.0938 20
+      vertex 32.1554 -39.1654 0
+    endloop
+  endfacet
+  facet normal -0.648093 0.751345 -0.124324
+    outer loop
+      vertex 30.7205 -37.0938 20
+      vertex 32.1477 -39.1721 0
+      vertex 30.5575 -37.2344 20
+    endloop
+  endfacet
+  facet normal 0.0290288 -0.991816 -0.124329
+    outer loop
+      vertex -2.47624 50.6139 0
+      vertex -2.3635 48.1101 20
+      vertex -2.48649 50.6136 0
+    endloop
+  endfacet
+  facet normal 0.0244252 -0.991942 -0.124319
+    outer loop
+      vertex -2.3635 48.1101 20
+      vertex -2.47624 50.6139 0
+      vertex -2.14826 48.1154 20
+    endloop
+  endfacet
+  facet normal -0.264973 -0.956209 -0.124315
+    outer loop
+      vertex 12.3129 49.156 0
+      vertex 11.9114 46.6671 20
+      vertex 11.7039 46.7246 20
+    endloop
+  endfacet
+  facet normal -0.261075 -0.957273 -0.124369
+    outer loop
+      vertex 11.9114 46.6671 20
+      vertex 12.3129 49.156 0
+      vertex 12.3228 49.1533 0
+    endloop
+  endfacet
+  facet normal -0.83592 -0.5346 -0.124257
+    outer loop
+      vertex 43.4651 26.052 0
+      vertex 41.2 24.9452 20
+      vertex 43.4596 26.0606 0
+    endloop
+  endfacet
+  facet normal -0.838272 -0.53089 -0.124318
+    outer loop
+      vertex 41.2 24.9452 20
+      vertex 43.4651 26.052 0
+      vertex 41.3152 24.7633 20
+    endloop
+  endfacet
+  facet normal 0.125813 -0.984241 -0.12426
+    outer loop
+      vertex -4.96699 50.4307 0
+      vertex -4.93498 47.9098 20
+      vertex -4.97716 50.4294 0
+    endloop
+  endfacet
+  facet normal 0.121212 -0.98481 -0.124324
+    outer loop
+      vertex -4.93498 47.9098 20
+      vertex -4.96699 50.4307 0
+      vertex -4.7213 47.9361 20
+    endloop
+  endfacet
+  facet normal 0.956305 0.264622 -0.124322
+    outer loop
+      vertex -46.094 -13.9825 20
+      vertex -49.1533 -12.3228 0
+      vertex -46.6671 -11.9114 20
+    endloop
+  endfacet
+  facet normal 0.956295 0.264661 -0.124317
+    outer loop
+      vertex -49.1533 -12.3228 0
+      vertex -46.094 -13.9825 20
+      vertex -48.4926 -14.7101 0
+    endloop
+  endfacet
+  facet normal -0.169599 -0.97764 -0.124319
+    outer loop
+      vertex 7.44562 50.1244 0
+      vertex 9.39713 47.2426 20
+      vertex 7.27986 47.6099 20
+    endloop
+  endfacet
+  facet normal -0.169608 -0.977639 -0.124318
+    outer loop
+      vertex 9.39713 47.2426 20
+      vertex 7.44562 50.1244 0
+      vertex 9.88614 49.701 0
+    endloop
+  endfacet
+  facet normal 0.31125 -0.942162 -0.124318
+    outer loop
+      vertex -14.7198 48.4894 0
+      vertex -16.2273 45.3524 20
+      vertex -17.0718 47.7124 0
+    endloop
+  endfacet
+  facet normal 0.311266 -0.942157 -0.124316
+    outer loop
+      vertex -16.2273 45.3524 20
+      vertex -14.7198 48.4894 0
+      vertex -14.1869 46.0265 20
+    endloop
+  endfacet
+  facet normal 0.222409 -0.966994 -0.12433
+    outer loop
+      vertex -12.3029 49.1583 0
+      vertex -11.7039 46.7246 20
+      vertex -12.3129 49.156 0
+    endloop
+  endfacet
+  facet normal 0.217053 -0.968211 -0.124318
+    outer loop
+      vertex -11.7039 46.7246 20
+      vertex -12.3029 49.1583 0
+      vertex -11.4938 46.7717 20
+    endloop
+  endfacet
+  facet normal 0.174093 -0.976858 -0.124258
+    outer loop
+      vertex -7.43552 50.1262 0
+      vertex -7.27986 47.6099 20
+      vertex -7.44562 50.1244 0
+    endloop
+  endfacet
+  facet normal 0.1696 -0.97764 -0.124322
+    outer loop
+      vertex -7.27986 47.6099 20
+      vertex -7.43552 50.1262 0
+      vertex -7.06773 47.6467 20
+    endloop
+  endfacet
+  facet normal 0.863332 0.489084 -0.124319
+    outer loop
+      vertex -41.4213 -24.576 20
+      vertex -44.6911 -23.8879 0
+      vertex -42.4805 -22.7063 20
+    endloop
+  endfacet
+  facet normal 0.863338 0.489073 -0.124321
+    outer loop
+      vertex -44.6911 -23.8879 0
+      vertex -41.4213 -24.576 20
+      vertex -43.4702 -26.0431 0
+    endloop
+  endfacet
+  facet normal -0.121212 -0.98481 -0.124324
+    outer loop
+      vertex 4.96699 50.4307 0
+      vertex 4.93498 47.9098 20
+      vertex 4.7213 47.9361 20
+    endloop
+  endfacet
+  facet normal -0.125813 -0.984241 -0.12426
+    outer loop
+      vertex 4.93498 47.9098 20
+      vertex 4.96699 50.4307 0
+      vertex 4.97716 50.4294 0
+    endloop
+  endfacet
+  facet normal 0.35684 -0.925856 -0.124321
+    outer loop
+      vertex -19.3828 46.821 0
+      vertex -18.4331 44.5015 20
+      vertex -19.3924 46.8173 0
+    endloop
+  endfacet
+  facet normal 0.357275 -0.925688 -0.124322
+    outer loop
+      vertex -18.4331 44.5015 20
+      vertex -19.3828 46.821 0
+      vertex -18.2323 44.579 20
+    endloop
+  endfacet
+  facet normal 0.966994 -0.222409 -0.12433
+    outer loop
+      vertex -46.7246 11.7039 20
+      vertex -49.1583 12.3029 0
+      vertex -49.156 12.3129 0
+    endloop
+  endfacet
+  facet normal 0.968211 -0.217053 -0.124318
+    outer loop
+      vertex -49.1583 12.3029 0
+      vertex -46.7246 11.7039 20
+      vertex -46.7717 11.4938 20
+    endloop
+  endfacet
+  facet normal 0.357275 0.925688 -0.124322
+    outer loop
+      vertex -19.3828 -46.821 0
+      vertex -18.4331 -44.5015 20
+      vertex -18.2323 -44.579 20
+    endloop
+  endfacet
+  facet normal 0.35684 0.925856 -0.124321
+    outer loop
+      vertex -18.4331 -44.5015 20
+      vertex -19.3828 -46.821 0
+      vertex -19.3924 -46.8173 0
+    endloop
+  endfacet
+  facet normal 0.451416 -0.883622 -0.12424
+    outer loop
+      vertex -21.6662 45.8094 0
+      vertex -20.7868 43.4466 20
+      vertex -21.6754 45.8047 0
+    endloop
+  endfacet
+  facet normal 0.446139 -0.886287 -0.124323
+    outer loop
+      vertex -20.7868 43.4466 20
+      vertex -21.6662 45.8094 0
+      vertex -20.5945 43.5434 20
+    endloop
+  endfacet
+  facet normal 0.976858 -0.174093 -0.124258
+    outer loop
+      vertex -47.6099 7.27986 20
+      vertex -50.1262 7.43552 0
+      vertex -50.1244 7.44562 0
+    endloop
+  endfacet
+  facet normal 0.97764 -0.1696 -0.124322
+    outer loop
+      vertex -50.1262 7.43552 0
+      vertex -47.6099 7.27986 20
+      vertex -47.6467 7.06773 20
+    endloop
+  endfacet
+  facet normal 0.357085 -0.925762 -0.124319
+    outer loop
+      vertex -17.0718 47.7124 0
+      vertex -18.2323 44.579 20
+      vertex -19.3828 46.821 0
+    endloop
+  endfacet
+  facet normal 0.357098 -0.925757 -0.124318
+    outer loop
+      vertex -18.2323 44.579 20
+      vertex -17.0718 47.7124 0
+      vertex -16.2273 45.3524 20
+    endloop
+  endfacet
+  facet normal 0.97764 0.169599 -0.124319
+    outer loop
+      vertex -47.2426 -9.39713 20
+      vertex -50.1244 -7.44562 0
+      vertex -47.6099 -7.27986 20
+    endloop
+  endfacet
+  facet normal 0.977639 0.169608 -0.124318
+    outer loop
+      vertex -50.1244 -7.44562 0
+      vertex -47.2426 -9.39713 20
+      vertex -49.701 -9.88614 0
+    endloop
+  endfacet
+  facet normal -0.5346 0.83592 -0.124257
+    outer loop
+      vertex 26.052 -43.4651 0
+      vertex 24.9452 -41.2 20
+      vertex 26.0606 -43.4596 0
+    endloop
+  endfacet
+  facet normal -0.53089 0.838272 -0.124318
+    outer loop
+      vertex 24.9452 -41.2 20
+      vertex 26.052 -43.4651 0
+      vertex 24.7633 -41.3152 20
+    endloop
+  endfacet
+  facet normal -0.956209 0.264973 -0.124315
+    outer loop
+      vertex 49.156 -12.3129 0
+      vertex 46.6671 -11.9114 20
+      vertex 46.7246 -11.7039 20
+    endloop
+  endfacet
+  facet normal -0.957273 0.261075 -0.124369
+    outer loop
+      vertex 46.6671 -11.9114 20
+      vertex 49.156 -12.3129 0
+      vertex 49.1533 -12.3228 0
+    endloop
+  endfacet
+  facet normal -0.684185 0.718634 -0.124321
+    outer loop
+      vertex 34.031 -37.5475 0
+      vertex 33.9041 -34.2084 20
+      vertex 35.825 -35.8395 0
+    endloop
+  endfacet
+  facet normal -0.684187 0.718632 -0.12432
+    outer loop
+      vertex 33.9041 -34.2084 20
+      vertex 34.031 -37.5475 0
+      vertex 32.3477 -35.6902 20
+    endloop
+  endfacet
+  facet normal -0.782228 0.610462 -0.12432
+    outer loop
+      vertex 40.7023 -30.1869 0
+      vertex 37.3669 -30.3878 20
+      vertex 38.689 -28.6937 20
+    endloop
+  endfacet
+  facet normal -0.782231 0.610458 -0.124321
+    outer loop
+      vertex 37.3669 -30.3878 20
+      vertex 40.7023 -30.1869 0
+      vertex 39.1784 -32.1396 0
+    endloop
+  endfacet
+  facet normal -0.217053 -0.968211 -0.124318
+    outer loop
+      vertex 12.3029 49.1583 0
+      vertex 11.7039 46.7246 20
+      vertex 11.4938 46.7717 20
+    endloop
+  endfacet
+  facet normal -0.222409 -0.966994 -0.12433
+    outer loop
+      vertex 11.7039 46.7246 20
+      vertex 12.3029 49.1583 0
+      vertex 12.3129 49.156 0
+    endloop
+  endfacet
+  facet normal 0.402118 -0.907109 -0.124317
+    outer loop
+      vertex -19.3924 46.8173 0
+      vertex -20.3977 43.6307 20
+      vertex -21.6568 45.8135 0
+    endloop
+  endfacet
+  facet normal 0.402079 -0.907125 -0.124322
+    outer loop
+      vertex -20.3977 43.6307 20
+      vertex -19.3924 46.8173 0
+      vertex -18.4331 44.5015 20
+    endloop
+  endfacet
+  facet normal 0.311146 0.942196 -0.124317
+    outer loop
+      vertex -14.7101 -48.4926 0
+      vertex -14.1869 -46.0265 20
+      vertex -13.9825 -46.094 20
+    endloop
+  endfacet
+  facet normal 0.310859 0.94229 -0.124321
+    outer loop
+      vertex -14.1869 -46.0265 20
+      vertex -14.7101 -48.4926 0
+      vertex -14.7198 -48.4894 0
+    endloop
+  endfacet
+  facet normal 0.264622 0.956305 -0.124322
+    outer loop
+      vertex -12.3228 -49.1533 0
+      vertex -13.9825 -46.094 20
+      vertex -11.9114 -46.6671 20
+    endloop
+  endfacet
+  facet normal 0.264661 0.956295 -0.124317
+    outer loop
+      vertex -13.9825 -46.094 20
+      vertex -12.3228 -49.1533 0
+      vertex -14.7101 -48.4926 0
+    endloop
+  endfacet
+  facet normal 0.989914 -0.0678023 -0.124389
+    outer loop
+      vertex -48.0942 2.57821 20
+      vertex -50.6136 2.48649 0
+      vertex -50.6129 2.49671 0
+    endloop
+  endfacet
+  facet normal 0.989533 -0.0732783 -0.124315
+    outer loop
+      vertex -50.6136 2.48649 0
+      vertex -48.0942 2.57821 20
+      vertex -48.1101 2.3635 20
+    endloop
+  endfacet
+  facet normal 0.97764 0.1696 -0.124322
+    outer loop
+      vertex -47.6099 -7.27986 20
+      vertex -50.1262 -7.43552 0
+      vertex -47.6467 -7.06773 20
+    endloop
+  endfacet
+  facet normal 0.976858 0.174093 -0.124258
+    outer loop
+      vertex -50.1262 -7.43552 0
+      vertex -47.6099 -7.27986 20
+      vertex -50.1244 -7.44562 0
+    endloop
+  endfacet
+  facet normal 0.925856 -0.35684 -0.124321
+    outer loop
+      vertex -44.5015 18.4331 20
+      vertex -46.821 19.3828 0
+      vertex -46.8173 19.3924 0
+    endloop
+  endfacet
+  facet normal 0.925688 -0.357275 -0.124322
+    outer loop
+      vertex -46.821 19.3828 0
+      vertex -44.5015 18.4331 20
+      vertex -44.579 18.2323 20
+    endloop
+  endfacet
+  facet normal -0.35684 0.925856 -0.124321
+    outer loop
+      vertex 19.3828 -46.821 0
+      vertex 18.4331 -44.5015 20
+      vertex 19.3924 -46.8173 0
+    endloop
+  endfacet
+  facet normal -0.357275 0.925688 -0.124322
+    outer loop
+      vertex 18.4331 -44.5015 20
+      vertex 19.3828 -46.821 0
+      vertex 18.2323 -44.579 20
+    endloop
+  endfacet
+  facet normal 0.98481 0.121212 -0.124324
+    outer loop
+      vertex -47.9098 -4.93498 20
+      vertex -50.4307 -4.96699 0
+      vertex -47.9361 -4.7213 20
+    endloop
+  endfacet
+  facet normal 0.984241 0.125813 -0.12426
+    outer loop
+      vertex -50.4307 -4.96699 0
+      vertex -47.9098 -4.93498 20
+      vertex -50.4294 -4.97716 0
+    endloop
+  endfacet
+  facet normal -0.968211 0.217053 -0.124318
+    outer loop
+      vertex 49.1583 -12.3029 0
+      vertex 46.7246 -11.7039 20
+      vertex 46.7717 -11.4938 20
+    endloop
+  endfacet
+  facet normal -0.966994 0.222409 -0.12433
+    outer loop
+      vertex 46.7246 -11.7039 20
+      vertex 49.1583 -12.3029 0
+      vertex 49.156 -12.3129 0
+    endloop
+  endfacet
+  facet normal -0.446139 -0.886287 -0.124323
+    outer loop
+      vertex 21.6662 45.8094 0
+      vertex 20.7868 43.4466 20
+      vertex 20.5945 43.5434 20
+    endloop
+  endfacet
+  facet normal -0.451416 -0.883622 -0.12424
+    outer loop
+      vertex 20.7868 43.4466 20
+      vertex 21.6662 45.8094 0
+      vertex 21.6754 45.8047 0
+    endloop
+  endfacet
+  facet normal -0.0244252 -0.991942 -0.124319
+    outer loop
+      vertex 2.47624 50.6139 0
+      vertex 2.3635 48.1101 20
+      vertex 2.14826 48.1154 20
+    endloop
+  endfacet
+  facet normal -0.0290288 -0.991816 -0.124329
+    outer loop
+      vertex 2.3635 48.1101 20
+      vertex 2.47624 50.6139 0
+      vertex 2.48649 50.6136 0
+    endloop
+  endfacet
+  facet normal 0.530842 0.838303 -0.124317
+    outer loop
+      vertex -26.0606 -43.4596 0
+      vertex -26.7608 -40.0503 20
+      vertex -24.9452 -41.2 20
+    endloop
+  endfacet
+  facet normal 0.530851 0.838298 -0.124315
+    outer loop
+      vertex -26.7608 -40.0503 20
+      vertex -26.0606 -43.4596 0
+      vertex -28.1533 -42.1344 0
+    endloop
+  endfacet
+  facet normal -0.530851 0.838298 -0.124315
+    outer loop
+      vertex 26.0606 -43.4596 0
+      vertex 26.7608 -40.0503 20
+      vertex 28.1533 -42.1344 0
+    endloop
+  endfacet
+  facet normal -0.530842 0.838303 -0.124317
+    outer loop
+      vertex 26.7608 -40.0503 20
+      vertex 26.0606 -43.4596 0
+      vertex 24.9452 -41.2 20
+    endloop
+  endfacet
+  facet normal 0.489084 0.863332 -0.124319
+    outer loop
+      vertex -23.8879 -44.6911 0
+      vertex -24.576 -41.4213 20
+      vertex -22.7063 -42.4805 20
+    endloop
+  endfacet
+  facet normal 0.489073 0.863338 -0.124321
+    outer loop
+      vertex -24.576 -41.4213 20
+      vertex -23.8879 -44.6911 0
+      vertex -26.0431 -43.4702 0
+    endloop
+  endfacet
+  facet normal -0.0732782 0.989533 -0.124318
+    outer loop
+      vertex 2.49671 -50.6129 0
+      vertex 2.3635 -48.1101 20
+      vertex 2.57821 -48.0942 20
+    endloop
+  endfacet
+  facet normal -0.0678028 0.989922 -0.12433
+    outer loop
+      vertex 2.3635 -48.1101 20
+      vertex 2.49671 -50.6129 0
+      vertex 2.48649 -50.6136 0
+    endloop
+  endfacet
+  facet normal 0.121457 -0.98478 -0.124322
+    outer loop
+      vertex -4.97716 50.4294 0
+      vertex -7.06773 47.6467 20
+      vertex -7.43552 50.1262 0
+    endloop
+  endfacet
+  facet normal 0.121484 -0.984777 -0.124318
+    outer loop
+      vertex -7.06773 47.6467 20
+      vertex -4.97716 50.4294 0
+      vertex -4.93498 47.9098 20
+    endloop
+  endfacet
+  facet normal -0.0243338 -0.991944 -0.12432
+    outer loop
+      vertex 0 50.6747 0
+      vertex 2.14826 48.1154 20
+      vertex 0 48.1681 20
+    endloop
+  endfacet
+  facet normal -0.0243555 -0.991943 -0.124318
+    outer loop
+      vertex 2.14826 48.1154 20
+      vertex 0 50.6747 0
+      vertex 2.47624 50.6139 0
+    endloop
+  endfacet
+  facet normal -0.0290288 0.991816 -0.124329
+    outer loop
+      vertex 2.47624 -50.6139 0
+      vertex 2.3635 -48.1101 20
+      vertex 2.48649 -50.6136 0
+    endloop
+  endfacet
+  facet normal -0.0244252 0.991942 -0.124319
+    outer loop
+      vertex 2.3635 -48.1101 20
+      vertex 2.47624 -50.6139 0
+      vertex 2.14826 -48.1154 20
+    endloop
+  endfacet
+  facet normal 0.53089 0.838272 -0.124318
+    outer loop
+      vertex -26.052 -43.4651 0
+      vertex -24.9452 -41.2 20
+      vertex -24.7633 -41.3152 20
+    endloop
+  endfacet
+  facet normal 0.5346 0.83592 -0.124257
+    outer loop
+      vertex -24.9452 -41.2 20
+      vertex -26.052 -43.4651 0
+      vertex -26.0606 -43.4596 0
+    endloop
+  endfacet
+  facet normal -0.86091 -0.493331 -0.124331
+    outer loop
+      vertex 43.4702 26.0431 0
+      vertex 41.3152 24.7633 20
+      vertex 43.4651 26.052 0
+    endloop
+  endfacet
+  facet normal -0.863345 -0.48906 -0.12432
+    outer loop
+      vertex 41.3152 24.7633 20
+      vertex 43.4702 26.0431 0
+      vertex 41.4213 24.576 20
+    endloop
+  endfacet
+  facet normal 0.968133 -0.217401 -0.124322
+    outer loop
+      vertex -46.7717 11.4938 20
+      vertex -49.701 9.88614 0
+      vertex -49.1583 12.3029 0
+    endloop
+  endfacet
+  facet normal 0.968125 -0.217435 -0.124318
+    outer loop
+      vertex -49.701 9.88614 0
+      vertex -46.7717 11.4938 20
+      vertex -47.2426 9.39713 20
+    endloop
+  endfacet
+  facet normal -0.48906 -0.863345 -0.12432
+    outer loop
+      vertex 26.0431 43.4702 0
+      vertex 24.7633 41.3152 20
+      vertex 24.576 41.4213 20
+    endloop
+  endfacet
+  facet normal -0.493331 -0.86091 -0.124331
+    outer loop
+      vertex 24.7633 41.3152 20
+      vertex 26.0431 43.4702 0
+      vertex 26.052 43.4651 0
+    endloop
+  endfacet
+  facet normal 0.907007 0.402346 -0.12432
+    outer loop
+      vertex -43.5434 -20.5945 20
+      vertex -45.8135 -21.6568 0
+      vertex -43.6307 -20.3977 20
+    endloop
+  endfacet
+  facet normal 0.909495 0.396695 -0.124303
+    outer loop
+      vertex -45.8135 -21.6568 0
+      vertex -43.5434 -20.5945 20
+      vertex -45.8094 -21.6662 0
+    endloop
+  endfacet
+  facet normal 0.957273 -0.261075 -0.124369
+    outer loop
+      vertex -46.6671 11.9114 20
+      vertex -49.156 12.3129 0
+      vertex -49.1533 12.3228 0
+    endloop
+  endfacet
+  facet normal 0.956209 -0.264973 -0.124315
+    outer loop
+      vertex -49.156 12.3129 0
+      vertex -46.6671 11.9114 20
+      vertex -46.7246 11.7039 20
+    endloop
+  endfacet
+  facet normal 0.264661 -0.956295 -0.124317
+    outer loop
+      vertex -12.3228 49.1533 0
+      vertex -13.9825 46.094 20
+      vertex -14.7101 48.4926 0
+    endloop
+  endfacet
+  facet normal 0.264622 -0.956305 -0.124322
+    outer loop
+      vertex -13.9825 46.094 20
+      vertex -12.3228 49.1533 0
+      vertex -11.9114 46.6671 20
+    endloop
+  endfacet
+  facet normal 0.751345 0.648093 -0.124324
+    outer loop
+      vertex -37.0938 -30.7205 20
+      vertex -39.1721 -32.1477 0
+      vertex -37.2344 -30.5575 20
+    endloop
+  endfacet
+  facet normal 0.748547 0.651333 -0.124264
+    outer loop
+      vertex -39.1721 -32.1477 0
+      vertex -37.0938 -30.7205 20
+      vertex -39.1654 -32.1554 0
+    endloop
+  endfacet
+  facet normal 0.886287 0.446139 -0.124323
+    outer loop
+      vertex -43.4466 -20.7868 20
+      vertex -45.8094 -21.6662 0
+      vertex -43.5434 -20.5945 20
+    endloop
+  endfacet
+  facet normal 0.883622 0.451416 -0.12424
+    outer loop
+      vertex -45.8094 -21.6662 0
+      vertex -43.4466 -20.7868 20
+      vertex -45.8047 -21.6754 0
+    endloop
+  endfacet
+  facet normal 0.0244252 0.991942 -0.124319
+    outer loop
+      vertex -2.47624 -50.6139 0
+      vertex -2.3635 -48.1101 20
+      vertex -2.14826 -48.1154 20
+    endloop
+  endfacet
+  facet normal 0.0290288 0.991816 -0.124329
+    outer loop
+      vertex -2.3635 -48.1101 20
+      vertex -2.47624 -50.6139 0
+      vertex -2.48649 -50.6136 0
+    endloop
+  endfacet
+  facet normal 0.0243338 0.991944 -0.12432
+    outer loop
+      vertex 0 -50.6747 0
+      vertex -2.14826 -48.1154 20
+      vertex 0 -48.1681 20
+    endloop
+  endfacet
+  facet normal 0.0243555 0.991943 -0.124318
+    outer loop
+      vertex -2.14826 -48.1154 20
+      vertex 0 -50.6747 0
+      vertex -2.47624 -50.6139 0
+    endloop
+  endfacet
+  facet normal 0.648093 0.751345 -0.124324
+    outer loop
+      vertex -32.1477 -39.1721 0
+      vertex -30.7205 -37.0938 20
+      vertex -30.5575 -37.2344 20
+    endloop
+  endfacet
+  facet normal 0.651333 0.748547 -0.124264
+    outer loop
+      vertex -30.7205 -37.0938 20
+      vertex -32.1477 -39.1721 0
+      vertex -32.1554 -39.1654 0
+    endloop
+  endfacet
+  facet normal 0.610644 0.782085 -0.124324
+    outer loop
+      vertex -32.1396 -39.1784 0
+      vertex -30.5575 -37.2344 20
+      vertex -30.3878 -37.3669 20
+    endloop
+  endfacet
+  facet normal 0.609178 0.783229 -0.124319
+    outer loop
+      vertex -30.5575 -37.2344 20
+      vertex -32.1396 -39.1784 0
+      vertex -32.1477 -39.1721 0
+    endloop
+  endfacet
+  facet normal -0.125813 0.984241 -0.12426
+    outer loop
+      vertex 4.96699 -50.4307 0
+      vertex 4.93498 -47.9098 20
+      vertex 4.97716 -50.4294 0
+    endloop
+  endfacet
+  facet normal -0.121212 0.98481 -0.124324
+    outer loop
+      vertex 4.93498 -47.9098 20
+      vertex 4.96699 -50.4307 0
+      vertex 4.7213 -47.9361 20
+    endloop
+  endfacet
+  facet normal -0.174093 0.976858 -0.124258
+    outer loop
+      vertex 7.43552 -50.1262 0
+      vertex 7.27986 -47.6099 20
+      vertex 7.44562 -50.1244 0
+    endloop
+  endfacet
+  facet normal -0.1696 0.97764 -0.124322
+    outer loop
+      vertex 7.27986 -47.6099 20
+      vertex 7.43552 -50.1262 0
+      vertex 7.06773 -47.6467 20
+    endloop
+  endfacet
+  facet normal 0.121212 0.98481 -0.124324
+    outer loop
+      vertex -4.96699 -50.4307 0
+      vertex -4.93498 -47.9098 20
+      vertex -4.7213 -47.9361 20
+    endloop
+  endfacet
+  facet normal 0.125813 0.984241 -0.12426
+    outer loop
+      vertex -4.93498 -47.9098 20
+      vertex -4.96699 -50.4307 0
+      vertex -4.97716 -50.4294 0
+    endloop
+  endfacet
+  facet normal -0.261075 0.957273 -0.124369
+    outer loop
+      vertex 12.3129 -49.156 0
+      vertex 11.9114 -46.6671 20
+      vertex 12.3228 -49.1533 0
+    endloop
+  endfacet
+  facet normal -0.264973 0.956209 -0.124315
+    outer loop
+      vertex 11.9114 -46.6671 20
+      vertex 12.3129 -49.156 0
+      vertex 11.7039 -46.7246 20
+    endloop
+  endfacet
+  facet normal -0.264661 0.956295 -0.124317
+    outer loop
+      vertex 12.3228 -49.1533 0
+      vertex 13.9825 -46.094 20
+      vertex 14.7101 -48.4926 0
+    endloop
+  endfacet
+  facet normal -0.264622 0.956305 -0.124322
+    outer loop
+      vertex 13.9825 -46.094 20
+      vertex 12.3228 -49.1533 0
+      vertex 11.9114 -46.6671 20
+    endloop
+  endfacet
+  facet normal -0.782085 0.610644 -0.124324
+    outer loop
+      vertex 39.1784 -32.1396 0
+      vertex 37.2344 -30.5575 20
+      vertex 37.3669 -30.3878 20
+    endloop
+  endfacet
+  facet normal -0.783229 0.609178 -0.124319
+    outer loop
+      vertex 37.2344 -30.5575 20
+      vertex 39.1784 -32.1396 0
+      vertex 39.1721 -32.1477 0
+    endloop
+  endfacet
+  facet normal -0.570311 0.811968 -0.124316
+    outer loop
+      vertex 30.1785 -40.7082 0
+      vertex 28.6937 -38.689 20
+      vertex 30.1869 -40.7023 0
+    endloop
+  endfacet
+  facet normal -0.571177 0.811358 -0.124319
+    outer loop
+      vertex 28.6937 -38.689 20
+      vertex 30.1785 -40.7082 0
+      vertex 28.5177 -38.8129 20
+    endloop
+  endfacet
+  facet normal -0.610458 0.782231 -0.124321
+    outer loop
+      vertex 30.1869 -40.7023 0
+      vertex 30.3878 -37.3669 20
+      vertex 32.1396 -39.1784 0
+    endloop
+  endfacet
+  facet normal -0.610462 0.782228 -0.12432
+    outer loop
+      vertex 30.3878 -37.3669 20
+      vertex 30.1869 -40.7023 0
+      vertex 28.6937 -38.689 20
+    endloop
+  endfacet
+  facet normal 0.446139 0.886287 -0.124323
+    outer loop
+      vertex -21.6662 -45.8094 0
+      vertex -20.7868 -43.4466 20
+      vertex -20.5945 -43.5434 20
+    endloop
+  endfacet
+  facet normal 0.451416 0.883622 -0.12424
+    outer loop
+      vertex -20.7868 -43.4466 20
+      vertex -21.6662 -45.8094 0
+      vertex -21.6754 -45.8047 0
+    endloop
+  endfacet
+  facet normal 0.863345 0.48906 -0.12432
+    outer loop
+      vertex -41.3152 -24.7633 20
+      vertex -43.4702 -26.0431 0
+      vertex -41.4213 -24.576 20
+    endloop
+  endfacet
+  facet normal 0.86091 0.493331 -0.124331
+    outer loop
+      vertex -43.4702 -26.0431 0
+      vertex -41.3152 -24.7633 20
+      vertex -43.4651 -26.052 0
+    endloop
+  endfacet
+  facet normal 0.838272 0.53089 -0.124318
+    outer loop
+      vertex -41.2 -24.9452 20
+      vertex -43.4651 -26.052 0
+      vertex -41.3152 -24.7633 20
+    endloop
+  endfacet
+  facet normal 0.83592 0.5346 -0.124257
+    outer loop
+      vertex -43.4651 -26.052 0
+      vertex -41.2 -24.9452 20
+      vertex -43.4596 -26.0606 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 7.5 57.8 38
+      vertex -7.5 57.8 40
+      vertex 7.5 57.8 40
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.5 57.8 40
+      vertex 7.5 57.8 38
+      vertex -7.5 57.8 38
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 7.5 57.8 20
+      vertex -7.5 57.8 38
+      vertex 7.5 57.8 38
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.5 57.8 38
+      vertex 7.5 57.8 20
+      vertex -7.5 57.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.5 57.8 40
+      vertex 7.5 52.8 40
+      vertex 7.5 57.8 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 52.8 40
+      vertex -7.5 57.8 40
+      vertex -7.5 52.8 40
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.5 54.8 20
+      vertex 7.5 57.8 20
+      vertex 7.5 54.8 20
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.5 57.8 20
+      vertex -7.5 54.8 20
+      vertex -7.5 57.8 20
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.5 54.8 20
+      vertex 7.5 54.8 38
+      vertex -7.5 54.8 38
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 7.5 54.8 38
+      vertex -7.5 54.8 20
+      vertex 7.5 54.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 54.8 38
+      vertex -7.5 57.8 38
+      vertex -7.5 57.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 54.8 38
+      vertex -7.5 57.8 20
+      vertex -7.5 54.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 57.8 38
+      vertex -7.5 54.8 38
+      vertex -7.5 57.8 40
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 52.8 40
+      vertex -7.5 54.8 38
+      vertex -7.5 52.8 38
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 54.8 38
+      vertex -7.5 52.8 40
+      vertex -7.5 57.8 40
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 54.8 38
+      vertex 7.5 57.8 38
+      vertex 7.5 57.8 40
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 57.8 38
+      vertex 7.5 54.8 38
+      vertex 7.5 57.8 20
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 7.5 52.8 40
+      vertex 7.5 54.8 38
+      vertex 7.5 57.8 40
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 54.8 38
+      vertex 7.5 52.8 40
+      vertex 7.5 52.8 38
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 57.8 20
+      vertex 7.5 54.8 38
+      vertex 7.5 54.8 20
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.5 52.8 38
+      vertex 7.5 54.8 38
+      vertex 7.5 52.8 38
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.5 54.8 38
+      vertex -7.5 52.8 38
+      vertex -7.5 54.8 38
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.5 52.8 38
+      vertex 7.5 52.8 40
+      vertex -7.5 52.8 40
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 7.5 52.8 40
+      vertex -7.5 52.8 38
+      vertex 7.5 52.8 38
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.5 -57.8 38
+      vertex 7.5 -57.8 40
+      vertex -7.5 -57.8 40
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 7.5 -57.8 40
+      vertex -7.5 -57.8 38
+      vertex 7.5 -57.8 38
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.5 -57.8 20
+      vertex 7.5 -57.8 38
+      vertex -7.5 -57.8 38
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 7.5 -57.8 38
+      vertex -7.5 -57.8 20
+      vertex 7.5 -57.8 20
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.5 -52.8 40
+      vertex 7.5 -57.8 40
+      vertex 7.5 -52.8 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 -57.8 40
+      vertex -7.5 -52.8 40
+      vertex -7.5 -57.8 40
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.5 -57.8 20
+      vertex 7.5 -54.8 20
+      vertex 7.5 -57.8 20
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.5 -54.8 20
+      vertex -7.5 -57.8 20
+      vertex -7.5 -54.8 20
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 7.5 -54.8 20
+      vertex -7.5 -54.8 38
+      vertex 7.5 -54.8 38
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.5 -54.8 38
+      vertex 7.5 -54.8 20
+      vertex -7.5 -54.8 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 -52.8 40
+      vertex 7.5 -54.8 38
+      vertex 7.5 -52.8 38
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 7.5 -57.8 40
+      vertex 7.5 -54.8 38
+      vertex 7.5 -52.8 40
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 -57.8 38
+      vertex 7.5 -54.8 38
+      vertex 7.5 -57.8 40
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 -54.8 38
+      vertex 7.5 -57.8 38
+      vertex 7.5 -54.8 20
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 -54.8 20
+      vertex 7.5 -57.8 38
+      vertex 7.5 -57.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 -54.8 20
+      vertex -7.5 -57.8 20
+      vertex -7.5 -54.8 38
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 -54.8 38
+      vertex -7.5 -52.8 40
+      vertex -7.5 -52.8 38
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 -57.8 38
+      vertex -7.5 -54.8 38
+      vertex -7.5 -57.8 20
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 -57.8 40
+      vertex -7.5 -54.8 38
+      vertex -7.5 -57.8 38
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 -54.8 38
+      vertex -7.5 -57.8 40
+      vertex -7.5 -52.8 40
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.5 -54.8 38
+      vertex 7.5 -52.8 38
+      vertex 7.5 -54.8 38
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.5 -52.8 38
+      vertex -7.5 -54.8 38
+      vertex -7.5 -52.8 38
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 7.5 -52.8 38
+      vertex -7.5 -52.8 40
+      vertex 7.5 -52.8 40
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.5 -52.8 40
+      vertex 7.5 -52.8 38
+      vertex -7.5 -52.8 38
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/esphome/rat-trap-2025.yaml
+++ b/esphome/rat-trap-2025.yaml
@@ -93,7 +93,7 @@ sensor:
           return x;
 
   # BME280 environmental sensor via STEMMA QT (I2C)
-  - platform: bme280
+  - platform: bme280_i2c
     address: 0x77   # Adafruit STEMMA QT BME280 default address
     temperature:
       name: Environmental Temperature

--- a/esphome/rat-trap-stemma-camera.yaml
+++ b/esphome/rat-trap-stemma-camera.yaml
@@ -123,7 +123,7 @@ sensor:
     long_range: true   # Enable long range mode for 2m detection
 
   # BME280 environmental sensor via STEMMA QT
-  - platform: bme280
+  - platform: bme280_i2c
     address: 0x77   # Adafruit STEMMA QT BME280 default address
     temperature:
       name: Environmental Temperature


### PR DESCRIPTION
This commit contains two fixes:

1.  The ESPHome compilation was failing because the `bme280` sensor platform was specified as `bme280` instead of `bme280_i2c`. This has been corrected in both `rat-trap-2025.yaml` and `rat-trap-stemma-camera.yaml`.

2.  The STL generation script was failing because it was passing filenames with extra single quotes to `openscad`. This was caused by the `@sh` filter in the `jq` command. The filter has been removed to fix the issue.