### PR TITLE
fix(ci): resolve setup-uv v9 tag and yamlfmt issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,22 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: weekly
+      day: monday
     open-pull-requests-limit: 10
     labels:
-      - "dependencies"
-      - "github-actions"
+      - dependencies
+      - github-actions
 
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: pip
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: weekly
+      day: monday
     open-pull-requests-limit: 10
     labels:
-      - "dependencies"
-      - "python"
+      - dependencies
+      - python

--- a/.github/workflows/bom-validation.yml
+++ b/.github/workflows/bom-validation.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           cache-dependency-glob: requirements.txt

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0         # Required for git-revision-date-localized plugin
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           cache-dependency-glob: docs-requirements.txt

--- a/.github/workflows/esphome-compile.yml
+++ b/.github/workflows/esphome-compile.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           cache-dependency-glob: requirements.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
             ${{ runner.os }}-pre-commit-
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           cache-dependency-glob: requirements.txt

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/stl-generation.yml
+++ b/.github/workflows/stl-generation.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           cache-dependency-glob: requirements.txt


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @bandwith :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Fixes the CI failure on main after PR #73 merge.

## Changes

1. **Downgrade `astral-sh/setup-uv` from v9 to v8** — v9.0.0 was released July 21 but GitHub Actions cannot resolve the `v9` major version tag yet. Using v8 (current stable) until it propagates.

2. **Apply yamlfmt formatting to dependabot.yml** — removes unnecessary quotes to pass the pre-commit `yamlfmt` hook.