### PR TITLE
fix: remove invalid ignoreUnstable from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,7 +44,6 @@
     {
       "description": "Python requirements - auto-update with automerge for patch/minor",
       "matchManagers": ["pip_requirements"],
-      "ignoreUnstable": false,
       "enabled": true,
       "automerge": true,
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @bandwith :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Removes `ignoreUnstable` from `packageRules[3]` in `renovate.json`.

Renovate does not allow combining `matchUpdateTypes` and `ignoreUnstable` in the same rule — this was blocking all Renovate PRs.